### PR TITLE
Send HomeLeaveModeStatusRequest directly through set_airco()

### DIFF
--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -581,8 +581,15 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
 
         _carry_forward_home_leave_mode() keeps the reading available on every
         following poll instead of it reverting to unknown.
+
+        Sent directly through set_airco() rather than async_queue_command():
+        the latter coalesces this with any command queued in the same
+        window, and since this request's own block carries no set-bits (see
+        RacParser.status_request_to_byte), a coalesced real command - e.g. a
+        setpoint change - would go out in that same block without its
+        set-bit and be silently ignored by the unit.
         """
-        await self.async_queue_command({AirconCommands.HomeLeaveModeStatusRequest: True})
+        await self.set_airco({AirconCommands.HomeLeaveModeStatusRequest: True})
 
     async def async_set_home_leave_mode(
         self, cooling: HomeLeaveModeSetting, heating: HomeLeaveModeSetting

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -403,6 +403,39 @@ async def test_async_queue_command_notifies_listeners_even_on_failure(device, mo
         unsubscribe()
 
 
+async def test_home_leave_mode_status_request_does_not_swallow_a_queued_command(
+    device, monkeypatch
+):
+    """Regression: async_request_home_leave_mode_status() used to go through
+    async_queue_command(), so if it landed in the same consolidation window as
+    a real command, both were merged into one AirconStat. to_base64() then
+    saw HomeLeaveModeStatusRequest set and picked status_request_to_byte(),
+    which carries no set-bits at all - so the real command (here: a setpoint
+    change) went out unset and was silently ignored by the unit. Sending the
+    status request directly through set_airco() keeps it out of that merge.
+    """
+    monkeypatch.setattr(device_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    sent = []
+
+    async def _capture_and_echo(airco_id, command):
+        sent.append(command)
+        return await _echo_send_airco_command(airco_id, command)
+
+    device._api.send_airco_command = AsyncMock(side_effect=_capture_and_echo)
+
+    await device.async_queue_command({AirconCommands.PresetTemp: 25.0})
+    await device.async_request_home_leave_mode_status()
+    await asyncio.sleep(0.05)
+
+    assert len(sent) == 2
+    # The setpoint change must have been sent in its own, separate command
+    # block with its set-bit (DB2[7]) intact.
+    blocks = [base64.b64decode(command)[:18] for command in sent]
+    assert any(block[4] & 0x80 for block in blocks)
+
+
 # --- misc: properties, delete_account(), availability retry, coordinator -
 
 


### PR DESCRIPTION
Follow-up to #252. SoftwareSchmied found that `async_request_home_leave_mode_status()` still went through `async_queue_command()`, so it could coalesce with a real command queued in the same 500ms window. `to_base64()` then saw `HomeLeaveModeStatusRequest` set on the merged `AirconStat` and picked `status_request_to_byte()`, which carries no set-bits at all - so the real command (e.g. a setpoint change) went out in that same block unset and was silently ignored by the unit.

Fix: send it directly through `set_airco()` instead, like the periodic service-data request already does. That keeps it out of the consolidation queue entirely, so it can no longer merge with anything.

Added a regression test that reproduces the report (queue a `PresetTemp` change, then request the Home Leave status) and checks the setpoint's set-bit survives in its own frame - fails without the fix (`1 == 2`, both sent as one merged block), passes with it. All 211 tests green.