### PR TITLE
Prepare 2026.9.2 release

### DIFF
--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues",
   "requirements": [],
-  "version": "2026.9.2-beta4",
+  "version": "2026.9.2",
   "zeroconf": [
     "_beaver._tcp.local."
   ]


### PR DESCRIPTION
Version bump from `2026.9.2-beta4` to `2026.9.2`. No code changes - beta4 plus the three commits merged since it (#224, #217, #226) ship as the final release.