### PR TITLE
Add regression tests for #219: entity coordinator-update path

### DIFF
--- a/tests/integration/test_entity.py
+++ b/tests/integration/test_entity.py
@@ -1,0 +1,35 @@
+"""Regression test for #219: WfRacEntity._handle_coordinator_update() must
+not report a failure for an entity whose _update_state() runs cleanly.
+EnergyTotalResetButton had no _update_state() at all, so this exact path
+raised AttributeError on every coordinator update and called
+Device.set_available(False) - needs the `hass` fixture (Device is a
+DataUpdateCoordinator), hence tests/integration/ rather than tests/unit/.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.mitsubishi_wf_rac.button import EnergyTotalResetButton
+from custom_components.mitsubishi_wf_rac.wfrac.device import Device
+
+
+@pytest.fixture
+async def device(hass):
+    dev = Device(
+        hass, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id",
+        create_swing_mode_select=True,
+    )
+    dev._api = AsyncMock()
+    return dev
+
+
+async def test_coordinator_update_does_not_report_failure(device, monkeypatch):
+    entity = EnergyTotalResetButton(device)
+    entity.async_write_ha_state = lambda: None
+    reported = []
+    monkeypatch.setattr(device, "set_available", lambda available: reported.append(available))
+
+    entity._handle_coordinator_update()
+
+    assert reported == []

--- a/tests/unit/test_entity_coverage.py
+++ b/tests/unit/test_entity_coverage.py
@@ -1,0 +1,28 @@
+"""Guards against the #219 regression: a WfRacEntity subclass that doesn't
+override _update_state(). WfRacEntity._handle_coordinator_update() calls
+self._update_state() unconditionally on every coordinator update; a missing
+override raises AttributeError, which the base class's except clause treats
+as an update failure and reports it through Device.set_available(False) -
+not just for the one entity missing it.
+"""
+
+from custom_components.mitsubishi_wf_rac import (
+    binary_sensor,  # noqa: F401
+    button,  # noqa: F401
+    climate,  # noqa: F401
+    number,  # noqa: F401
+    select,  # noqa: F401
+    sensor,  # noqa: F401
+    update,  # noqa: F401
+)
+from custom_components.mitsubishi_wf_rac.entity import WfRacEntity
+
+
+def test_every_entity_subclass_overrides_update_state():
+    # Importing the platform modules above is what populates this - each of
+    # their entity classes subclasses WfRacEntity directly.
+    subclasses = WfRacEntity.__subclasses__()
+    assert subclasses
+
+    missing = [cls.__name__ for cls in subclasses if not hasattr(cls, "_update_state")]
+    assert not missing, f"missing _update_state(): {missing}"


### PR DESCRIPTION
Two new tests close the coverage gap that let #219 through:

- `test_entity_coverage.py`: every `WfRacEntity` subclass, across all platform
  modules, must override `_update_state()`.
- `test_entity.py`: `_handle_coordinator_update()` must not report a failure
  for an entity whose `_update_state()` runs cleanly.

Both fail against the pre-#220 `button.py` and pass against current main -
verified locally by swapping the file back and forth.