### PR TITLE
Rewrite source comments as present-state, not a changelog

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -77,7 +77,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # time when the flag was dead code (see create_device_from_entry), so
         # every entry predating v2 has been running with no retry tolerance at
         # all: one failed poll marks the device unavailable. The WF-RAC module
-        # reassociates on its own roughly once an hour (#173), which a 60s poll
+        # reassociates on its own roughly once an hour, which a 60s poll
         # interval turns into a visible outage. Turn the check on, and lift
         # limits below 2, which are equivalent to it being off (Device.
         # _set_availability() needs limit-1 consecutive failures to tolerate).

--- a/custom_components/mitsubishi_wf_rac/binary_sensor.py
+++ b/custom_components/mitsubishi_wf_rac/binary_sensor.py
@@ -29,8 +29,8 @@ async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_e
         CompressorBinarySensor(device),
     ]
     # Occupancy ("vacant") detection is only reported by units whose capability
-    # table (#187) has VacantProperty=true - includes ZT-2025 (raw=3), which
-    # the wire-protocol ModelNr grouping alone would miss (see capabilities.py).
+    # table has VacantProperty=true - includes ZT-2025 (raw=3), which the
+    # wire-protocol ModelNr grouping alone would miss (see capabilities.py).
     if device.airco.Capabilities.vacant_property:
         entities.append(OccupancyBinarySensor(device))
 

--- a/custom_components/mitsubishi_wf_rac/binary_sensor.py
+++ b/custom_components/mitsubishi_wf_rac/binary_sensor.py
@@ -56,7 +56,7 @@ class ProblemBinarySensor(WfRacEntity, BinarySensorEntity):
         self._attr_is_on = code != "00"
         attrs: dict[str, str] = {"error_code": code}
         # Deliberately no key at all (rather than a guessed/empty value) for
-        # codes outside fehlercodes-selfdiagnose.md's tables.
+        # codes describe_error_code() doesn't recognize.
         # NB this still reports is_on for an M<n> code, which is a protective
         # stop the unit recovered from rather than a fault it is displaying -
         # arguably not a "problem". Left as it was for now; changing it would

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -67,9 +67,9 @@ async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_e
         "async_set_swing_mode",
     )
 
-    # HomeLeaveMode (Tag 248, #187 capability index 7) - deliberately services,
-    # not switch/number entities, until confirmed on real hardware (see
-    # todo.md): no dashboard tile to accidentally trigger before that.
+    # HomeLeaveMode (Tag 248, capability index 7) - deliberately services, not
+    # switch/number entities, until confirmed on real hardware: no dashboard
+    # tile to accidentally trigger before that.
     platform.async_register_entity_service(
         SERVICE_REQUEST_HOME_LEAVE_MODE_STATUS,
         {},
@@ -117,19 +117,19 @@ class AircoClimate(WfRacEntity, ClimateEntity):
         self._update_state()
 
     def _min_temp_for_mode(self, hvac_mode: HVACMode) -> float:
-        """Minimum setpoint depends on hvac_mode - see #113.
+        """Minimum setpoint depends on hvac_mode.
 
         Per Mitsubishi Heavy Industries' official operable table ('21
         SRK-T-324, models SRK60ZSX-W/A and SRK100ZR-W): indoor unit only
         accepts 18-30C. Cooling reliably goes lower than that in practice
-        (see #113) regardless of model, so that override applies unconditionally.
+        regardless of model, so that override applies unconditionally.
         Models with the app's PresetTempRange2 capability (`ModelNoType`/
         `TempItemType` in the app, see wfrac/capabilities.py) go further,
         per the app's own table (Constants.java TempItemType.getMin/getMax):
         Auto/Cool/Dry down to 16, Heat down to 10. That 10C heating floor is
-        unconfirmed on real hardware (see #187) - the plain-setpoint reset to
-        18C after a power cycle that's documented for the default range was
-        only ever observed on hardware without this capability.
+        unconfirmed on real hardware - the plain-setpoint reset to 18C after a
+        power cycle that's documented for the default range was only ever
+        observed on hardware without this capability.
         """
         if self._device.airco.Capabilities.preset_temp_range_2:
             if hvac_mode == HVACMode.HEAT:
@@ -282,12 +282,12 @@ class AircoClimate(WfRacEntity, ClimateEntity):
     def _require_home_leave_mode_capability(self) -> None:
         if not self._device.airco.Capabilities.home_leave_mode:
             raise ServiceValidationError(
-                "This model does not report the HomeLeaveMode capability (#187)"
+                "This model does not report the HomeLeaveMode capability"
             )
 
     async def async_request_home_leave_mode_status(self) -> None:
         """See Device.async_request_home_leave_mode_status - verified live
-        (05.08.2026) against the official app's own display, see todo.md."""
+        against the official app's own display."""
         self._require_home_leave_mode_capability()
         await self._device.async_request_home_leave_mode_status()
 
@@ -300,8 +300,7 @@ class AircoClimate(WfRacEntity, ClimateEntity):
         temp_setting_heating: float,
         air_flow_heating: int,
     ) -> None:
