### PR TITLE
Resolve the target temperature sensor's offset per mode

### DIFF
--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -35,9 +35,6 @@ from .const import (
     SWING_HORIZONTAL_MODE_TRANSLATION,
     SUPPORT_SWING_HORIZONTAL_MODES,
     CONF_INDOOR_OFFSET,
-    CONF_TARGET_OFFSET,
-    CONF_TARGET_OFFSET_COOL,
-    CONF_TARGET_OFFSET_HEAT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -155,27 +152,6 @@ class AircoClimate(WfRacEntity, ClimateEntity):
     @property
     def max_temp(self) -> float:
         return self._max_temp_for_mode(self._attr_hvac_mode)
-
-    def _resolve_target_offset(self, hvac_mode: HVACMode) -> float:
-        """Resolve the effective target_offset for a given hvac_mode.
-
-        COOL/DRY fall back to CONF_TARGET_OFFSET_COOL, HEAT to
-        CONF_TARGET_OFFSET_HEAT, everything else always uses the global
-        CONF_TARGET_OFFSET - and so does COOL/HEAT when its per-mode option
-        is unset (None), which is what keeps single-target_offset installs
-        unchanged. Called from both the write and read-back path so they can
-        never resolve a different offset for the same mode (see beta2: that
-        divergence is what caused the target_temperature re-send loop).
-        """
-        options = self._device.config_entry.options
-        base_offset = options.get(CONF_TARGET_OFFSET, 0.0)
-        if hvac_mode in (HVACMode.COOL, HVACMode.DRY):
-            override = options.get(CONF_TARGET_OFFSET_COOL)
-        elif hvac_mode == HVACMode.HEAT:
-            override = options.get(CONF_TARGET_OFFSET_HEAT)
-        else:
-            override = None
-        return base_offset if override is None else override
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
@@ -321,12 +297,10 @@ class AircoClimate(WfRacEntity, ClimateEntity):
 
         # Apply indoor offset
         indoor_offset = self._device.config_entry.options.get(CONF_INDOOR_OFFSET, 0.0)
-        # airco.OperationMode reports the underlying cool/heat mode even
-        # while the unit is off (self._attr_hvac_mode gets forced to OFF
-        # below in that case) - both the displayed hvac_mode and the
-        # target_offset resolution need that underlying mode, so it's
-        # computed once here and shared between them.
-        mode_from_operation = list(HVAC_TRANSLATION.keys())[airco.OperationMode]
+        # Both the displayed hvac_mode and the target_offset resolution need
+        # the underlying cool/heat mode, so it's computed once here and shared
+        # between them.
+        mode_from_operation = self._hvac_mode_from_operation
         # Mirror the subtraction in async_set_temperature() so the displayed
         # target_temperature agrees with what the user set - PresetTemp itself
         # holds the offset-lowered value that was actually sent to the device.

--- a/custom_components/mitsubishi_wf_rac/entity.py
+++ b/custom_components/mitsubishi_wf_rac/entity.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 import logging
 
+from homeassistant.components.climate.const import HVACMode
 from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import (
+    CONF_TARGET_OFFSET,
+    CONF_TARGET_OFFSET_COOL,
+    CONF_TARGET_OFFSET_HEAT,
+    HVAC_TRANSLATION,
+)
 from .wfrac.device import Device
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,6 +33,38 @@ class WfRacEntity(CoordinatorEntity[Device]):
         super().__init__(device)
         self._device = device
         self._attr_device_info = device.device_info
+
+    @property
+    def _hvac_mode_from_operation(self) -> HVACMode:
+        """The unit's underlying cool/heat mode.
+
+        airco.OperationMode keeps reporting it while the unit is off, which is
+        what the offset resolution below needs - the climate entity's own
+        hvac_mode is forced to OFF in that case.
+        """
+        return list(HVAC_TRANSLATION.keys())[self._device.airco.OperationMode]
+
+    def _resolve_target_offset(self, hvac_mode: HVACMode) -> float:
+        """Resolve the effective target_offset for a given hvac_mode.
+
+        COOL/DRY fall back to CONF_TARGET_OFFSET_COOL, HEAT to
+        CONF_TARGET_OFFSET_HEAT, everything else always uses the global
+        CONF_TARGET_OFFSET - and so does COOL/HEAT when its per-mode option
+        is unset (None), which is what keeps single-target_offset installs
+        unchanged. Lives on the base entity so the climate write path, the
+        climate read-back path and the target temperature sensor can never
+        resolve a different offset for the same mode (see beta2: that
+        divergence is what caused the target_temperature re-send loop).
+        """
+        options = self._device.config_entry.options
+        base_offset = options.get(CONF_TARGET_OFFSET, 0.0)
+        if hvac_mode in (HVACMode.COOL, HVACMode.DRY):
+            override = options.get(CONF_TARGET_OFFSET_COOL)
+        elif hvac_mode == HVACMode.HEAT:
+            override = options.get(CONF_TARGET_OFFSET_HEAT)
+        else:
+            override = None
+        return base_offset if override is None else override
 
     @property
     def available(self) -> bool:

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -61,7 +61,6 @@ from .const import (
     ATTR_COOL_HOT_JUDGE,
     CONF_INDOOR_OFFSET,
     CONF_OUTDOOR_OFFSET,
-    CONF_TARGET_OFFSET,
     CONF_SERVICE_DATA,
     SERVICE_SET_ENERGY_TOTAL,
     SIGNAL_SET_ENERGY_TOTAL,
@@ -331,9 +330,10 @@ class TemperatureSensor(WfRacEntity, SensorEntity):
             outdoor_offset = self._device.config_entry.options.get(CONF_OUTDOOR_OFFSET, 0.0)
             self._attr_native_value = self._device.airco.OutdoorTemp + outdoor_offset
         elif self._custom_type == ATTR_TARGET_TEMPERATURE:
-            # Kept symmetric with climate.py's target_temperature - see the
-            # comment in ClimateEntity._update_state().
-            target_offset = self._device.config_entry.options.get(CONF_TARGET_OFFSET, 0.0)
+            # Kept symmetric with climate.py's target_temperature by going
+            # through the same resolver, per-mode overrides included - see
+            # WfRacEntity._resolve_target_offset().
+            target_offset = self._resolve_target_offset(self._hvac_mode_from_operation)
             self._attr_native_value = self._device.airco.PresetTemp + target_offset
 
 

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -1,8 +1,10 @@
-"""Tests for climate.py's target_offset symmetry between the write path
+"""Tests for target_offset symmetry between the write path
 (async_set_temperature) and the read-back path (_update_state). Without this,
 a non-zero CONF_TARGET_OFFSET makes target_temperature permanently disagree
 with what the user set, which trips automations' `state_attr(...) != desired`
-guards into a set_temperature re-send loop. Needs the `hass` fixture (Device
+guards into a set_temperature re-send loop. The "Target" temperature sensor
+displays the same setpoint and is covered here too, since it has to resolve
+the offset exactly like the climate entity. Needs the `hass` fixture (Device
 is a DataUpdateCoordinator), hence tests/integration/ rather than tests/unit/.
 """
 
@@ -14,7 +16,9 @@ import pytest
 from homeassistant.components.climate.const import HVACMode
 
 from custom_components.mitsubishi_wf_rac.climate import AircoClimate
+from custom_components.mitsubishi_wf_rac.sensor import TemperatureSensor
 from custom_components.mitsubishi_wf_rac.const import (
+    ATTR_TARGET_TEMPERATURE,
     CONF_TARGET_OFFSET,
     CONF_TARGET_OFFSET_COOL,
     CONF_TARGET_OFFSET_HEAT,
@@ -182,3 +186,38 @@ async def test_round_trip_symmetry_survives_unit_being_off(device):
     entity._update_state()
 
     assert entity._attr_target_temperature == 21
+
+
+# --- the Target sensor agrees with the climate entity ---------------------
+#
+# TemperatureSensor("Target") shows the same setpoint as the climate entity,
+# derived from the same PresetTemp, so it has to resolve the offset the same
+# way. Adding only the global CONF_TARGET_OFFSET there made the two disagree
+# by the difference as soon as a per-mode override was configured.
+
+
+@pytest.mark.parametrize(
+    "hvac_mode,override_key,offset",
+    [
+        (HVACMode.COOL, CONF_TARGET_OFFSET_COOL, 1.5),
+        (HVACMode.DRY, CONF_TARGET_OFFSET_COOL, 1.5),
+        (HVACMode.HEAT, CONF_TARGET_OFFSET_HEAT, -1.5),
+        (HVACMode.AUTO, None, 0.5),
+    ],
+)
+async def test_target_sensor_matches_climate_entity(device, hvac_mode, override_key, offset):
+    device.config_entry.options[CONF_TARGET_OFFSET] = 1.0
+    if override_key is not None:
+        device.config_entry.options[override_key] = offset
+    else:
+        device.config_entry.options[CONF_TARGET_OFFSET] = offset
+    device.airco.PresetTemp = 22
+    device.airco.OperationMode = HVAC_TRANSLATION[hvac_mode]
+
+    climate = AircoClimate(device)
+    sensor = TemperatureSensor(device, "Target", ATTR_TARGET_TEMPERATURE, False)
+    climate._update_state()
+    sensor._update_state()
+
+    assert sensor._attr_native_value == 22 + offset
+    assert sensor._attr_native_value == climate._attr_target_temperature


### PR DESCRIPTION
The "Target" temperature sensor added the global `target_offset`, while the climate entity resolves the cooling/heating override for the mode the unit is actually in. With `target_offset_cool` or `target_offset_heat` configured, the two disagreed by the difference - the sensor showed one setpoint, the thermostat card another.

The resolver now lives on the shared entity base class, so the climate write path, the climate read-back path and the sensor all reach the same one. A second copy is what let them drift apart in the first place, and that is also what caused the `target_temperature` re-send loop fixed in beta2.

Four new parametrised tests check the sensor against the climate entity across cool/dry/heat/auto. They fail on the old sensor code in three of the four cases. Full suite: 214 passing.