### PR TITLE
Pass the config entry to the Device coordinator explicitly

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -161,7 +161,7 @@ async def create_device_from_entry(entry: ConfigEntry, hass: HomeAssistant) -> D
         CONF_AVAILABILITY_RETRY_LIMIT, AVAILABILITY_FAILURE_LIMIT_MIN
     )
     connection_method: str | None = entry.data.get(CONF_CONNECTION_METHOD)
-    _device = Device(hass, name, device, port, device_id, operator_id, airco_id,
+    _device = Device(hass, entry, name, device, port, device_id, operator_id, airco_id,
                      create_swing_mode_select,
                      availability_failure_limit=availability_failure_limit,
                      firmware_update_check_enabled=firmware_update_check_enabled,

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -137,6 +138,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
     def __init__(  # pylint: disable=too-many-arguments
             self,
             hass: HomeAssistant,
+            config_entry: ConfigEntry,
             name: str,
             hostname: str,
             port: int,
@@ -200,6 +202,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=config_entry,
             name=name,
             update_interval=MIN_TIME_BETWEEN_UPDATES,
         )

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -8,12 +8,12 @@ the offset exactly like the climate entity. Needs the `hass` fixture (Device
 is a DataUpdateCoordinator), hence tests/integration/ rather than tests/unit/.
 """
 
-from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
 from homeassistant.components.climate.const import HVACMode
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.mitsubishi_wf_rac.climate import AircoClimate
 from custom_components.mitsubishi_wf_rac.sensor import TemperatureSensor
@@ -22,16 +22,32 @@ from custom_components.mitsubishi_wf_rac.const import (
     CONF_TARGET_OFFSET,
     CONF_TARGET_OFFSET_COOL,
     CONF_TARGET_OFFSET_HEAT,
+    DOMAIN,
     HVAC_TRANSLATION,
 )
 from custom_components.mitsubishi_wf_rac.wfrac.device import Device
 from custom_components.mitsubishi_wf_rac.wfrac.models.aircon import AirconCommands
 
 
+def _set_options(device: Device, options: dict[str, float]) -> None:
+    # ConfigEntry.options is a read-only mappingproxy, so tests set the offsets
+    # the same way the options flow does - through async_update_entry(), merged
+    # onto whatever is already there.
+    device.hass.config_entries.async_update_entry(
+        device.config_entry,
+        options={**device.config_entry.options, **options},
+    )
+
+
 @pytest.fixture
 async def device(hass):
+    # The climate paths use per-entry target offsets, so each test needs
+    # options it can tailor without a full integration setup.
+    entry = MockConfigEntry(domain=DOMAIN, options={})
+    entry.add_to_hass(hass)
     dev = Device(
         hass,
+        entry,
         "Test AC",
         "127.0.0.1",
         51443,
@@ -41,15 +57,11 @@ async def device(hass):
         create_swing_mode_select=True,
     )
     dev._api = AsyncMock()
-    # async_set_temperature()/_update_state() read the option straight off
-    # config_entry.options - Device doesn't get one from the coordinator base
-    # outside of a real config entry setup, so tests provide their own.
-    dev.config_entry = SimpleNamespace(options={})
     return dev
 
 
 async def test_set_temperature_subtracts_target_offset(device):
-    device.config_entry.options[CONF_TARGET_OFFSET] = 1.0
+    _set_options(device, {CONF_TARGET_OFFSET: 1.0})
     device.async_queue_command = AsyncMock()
     entity = AircoClimate(device)
 
@@ -60,7 +72,7 @@ async def test_set_temperature_subtracts_target_offset(device):
 
 
 async def test_update_state_re_adds_target_offset(device):
-    device.config_entry.options[CONF_TARGET_OFFSET] = 1.0
+    _set_options(device, {CONF_TARGET_OFFSET: 1.0})
     device.airco.PresetTemp = 22
     entity = AircoClimate(device)
 
@@ -99,8 +111,7 @@ async def test_target_offset_zero_is_identity(device):
     ],
 )
 async def test_resolve_target_offset_uses_override_when_set(device, hvac_mode, override_key):
-    device.config_entry.options[CONF_TARGET_OFFSET] = 1.0
-    device.config_entry.options[override_key] = 2.5
+    _set_options(device, {CONF_TARGET_OFFSET: 1.0, override_key: 2.5})
     entity = AircoClimate(device)
 
     assert entity._resolve_target_offset(hvac_mode) == 2.5
@@ -111,7 +122,7 @@ async def test_resolve_target_offset_uses_override_when_set(device, hvac_mode, o
     [HVACMode.COOL, HVACMode.DRY, HVACMode.HEAT],
 )
 async def test_resolve_target_offset_falls_back_when_override_unset(device, hvac_mode):
-    device.config_entry.options[CONF_TARGET_OFFSET] = 1.0
+    _set_options(device, {CONF_TARGET_OFFSET: 1.0})
     entity = AircoClimate(device)
 
     assert entity._resolve_target_offset(hvac_mode) == 1.0
@@ -124,9 +135,14 @@ async def test_resolve_target_offset_falls_back_when_override_unset(device, hvac
 async def test_resolve_target_offset_ignores_overrides_for_other_modes(device, hvac_mode):
     # AUTO/FAN_ONLY/OFF never had per-mode behaviour asked for them - they
     # must always use the global value even when both overrides are set.
-    device.config_entry.options[CONF_TARGET_OFFSET] = 1.0
-    device.config_entry.options[CONF_TARGET_OFFSET_COOL] = 2.5
-    device.config_entry.options[CONF_TARGET_OFFSET_HEAT] = -2.5
+    _set_options(
+        device,
+        {
+            CONF_TARGET_OFFSET: 1.0,
+            CONF_TARGET_OFFSET_COOL: 2.5,
+            CONF_TARGET_OFFSET_HEAT: -2.5,
+        },
+    )
     entity = AircoClimate(device)
 
     assert entity._resolve_target_offset(hvac_mode) == 1.0
@@ -152,9 +168,9 @@ async def test_resolve_target_offset_ignores_overrides_for_other_modes(device, h
 )
 async def test_round_trip_symmetry_per_mode(device, hvac_mode, override_key, offset):
     if override_key is not None:
-        device.config_entry.options[override_key] = offset
+        _set_options(device, {override_key: offset})
     else:
-        device.config_entry.options[CONF_TARGET_OFFSET] = offset
+        _set_options(device, {CONF_TARGET_OFFSET: offset})
     device.async_queue_command = AsyncMock()
     entity = AircoClimate(device)
 
@@ -172,8 +188,10 @@ async def test_round_trip_symmetry_survives_unit_being_off(device):
     # airco.OperationMode still reports the underlying cool/heat mode while
     # airco.Operation is False (unit off) - the offset resolution must use
     # that underlying mode, not the OFF hvac_mode the entity reports.
-    device.config_entry.options[CONF_TARGET_OFFSET] = 0.0
-    device.config_entry.options[CONF_TARGET_OFFSET_HEAT] = -2.0
+    _set_options(
+        device,
+        {CONF_TARGET_OFFSET: 0.0, CONF_TARGET_OFFSET_HEAT: -2.0},
+    )
     device.async_queue_command = AsyncMock()
     entity = AircoClimate(device)
 
@@ -206,11 +224,11 @@ async def test_round_trip_symmetry_survives_unit_being_off(device):
     ],
 )
 async def test_target_sensor_matches_climate_entity(device, hvac_mode, override_key, offset):
-    device.config_entry.options[CONF_TARGET_OFFSET] = 1.0
+    _set_options(device, {CONF_TARGET_OFFSET: 1.0})
     if override_key is not None:
-        device.config_entry.options[override_key] = offset
+        _set_options(device, {override_key: offset})
     else:
-        device.config_entry.options[CONF_TARGET_OFFSET] = offset
+        _set_options(device, {CONF_TARGET_OFFSET: offset})
     device.airco.PresetTemp = 22
     device.airco.OperationMode = HVAC_TRANSLATION[hvac_mode]
 

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -13,6 +13,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.mitsubishi_wf_rac.const import DOMAIN
 from custom_components.mitsubishi_wf_rac.wfrac import device as device_module
 from custom_components.mitsubishi_wf_rac.wfrac.device import (
     AVAILABILITY_FAILURE_LIMIT_MIN,
@@ -86,6 +89,7 @@ def _shorten_service_data_timing(monkeypatch, offset_ms: int = 5) -> None:
 async def device(hass):
     dev = Device(
         hass,
+        MockConfigEntry(domain=DOMAIN),
         "Test AC",
         "127.0.0.1",
         51443,
@@ -466,7 +470,8 @@ async def test_availability_tolerates_failures_below_limit(hass):
     """The module reassociates to WiFi about once an hour and misses a poll
     while it does; only a sustained run of failures is a real outage."""
     dev = Device(
-        hass, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id",
+        hass, MockConfigEntry(domain=DOMAIN), "Test AC", "127.0.0.1", 51443,
+        "device-id", "operator-id", "airco-id",
         create_swing_mode_select=True,
     )
     dev._api = AsyncMock()
@@ -490,13 +495,15 @@ async def test_availability_limit_can_be_raised_but_not_lowered(hass):
     enough. Below the floor it only ever produced phantom outages, so a lower
     value is clamped rather than honoured."""
     raised = Device(
-        hass, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id",
+        hass, MockConfigEntry(domain=DOMAIN), "Test AC", "127.0.0.1", 51443,
+        "device-id", "operator-id", "airco-id",
         create_swing_mode_select=True, availability_failure_limit=5,
     )
     assert raised._availability_failure_limit == 5
 
     lowered = Device(
-        hass, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id",
+        hass, MockConfigEntry(domain=DOMAIN), "Test AC", "127.0.0.1", 51443,
+        "device-id", "operator-id", "airco-id",
         create_swing_mode_select=True, availability_failure_limit=1,
     )
     assert lowered._availability_failure_limit == AVAILABILITY_FAILURE_LIMIT_MIN
@@ -515,7 +522,8 @@ async def test_availability_recovers_and_resets_the_failure_count(hass):
     """A success in between must clear the run, not leave it part-way to the
     limit."""
     dev = Device(
-        hass, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id",
+        hass, MockConfigEntry(domain=DOMAIN), "Test AC", "127.0.0.1", 51443,
+        "device-id", "operator-id", "airco-id",
         create_swing_mode_select=True,
     )
     dev._api = AsyncMock()

--- a/tests/integration/test_entity.py
+++ b/tests/integration/test_entity.py
@@ -10,14 +10,18 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
 from custom_components.mitsubishi_wf_rac.button import EnergyTotalResetButton
+from custom_components.mitsubishi_wf_rac.const import DOMAIN
 from custom_components.mitsubishi_wf_rac.wfrac.device import Device
 
 
 @pytest.fixture
 async def device(hass):
     dev = Device(
-        hass, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id",
+        hass, MockConfigEntry(domain=DOMAIN), "Test AC", "127.0.0.1", 51443,
+        "device-id", "operator-id", "airco-id",
         create_swing_mode_select=True,
     )
     dev._api = AsyncMock()


### PR DESCRIPTION
`DataUpdateCoordinator` falls back to the `config_entries.current_entry` ContextVar when an integration does not pass an entry, which is why the entities could read `config_entry.options` all along. Home Assistant asks integrations to hand the entry over directly instead - it does not enforce it for custom integrations, so this is a tidy-up, not a fix. Nothing changes at runtime.

`Device` now takes the entry and forwards it to the coordinator, and the test fixtures build a `MockConfigEntry` instead of attaching a stand-in attribute afterwards. Since a real entry's `options` is read-only, the offset tests go through `async_update_entry()` the way the options flow does.

Suite stays at 214 passing. Best merged after #267, which it builds on.