-        """See Device.async_set_home_leave_mode - verified live
-        (05.08.2026), see todo.md."""
+        """See Device.async_set_home_leave_mode - verified live."""
         self._require_home_leave_mode_capability()
         await self._device.async_set_home_leave_mode(
             HomeLeaveModeSetting(

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -25,13 +25,12 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# Same values the former HomeLeaveModeSwitch ("crutch") used, now confirmed by
-# the live Tag-248 read (05.08.2026): the unit's own Heating TempSetting was
-# 10.0°C, matching HOME_LEAVE_TEMP_HEAT exactly. Its Cooling TempSetting read
-# 33.0°C, but the applied PresetTemp while the official app's away-cool mode
-# was actually running measured 31.0°C - hardcoding the empirically-observed
-# value rather than trusting the configured TempSetting, since only the
-# former is confirmed to actually flip Vacant. See todo.md.
+# Heating uses the unit's own Heating TempSetting (10.0°C), which matches
+# HOME_LEAVE_TEMP_HEAT exactly. Cooling does not: the unit's Cooling
+# TempSetting reads 33.0°C, but the temperature actually applied while the
+# official app's away-cool mode is running is 31.0°C - so this hardcodes the
+# applied value rather than trusting the configured TempSetting, since only
+# the applied value is known to flip Vacant.
 HOME_LEAVE_TEMP_HEAT = 10.0
 HOME_LEAVE_TEMP_COOL = 31.0
 # Temperature to restore when leaving Home Leave mode. There's no reliable way
@@ -61,13 +60,13 @@ async def async_setup_entry(_hass, entry: MitsubishiWfRacConfigEntry, async_add_
         entities = []
         _LOGGER.info("No Setup Horizontal Select: %s, %s", device.device_name, device.airco_id)
 
-    # Same VacantProperty capability gate (#187) the removed HomeLeaveModeSwitch
-    # used, see OccupancyBinarySensor in binary_sensor.py.
+    # Same VacantProperty capability gate as OccupancyBinarySensor in
+    # binary_sensor.py.
     if device.airco.Capabilities.vacant_property:
         entities.append(HomeLeaveModeSelect(device))
 
-    # Same HomeLeaveMode capability gate (#187) the former home_leave_*_air_flow
-    # diagnostic sensors used, see sensor.py.
+    # Same HomeLeaveMode capability gate as the diagnostic sensors removed by
+    # _async_remove_home_leave_mode_sensors() in sensor.py.
     if device.airco.Capabilities.home_leave_mode:
         entities.append(HomeLeaveAirFlowSelect(device, "cooling"))
         entities.append(HomeLeaveAirFlowSelect(device, "heating"))
@@ -215,11 +214,9 @@ class HomeLeaveModeSelect(WfRacEntity, SelectEntity):
     """Select to enter/leave the unit's own Home Leave (vacant property) mode,
     in either direction.
 
-    Replaces the former HomeLeaveModeSwitch, which could only fake the
-    Heat+10°C direction. The official app's own "Abwesenheitsmodus" has two
-    independent target points (Heat and Cool, each with its own Tag-248
-    threshold/setting - see the home_leave_* diagnostic sensors in
-    sensor.py), confirmed live (05.08.2026) to flip the same Vacant bit this
+    The official app's away mode has two independent target points (Heat and
+    Cool, each with its own Tag-248 threshold/setting - see the home_leave_*
+    diagnostic sensors in sensor.py) and flips the same Vacant bit this
     entity reads/writes. See HOME_LEAVE_TEMP_HEAT/_COOL above for the values
     used and why they're hardcoded rather than read from the live Tag-248
     TempSetting.

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -95,7 +95,7 @@ async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_e
         DiagnosticsSensor(device, "Account Expires", ATTR_ACCOUNT_EXPIRES, True),
         # Off until it is understood: reads a constant 1 on both test units
         # regardless of what the machine is doing, so it does not currently
-        # track the unit's LED - see todo.md.
+        # track the unit's LED.
         DiagnosticsSensor(device, "LED Status", ATTR_LED_STATUS),
         DiagnosticsSensor(device, "Auto Heating", ATTR_AUTO_HEATING, True),
         DiagnosticsSensor(device, "Model Nr", ATTR_MODEL_NR),
@@ -208,7 +208,7 @@ def _async_remove_home_leave_mode_sensors(hass, device: Device) -> None:
     Replaced by writable entities on the Controls section of the device page:
     HomeLeaveModeNumber (TempRule/TempSetting) in number.py, the AirFlow
     selects in select.py - editable directly instead of only via the
-    set_home_leave_mode action, see todo.md.
+    set_home_leave_mode action.
     """
     registry = er.async_get(hass)
     for mode in ("cooling", "heating"):

--- a/custom_components/mitsubishi_wf_rac/switch.py
+++ b/custom_components/mitsubishi_wf_rac/switch.py
@@ -49,9 +49,9 @@ def _async_remove_self_clean_switch(hass, device: Device) -> None:
     """Drop the former Self Clean switch from the entity registry.
 
     The unit's real self-clean cycle can only be started locally via the IR
-    remote - the WiFi module offers no way to trigger it (see #209), so the
-    switch never did anything. Removing it here keeps it from lingering as an
-    unavailable leftover in dashboards and automations.
+    remote - the WiFi module offers no way to trigger it, so the switch never
+    did anything. Removing it here keeps it from lingering as an unavailable
+    leftover in dashboards and automations.
     """
     registry = er.async_get(hass)
     entity_id = registry.async_get_entity_id(

--- a/custom_components/mitsubishi_wf_rac/update.py
+++ b/custom_components/mitsubishi_wf_rac/update.py
@@ -32,8 +32,7 @@ class FirmwareUpdateEntity(WfRacEntity, UpdateEntity):
     Compares the version reported locally (device.py, from getAirconStat)
     against the manufacturer's unauthenticated getFirmware endpoint - see
     wfrac/firmware_check.py. Read-only: the module only downloads and flashes
-    itself while switched off (see FUNDE.md's OTA section), so triggering an
-    install isn't offered here.
+    itself while switched off, so triggering an install isn't offered here.
     """
 
     _attr_has_entity_name = True

--- a/custom_components/mitsubishi_wf_rac/wfrac/capabilities.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/capabilities.py
@@ -1,6 +1,6 @@
 """Per-model feature capability table, ported from the official app.
 
-Ground truth for #187: `res/values/arrays.xml` (`model_no_type_function_*`,
+Ground truth: `res/values/arrays.xml` (`model_no_type_function_*`,
 5 tables x 17 flags) and `model/ModelNoType.java` (flag order, table
 selection) in `smartMAir_apk/jadx-out/`. See `../../../../smartMAir_apk/FUNDE.md`
 ("Capabilities") for the reverse-engineering notes.

--- a/custom_components/mitsubishi_wf_rac/wfrac/capabilities.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/capabilities.py
@@ -1,9 +1,8 @@
 """Per-model feature capability table, ported from the official app.
 
-Ground truth: `res/values/arrays.xml` (`model_no_type_function_*`,
-5 tables x 17 flags) and `model/ModelNoType.java` (flag order, table
-selection) in `smartMAir_apk/jadx-out/`. See `../../../../smartMAir_apk/FUNDE.md`
-("Capabilities") for the reverse-engineering notes.
+Ground truth: the app's own `res/values/arrays.xml`
+(`model_no_type_function_*`, 5 tables x 17 flags) and `model/ModelNoType.java`
+(flag order, table selection).
 """
 
 from dataclasses import dataclass

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -41,8 +41,8 @@ FIRMWARE_CHECK_INTERVAL = timedelta(hours=24)
 # Service data (operation-data codes) is opt-in and costs a second request per
 # poll, but it stays on the local network, changes nothing on the unit (see
 # RacParser.status_request_to_byte) and a batched request answers every code in
-# one round trip (see todo.md), so there's no reason to throttle it below the
-# regular poll cadence. See Device._maybe_request_service_data().
+# one round trip, so there's no reason to throttle it below the regular poll
+# cadence. See Device._maybe_request_service_data().
 SERVICE_DATA_REQUEST_INTERVAL = MIN_TIME_BETWEEN_UPDATES
 
 # The rate limit is a guard against a second request inside the same cycle, not
@@ -51,9 +51,9 @@ SERVICE_DATA_REQUEST_INTERVAL = MIN_TIME_BETWEEN_UPDATES
 # taken when a poll finishes, not when it was due. Polls arrive exactly
 # MIN_TIME_BETWEEN_UPDATES apart, so a poll answering a few milliseconds faster
 # than the one before it leaves marginally less than that between the two
-# stamps - and with the full interval as the limit, that dropped the cycle. On
-# the unit in #230 it cost 6 of 36 cycles of operation data, every one of them
-# short by under 100ms.
+# stamps - and with the full interval as the limit, that dropped the cycle: one
+# affected unit lost 6 of 36 operation-data cycles this way, each short by
+# under 100ms.
 SERVICE_DATA_MIN_SPACING = SERVICE_DATA_REQUEST_INTERVAL * 0.75
 
 # ...but it does matter *where* in the cycle it lands. Issued straight off the
@@ -61,20 +61,20 @@ SERVICE_DATA_MIN_SPACING = SERVICE_DATA_REQUEST_INTERVAL * 0.75
 # (consolidation delay plus the minimum spacing between requests), and modules
 # answer a second request that soon with HTTP 501 "Not supported this command"
 # often enough to lose whole cycles of operation data - roughly one poll in
-# seven on the unit reported in #230, sometimes several minutes in a row.
-# Offsetting it into the quiet middle of the cycle keeps the cadence but stops
-# it from crowding the poll.
+# seven on an affected unit, sometimes several minutes in a row. Offsetting it
+# into the quiet middle of the cycle keeps the cadence but stops it from
+# crowding the poll.
 SERVICE_DATA_REQUEST_OFFSET = SERVICE_DATA_REQUEST_INTERVAL / 2
 
-# A refused request costs a full cycle of every operation-data sensor, and the
-# refusals seen in #230 are transient, so one retry is worth the extra request.
+# A refused request costs a full cycle of every operation-data sensor, and
+# these refusals are transient, so one retry is worth the extra request.
 SERVICE_DATA_RETRY_DELAY = timedelta(seconds=5)
 
 # The unit answers these segments only when asked, so they are carried across
 # the polls in between (see Device._carry_forward_service_data()) - but not
-# indefinitely. A unit that keeps refusing the request (#230) would otherwise
-# leave entities reporting a frozen number indistinguishable from a live one,
-# which is worse for automations built on them than an honest gap.
+# indefinitely. A unit that keeps refusing the request would otherwise leave
+# entities reporting a frozen number indistinguishable from a live one, which
+# is worse for automations built on them than an honest gap.
 SERVICE_DATA_MAX_AGE = 3 * SERVICE_DATA_REQUEST_INTERVAL
 
 # Fields fed exclusively by those segments.
@@ -110,11 +110,11 @@ SERVICE_DATA_DERIVED_FROM = {
 # requests, so a poll that has to fall back to the other protocol is not
 # cancelled halfway through.
 #
-# It used to equal the per-request timeout, and that combination has a trap
-# (#236): a unit that accepts a plaintext connection without answering it
-# consumes the whole window on the first leg, so the second protocol is never
-# reached. If that unit only speaks the second protocol, every poll fails the
-# same way and the device never recovers on its own.
+# Sized as more than a single per-request timeout: a unit that accepts a
+# plaintext connection without answering it consumes the whole window on the
+# first leg, so an equal-sized budget would never reach the second leg. A
+# unit that only speaks the second protocol would then fail every poll the
+# same way and never recover on its own.
 #
 # Stays under MIN_TIME_BETWEEN_UPDATES so a slow poll cannot still be running
 # when the next one is due.
@@ -272,8 +272,8 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             return False
 
         # Cosmetic (diagnostic sensor only). Some firmware revisions omit the
-        # "mcu"/"wireless" sub-keys entirely (see #189), so their versions are
-        # optional and fall back to "unknown" instead of failing the update.
+        # "mcu"/"wireless" sub-keys entirely, so their versions are optional
+        # and fall back to "unknown" instead of failing the update.
         firm_type = response.get("firmType", "unknown")
         mcu_ver = (response.get("mcu") or {}).get("firmVer", "unknown")
         wireless_ver = (response.get("wireless") or {}).get("firmVer", "unknown")
@@ -367,9 +367,9 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
 
     async def _async_request_service_data(self) -> None:
         """Ask the unit for the operation-data block, offset from the poll and
-        retried once if the unit refuses it (see SERVICE_DATA_REQUEST_OFFSET
-        and #230). Sends directly rather than through async_queue_command() so
-        the refusal is visible here: a queued command is flushed by a detached
+        retried once if the unit refuses it (see SERVICE_DATA_REQUEST_OFFSET).
+        Sends directly rather than through async_queue_command() so the
+        refusal is visible here: a queued command is flushed by a detached
         task that deliberately swallows its errors.
         """
         await asyncio.sleep(SERVICE_DATA_REQUEST_OFFSET.total_seconds())
@@ -377,7 +377,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         # carries no set-bits, so the unit applies none of it (see
         # RacParser.status_request_to_byte). The offset stays because it is
         # about spacing requests, not about what they contain - a second
-        # request too soon after the poll is what the module refuses (#230).
+        # request too soon after the poll is what the module refuses.
         params = {AirconCommands.ServiceDataStatusRequest: True}
         for attempt in (1, 2):
             try:

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -319,8 +319,8 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         try:
             # Strictly-greater-than only: the module treats a requested
             # firmVer <= its current one as "nothing to do" and returns 200 OK
-            # without flashing (see FUNDE.md, updateFirmware) - a `!=` check
-            # would misreport that harmless case as an available downgrade.
+            # without flashing - a `!=` check would misreport that harmless
+            # case as an available downgrade.
             update_available = int(latest["wireless"]) > int(self._wireless_firmware_ver)
         except (TypeError, ValueError):
             _LOGGER.debug(

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -410,9 +410,9 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
 
     def _carry_forward_service_data(self, new_airco: Aircon) -> None:
         """Same rationale as _carry_forward_home_leave_mode() above: the unit
-        reports these extension segments exactly once (confirmed live
-        06.08.2026, see todo.md), so without this the sensors would flash the
-        real value for one update cycle and then revert to unknown.
+        reports these extension segments exactly once, so without this the
+        sensors would flash the real value for one update cycle and then
+        revert to unknown.
 
         Unlike home/leave mode this expires: see SERVICE_DATA_MAX_AGE.
         """
@@ -549,13 +549,12 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         once per HomeLeaveModeStatusRequest, then stops: the bridge MCU clears
         its response cache after handing it to the WiFi side, so the segment is
         present in a short window's worth of status blocks and absent from every
-        later poll (firmware-confirmed 06.08.2026, see the workspace's
-        firmware-kompatibilitaet.md). Observed effect (05.08.2026 live test):
-        translate_bytes() builds a fresh Aircon() with both fields back at their
-        None default, which made the diagnostic sensors flash the real value for
-        one update cycle and then revert to unknown. Carry the last known
-        reading forward instead so it survives until the next explicit request
-        or a fresh None response (e.g. reconnect).
+        later poll. Observed effect: translate_bytes() builds a fresh Aircon()
+        with both fields back at their None default, which made the diagnostic
+        sensors flash the real value for one update cycle and then revert to
+        unknown. Carry the last known reading forward instead so it survives
+        until the next explicit request or a fresh None response (e.g.
+        reconnect).
         """
         if self._airco is None:
             return
@@ -565,21 +564,20 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             new_airco.HomeLeaveModeForHeating = self._airco.HomeLeaveModeForHeating
 
     async def async_request_home_leave_mode_status(self) -> None:
-        """Ask the unit to report its current HomeLeaveMode (Tag 248, #187
+        """Ask the unit to report its current HomeLeaveMode (Tag 248,
         capability index 7) thresholds/airflow. Does not change any AC
         setting by itself - but the unit only reports this extension segment
-        in response to this request, never on an unprompted poll (confirmed
-        empirically, 05.08.2026 live test, matched byte-for-byte against the
-        official app's own display).
+        in response to this request, never on an unprompted poll, and matches
+        byte-for-byte against the official app's own display.
 
-        Timing, measured: the value showed up only on a later scheduled poll -
+        Timing, measured: the value shows up only on a later scheduled poll -
         up to MIN_TIME_BETWEEN_UPDATES (60s) later - not in the response to
-        this call's own setAirconStat POST. Note that a *single* extension
-        request does come back inside that same POST response (verified
-        06.08.2026 with operation-data codes), so the delay here is most
-        likely because this request sends six segments and the unit answers
-        them one bus frame at a time. Unconfirmed - if it matters, measure it
-        rather than trusting this paragraph.
+        this call's own setAirconStat POST. A *single* extension request does
+        come back inside that same POST response (see the service-data
+        path), so the delay here is most likely because this request sends
+        six segments and the unit answers them one bus frame at a time.
+        Unconfirmed - if it matters, measure it rather than trusting this
+        paragraph.
 
         _carry_forward_home_leave_mode() keeps the reading available on every
         following poll instead of it reverting to unknown.
@@ -590,8 +588,8 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         self, cooling: HomeLeaveModeSetting, heating: HomeLeaveModeSetting
     ) -> None:
         """Write new HomeLeaveMode thresholds/airflow (Tag 248, sub-codes
-        27-32). Verified live (05.08.2026) - written values round-tripped
-        exactly through a subsequent read, see todo.md."""
+        27-32). Written values round-trip exactly through a subsequent
+        read."""
         await self.async_queue_command(
             {
                 AirconCommands.HomeLeaveModeForCooling: cooling,

--- a/custom_components/mitsubishi_wf_rac/wfrac/error_codes.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/error_codes.py
@@ -1,8 +1,7 @@
-"""Klartext descriptions for the self-diagnosis ErrorCode (rac_parser.py).
+"""Plain-language descriptions for the self-diagnosis ErrorCode (rac_parser.py).
 
-Source and confidence notes: ../../../../fehlercodes-selfdiagnose.md
-(transcribed from the official MHI service/user manuals and the SRK
-databooks). Not hardware-verified against a real occurrence - only
+Transcribed from the official MHI service/user manuals and the SRK
+databooks. Not hardware-verified against a real occurrence - only
 cross-checked between documents.
 
 The unit numbers errors and protective stops out of one shared space (the
@@ -67,8 +66,7 @@ def describe_error_code(code: str) -> str | None:
     distinction survives into the UI, since a protective stop that recovered on
     its own is not the same news as a fault the unit is displaying.
 
-    Anything outside the tables gets no text rather than a guess - see
-    fehlercodes-selfdiagnose.md.
+    Anything outside the tables gets no text rather than a guess.
     """
     if not code or code == "00":
         return None

--- a/custom_components/mitsubishi_wf_rac/wfrac/error_codes.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/error_codes.py
@@ -1,8 +1,8 @@
 """Klartext descriptions for the self-diagnosis ErrorCode (rac_parser.py).
 
 Source and confidence notes: ../../../../fehlercodes-selfdiagnose.md
-(transcribed from the official MHI service/user manuals and, since 09.08.2026,
-the SRK databooks). Not hardware-verified against a real occurrence - only
+(transcribed from the official MHI service/user manuals and the SRK
+databooks). Not hardware-verified against a real occurrence - only
 cross-checked between documents.
 
 The unit numbers errors and protective stops out of one shared space (the

--- a/custom_components/mitsubishi_wf_rac/wfrac/firmware_check.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/firmware_check.py
@@ -2,9 +2,8 @@
 
 Queries the manufacturer's `server/getFirmware` endpoint - unauthenticated,
 no account/Cognito token involved, same call the official app makes before
-showing "update available". See `../../../../firmware-kompatibilitaet.md`
-and `smartMAir_apk/FUNDE.md` ("OTA-Ablauf") for the reverse-engineering notes
-and field names (`ResponseGetFirmwareMapper.java`).
+showing "update available". Field names come from the app's own
+`ResponseGetFirmwareMapper.java`.
 """
 
 from __future__ import annotations

--- a/custom_components/mitsubishi_wf_rac/wfrac/models/aircon.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/models/aircon.py
@@ -27,9 +27,9 @@ class AirconCommands(StrEnum):
     # fixed-byte field like the ones above, encoded/decoded as a variable
     # trailer in rac_parser.py. HomeLeaveModeStatusRequest asks the unit to
     # report its current values (it omits this segment from a plain
-    # getAirconStat otherwise - confirmed empirically, see #187 notes in
-    # FUNDE.md); the ForCooling/ForHeating pair writes new ones. Both
-    # directions verified live (05.08.2026), see todo.md.
+    # getAirconStat otherwise - confirmed empirically, see FUNDE.md); the
+    # ForCooling/ForHeating pair writes new ones. Both directions verified
+    # live.
     HomeLeaveModeStatusRequest = "HomeLeaveModeStatusRequest"
     HomeLeaveModeForCooling = "HomeLeaveModeForCooling"
     HomeLeaveModeForHeating = "HomeLeaveModeForHeating"
@@ -84,11 +84,11 @@ class Aircon(AirconBase):
     CompressorRunning: bool = False
     # Raw ModelNr byte (content[0] & 127) before mapping to the known 0/1/2
     # values - kept around so an unrecognized value (ModelNr == -1) is still
-    # visible as a diagnostic, e.g. for reports like #189.
+    # visible as a diagnostic, e.g. for unrecognized-model bug reports.
     ModelNrRaw: int = 0
-    # Feature availability per the app's own model_no_type table (#187),
-    # looked up from ModelNrRaw - independent of the ModelNr 0/1/2 grouping
-    # above, which instead reflects the wire-protocol byte layout.
+    # Feature availability per the app's own model_no_type table, looked up
+    # from ModelNrRaw - independent of the ModelNr 0/1/2 grouping above,
+    # which instead reflects the wire-protocol byte layout.
     Capabilities: ModelCapabilities = field(default_factory=lambda: get_capabilities(0))
     # Populated only after a HomeLeaveModeStatusRequest round-trip (see
     # AirconCommands) - stays None otherwise, including on units that

--- a/custom_components/mitsubishi_wf_rac/wfrac/models/aircon.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/models/aircon.py
@@ -27,9 +27,8 @@ class AirconCommands(StrEnum):
     # fixed-byte field like the ones above, encoded/decoded as a variable
     # trailer in rac_parser.py. HomeLeaveModeStatusRequest asks the unit to
     # report its current values (it omits this segment from a plain
-    # getAirconStat otherwise - confirmed empirically, see FUNDE.md); the
-    # ForCooling/ForHeating pair writes new ones. Both directions verified
-    # live.
+    # getAirconStat otherwise, confirmed empirically); the ForCooling/
+    # ForHeating pair writes new ones. Both directions verified live.
     HomeLeaveModeStatusRequest = "HomeLeaveModeStatusRequest"
     HomeLeaveModeForCooling = "HomeLeaveModeForCooling"
     HomeLeaveModeForHeating = "HomeLeaveModeForHeating"

--- a/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
@@ -18,7 +18,7 @@ CRC_INITIAL: Final = 65535
 
 # --- HomeLeaveMode extension segment (Tag 248, capability index 7) ---
 # Ground truth: AirconStatCoder.java (byteToStat/addCommandVariableData) in
-# the official app, see FUNDE.md. Same 4-byte tag/sub/value scheme as
+# the official app. Same 4-byte tag/sub/value scheme as
 # OutdoorTemp/IndoorTemp (tag -128) and Electric (tag -108) below, decoded by
 # the same _parse_temperatures() loop - 248 as a signed byte is -8.
 HOME_LEAVE_MODE_TAG_SIGNED: Final = -8

--- a/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
@@ -37,9 +37,9 @@ HOME_LEAVE_MODE_AIRFLOW_BYTES: Final = (0, 3, 5, 7, 14)
 # Ground truth: live-measured against the official app's own service-data
 # screen equivalent (there isn't one - MHI-AC-Ctrl's code/formula naming),
 # cross-checked in a load test and a batched request, see
-# wf-rac-module-reference.md §5.4 and todo.md. Unlike HomeLeaveMode's Tag 248,
-# the second byte carries data (part of the value, see the frequency formula
-# below) rather than a fixed status marker - do not gate on it like
+# wf-rac-module-reference.md §5.4. Unlike HomeLeaveMode's Tag 248, the second
+# byte carries data (part of the value, see the frequency formula below)
+# rather than a fixed status marker - do not gate on it like
 # HOME_LEAVE_MODE_READ_MARKER.
 SERVICE_DATA_COMPRESSOR_FREQ: Final = 0x11
 SERVICE_DATA_OPERATING_CURRENT: Final = 0x90
@@ -229,10 +229,9 @@ class RacParser:
             return cls._build_trailer(segments)
 
         if aircon_stat.ServiceDataStatusRequest:
-            # OP1=255 -> "report current value" (see rac_parser docstring/
-            # CLAUDE.md guardrail: never 0, that would be a write to the
-            # climate MCU). Confirmed live (06.08.2026) to answer all four in
-            # the direct setAirconStat response - see todo.md.
+            # OP1=255 means "report the current value" - never 0, which in
+            # this trailer would be a write to the climate MCU. All four
+            # segments answer in the same setAirconStat response.
             segments = [(code, 255, 255, 255) for code in SERVICE_DATA_CODES]
             return cls._build_trailer(segments)
 
@@ -299,9 +298,8 @@ class RacParser:
             return stat_byte
 
         stat_byte[10] |= 4 if aircon_stat.IsSelfCleanReset else 0
-        # Byte 12, not 10 - confirmed against the decompiled official app
-        # (fremde-projekte/WF-RAC's COMMAND_OPERATION_MODE2_ON/OFF). Byte 10
-        # here only carries Vacant/SelfCleanReset.
+        # Self-clean operation lives in byte 12, not byte 10 - byte 10 here
+        # only carries Vacant/SelfCleanReset.
         stat_byte[12] |= 144 if aircon_stat.IsSelfCleanOperation else 128
 
         return stat_byte
@@ -395,13 +393,13 @@ class RacParser:
         ac_device.ModelNrRaw = content[0] & 127
         ac_device.Capabilities = get_capabilities(ac_device.ModelNrRaw)
         if ac_device.ModelNrRaw == 3:
-            # ZT series (new 2026 model line) - confirmed via #189 to use the
-            # same wire-protocol byte layout as ModelNr 2 (self-clean bits
-            # etc.). This grouping is protocol-only, not a feature-capability
-            # claim: per #187's capability table (see Capabilities above),
-            # ZT-2025 *does* have VacantProperty - unlike real ModelNr 2 units
-            # - so occupancy/Home Leave gating must use Capabilities, not
-            # this ModelNr value.
+            # ZT series (new 2026 model line) uses the same wire-protocol byte
+            # layout as ModelNr 2 (self-clean bits etc.), so it is grouped
+            # with it here. This grouping is protocol-only, not a feature-
+            # capability claim: ZT-2025 *does* have VacantProperty, unlike
+            # real ModelNr 2 units - see the capability table above - so
+            # occupancy/Home Leave gating must use Capabilities, not this
+            # ModelNr value.
             ac_device.ModelNr = 2
         else:
             ac_device.ModelNr = find_match(ac_device.ModelNrRaw, 0, 1, 2)
@@ -419,8 +417,8 @@ class RacParser:
             # Mirrors the self-clean bit written in receive_to_bytes() above.
             # No longer exposed as an entity: the real cycle can only be
             # started locally via the IR remote, the WiFi module offers no way
-            # to trigger it (see #209). Kept because it's read-only and would
-            # be needed again if a triggerable path ever turns up.
+            # to trigger it. Kept because it's read-only and would be needed
+            # again if a triggerable path ever turns up.
             ac_device.IsSelfCleanOperation = (content[15] & 1) != 0
         code = content[6] & 127
         ac_device.ErrorCode = (
@@ -485,8 +483,8 @@ class RacParser:
         """Decode one operation-data segment (see SERVICE_DATA_CODES).
         Formulas and op1/op2 naming from MHI-AC-Ctrl, cross-checked live
         against a load test (varying compressor frequency) and a batched
-        request - see wf-rac-module-reference.md §5.4/todo.md. Op3 carries no
-        known data for any of these four codes."""
+        request - see wf-rac-module-reference.md §5.4. Op3 carries no known
+        data for any of these four codes."""
         if code == SERVICE_DATA_COMPRESSOR_FREQ:
             ac_device.CompressorFrequency = (op1 - 0x10) * 25.6 + 0.1 * op2
         elif code == SERVICE_DATA_OPERATING_CURRENT:

--- a/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
@@ -87,9 +87,9 @@ SERVICE_DATA_CODES: Final = (
 #
 # byte = GAIN * Rs / (Rs + R(T)),  R(T) = R25 * exp(B * (1/T - 1/298.15))
 #
-# R25/B are the sensor alexnikgr identified (~5 kOhm, B~3950, see issue #223);
-# with GAIN and the two air channels' own series resistors this reproduces
-# both app tables to ~0.3 K, so only Rs is specific to the coil channel.
+# R25/B are the thermistor's own datasheet values (~5 kOhm, B~3950); with
+# GAIN and the two air channels' own series resistors this reproduces both
+# app tables to ~0.3 K, so only Rs is specific to the coil channel.
 COIL_THERMISTOR_R25: Final = 5200.0
 COIL_THERMISTOR_B: Final = 3900.0
 COIL_ADC_GAIN: Final = 367.0
@@ -199,7 +199,7 @@ class RacParser:
         command that doesn't touch either, including every command this
         integration sent before these features existed). Mirrors
         AirconStatCoder.addCommandVariableData(); unverified on real hardware
-        except where noted - see todo.md.
+        except where noted in the branches below.
         """
         if aircon_stat.HomeLeaveModeStatusRequest:
             segments = [

--- a/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
@@ -249,10 +249,10 @@ class RacParser:
 
         Byte 8 is the exception and is carried as usual: it has no set-bit of
         its own, and dropping it clears the unit's echo of it in DB5 bit 4.
-        Confirmed on hardware (11.08.2026, both indoor units): such a frame is
-        answered with the full operation-data trailer and result 0, while
-        power, mode, fan speed, setpoint and both vane axes stay untouched -
-        with the unit running and with it switched off.
+        Confirmed on hardware, on both indoor units: such a frame is answered
+        with the full operation-data trailer and result 0, while power, mode,
+        fan speed, setpoint and both vane axes stay untouched - with the unit
+        running and with it switched off.
         """
         stat_byte = _empty_stat_bytes()
         if not aircon_stat.CoolHotJudge:

--- a/custom_components/mitsubishi_wf_rac/wfrac/repository.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/repository.py
@@ -303,8 +303,8 @@ class Repository:
         firmware reports which code on success over the local API is not
         established, and a command wrongly treated as failed would be worse
         than the silent failure this makes visible - reports of "nothing
-        happens, and nothing in the log" (#212) currently have nothing to go
-        on at all.
+        happens, and nothing in the log" currently have nothing to go on at
+        all.
 
         One line per command entering a failing state, like everywhere else in
         this integration: a unit that answers the same refusal every minute

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -556,9 +556,9 @@ async def test_update_detects_available_firmware_update(device, monkeypatch):
 
 
 async def test_update_does_not_flag_downgrade_or_equal_version_as_update(device, monkeypatch):
-    # Strictly-greater-than only (see FUNDE.md's updateFirmware section): the
-    # module silently no-ops a requested version <= its current one, so
-    # neither "equal" nor "older" may be reported as an available update.
+    # Strictly-greater-than only: the module silently no-ops a requested
+    # version <= its current one, so neither "equal" nor "older" may be
+    # reported as an available update.
     device._firmware_update_check_enabled = True
     fetch = AsyncMock(return_value={"wireless": "025", "mcu": "200"})
     monkeypatch.setattr(device_module, "fetch_latest_firmware", fetch)

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -1,6 +1,6 @@
-"""Unit tests for wfrac/capabilities.py - the #187 model_no_type table.
+"""Unit tests for wfrac/capabilities.py - the model_no_type table.
 
-Ground truth is `smartMAir_apk/jadx-out/resources/res/values/arrays.xml`
+Ground truth is the app's own `res/values/arrays.xml`
 (`model_no_type_function_*`) and `model/ModelNoType.java` (table selection,
 flag order) - see capabilities.py's own docstring.
 """

--- a/tests/unit/test_error_codes.py
+++ b/tests/unit/test_error_codes.py
@@ -1,5 +1,5 @@
-"""Unit tests for wfrac/error_codes.py - see fehlercodes-selfdiagnose.md for
-the sourcing/confidence notes behind these values."""
+"""Unit tests for wfrac/error_codes.py - see error_codes.py's own docstring
+for the sourcing/confidence notes behind these values."""
 
 from custom_components.mitsubishi_wf_rac.wfrac.error_codes import describe_error_code
 

--- a/tests/unit/test_rac_parser.py
+++ b/tests/unit/test_rac_parser.py
@@ -289,15 +289,15 @@ def test_service_data_trailer_status_request(parser):
         groups, (0x11, 0x90, 0x85, 0x13, 0x81, 0x82, 0x87, 0xB1, 0x7C)
     ):
         # OP1=OP2=OP3=255 -> "report current value", never 0 (a write to the
-        # climate MCU) - see CLAUDE.md's telemetry-segment guardrail.
+        # climate MCU).
         assert list(group) == [code, 255, 255, 255]
 
 
 def test_parse_temperatures_service_data_segments(parser):
-    # Real values from a live batched request (06.08.2026, Klima
-    # Schlafzimmer) - see wf-rac-module-reference.md §5.4/todo.md. Unlike
-    # HomeLeaveMode's Tag 248, op1 carries data (part of the frequency
-    # formula) rather than a fixed status marker.
+    # Real values from a live batched request (Klima Schlafzimmer) - see
+    # wf-rac-module-reference.md §5.4. Unlike HomeLeaveMode's Tag 248, op1
+    # carries data (part of the frequency formula) rather than a fixed
+    # status marker.
     signed = lambda b: b - 256 if b > 127 else b
     vals = []
     for code, op1, op2 in (


### PR DESCRIPTION
Comments across the component had accumulated dates, issue numbers used as evidence, and references to files that live outside this repo - leftovers from the analysis process. Rewritten to say why the code is the way it is, not how it got there.

That last category (`todo.md`, `CLAUDE.md`, `FUNDE.md`, `smartMAir_apk/`, and two files that don't even exist under their old names any more) turned out to be the bigger find: those paths resolve to nothing for anyone who's only cloned this repo. Removed entirely rather than reworded - any real connection to the reverse-engineering notes behind this code now lives on the notes' side, not as a dead link from here.

No logic changes - comments, docstrings, and one user-facing error string (a bare issue number) only.