### PR TITLE
Disable Airco ID and Account Expires by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ This integration creates one device per airco with the following entities.
 | EEV Position *(diagnostic, only with Service Data on)* | % | Same value as EEV Pulses, linearly mapped to 0-255=0-100%. The real full-open pulse count is unknown, so treat this as relative, not calibrated - useful for comparing indoor units on the same system. Same "Service Data" requirement as above. |
 | Indoor Coil Temperature *(diagnostic, only with Service Data on)* | °C | Indoor heat-exchanger temperature (MHI's THI-R1). Per indoor unit, not shared. In cooling it drops as the coil gets cold and rises back to room temperature once the compressor stops - the clearest signal there is for what the unit is actually doing. Works in heating too, where the coil is the condenser and runs to 45 °C and beyond. Same "Service Data" requirement as above. |
 | Indoor Coil Outlet Temperature *(diagnostic, only with Service Data on)* | °C | Indoor heat-exchanger outlet, on the suction side (MHI's THI-R3). Also per indoor unit. Equal to Indoor Coil Temperature while the compressor is off; the difference between the two while it runs is the evaporator superheat. Same "Service Data" requirement as above. |
-| Airco ID *(diagnostic)* | text | Internal ID of the airco. |
+| Airco ID *(diagnostic, disabled by default)* | text | Internal ID of the airco. |
 | Operator ID *(diagnostic, disabled by default)* | text | Internal operator/account ID. |
 | Device ID *(diagnostic, disabled by default)* | text | Internal device ID. |
 | IP *(diagnostic, disabled by default)* | text | Local IP address of the WF-RAC module. |
 | Accounts *(diagnostic, disabled by default)* | number | Number of app accounts currently connected to the unit. |
 | Error *(diagnostic)* | error code | Raw error code reported by the unit; `00` means no error. |
 | Updated By *(diagnostic)* | text | Which account last changed the unit's settings (this integration or the Smart M-Air app). |
-| Account Expires *(diagnostic)* | text | Expiry of the current operator session. |
+| Account Expires *(diagnostic, disabled by default)* | text | Expiry of the current operator session. |
 | LED Status *(diagnostic, disabled by default)* | text | State of the unit's status LED. |
 | Auto Heating *(diagnostic)* | text | State of the unit's automatic heating assist. |
 | Model Nr *(diagnostic, disabled by default)* | number | Raw model-identifier byte reported by the unit. Used to gate which optional features (occupancy, Home Leave) are exposed; mostly useful for diagnosing unsupported models. |

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -85,14 +85,14 @@ async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_e
         # plumbing (ids, session, addressing) that only matters when
         # diagnosing a connection problem. All of these come out of the
         # regular poll, so enabling one costs no extra request.
-        DiagnosticsSensor(device, "Airco ID", CONF_AIRCO_ID, True),
+        DiagnosticsSensor(device, "Airco ID", CONF_AIRCO_ID),
         DiagnosticsSensor(device, "Operator ID", CONF_OPERATOR_ID),
         DiagnosticsSensor(device, "Device ID", ATTR_DEVICE_ID),
         DiagnosticsSensor(device, "IP", CONF_HOST),
         DiagnosticsSensor(device, "Accounts", ATTR_CONNECTED_ACCOUNTS),
         DiagnosticsSensor(device, "Error", CONF_ERROR, True),
         DiagnosticsSensor(device, "Updated By", ATTR_UPDATED_BY, True),
-        DiagnosticsSensor(device, "Account Expires", ATTR_ACCOUNT_EXPIRES, True),
+        DiagnosticsSensor(device, "Account Expires", ATTR_ACCOUNT_EXPIRES),
         # Off until it is understood: reads a constant 1 on both test units
         # regardless of what the machine is doing, so it does not currently
         # track the unit's LED.

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -92,8 +92,12 @@ async def test_platform_entity_composition_and_metadata(hass, platform_device, m
     assert details[f"{DOMAIN}-airco-id-home-leave-cooling-temp_rule-number"] == (False, None)
     assert details[f"{DOMAIN}-airco-id-home-leave-heating-air-flow-select"] == (False, None)
     assert details[f"{DOMAIN}-airco-id-compressor_frequency-sensor"] == (True, EntityCategory.DIAGNOSTIC)
-    assert details[f"{DOMAIN}-airco-id-airco_id-sensor"] == (True, EntityCategory.DIAGNOSTIC)
+    assert details[f"{DOMAIN}-airco-id-airco_id-sensor"] == (False, EntityCategory.DIAGNOSTIC)
     assert details[f"{DOMAIN}-airco-id-operator_id-sensor"] == (False, EntityCategory.DIAGNOSTIC)
+    assert details[f"{DOMAIN}-airco-id-account_expires-sensor"] == (False, EntityCategory.DIAGNOSTIC)
+    assert details[f"{DOMAIN}-airco-id-error-sensor"] == (True, EntityCategory.DIAGNOSTIC)
+    assert details[f"{DOMAIN}-airco-id-updated_by-sensor"] == (True, EntityCategory.DIAGNOSTIC)
+    assert details[f"{DOMAIN}-airco-id-auto_heating-sensor"] == (True, EntityCategory.DIAGNOSTIC)
     assert details[f"{DOMAIN}-airco-id-target_temperature-sensor"] == (False, None)
 
 


### PR DESCRIPTION
`Airco ID` and `Account Expires` were the only two protocol internals created enabled by default, while `Operator ID`, `Device ID`, `IP` and `Accounts` — the same kind of value — were already off. Both are now off too.

Nothing changes on an existing installation: `entity_registry_enabled_default` only applies when an entity is first registered, so both sensors stay exactly as they are today, enabled or disabled. The quieter default applies to new installations only. That is why there is no migration here.

The metadata test now pins the three diagnostic sensors that stay enabled (`Error`, `Updated By`, `Auto Heating`) alongside the two that changed, so a future pass over these defaults can't flip them unnoticed.

243 tests pass, coverage unchanged at 95%.
