### PR TITLE
Request operation data only for active entities

### DIFF
--- a/custom_components/mitsubishi_wf_rac/entity.py
+++ b/custom_components/mitsubishi_wf_rac/entity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.core import callback
@@ -29,8 +30,8 @@ class WfRacEntity(CoordinatorEntity[Device]):
     command completes.
     """
 
-    def __init__(self, device: Device) -> None:
-        super().__init__(device)
+    def __init__(self, device: Device, context: Any | None = None) -> None:
+        super().__init__(device, context=context)
         self._device = device
         self._attr_device_info = device.device_info
 

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -32,6 +32,7 @@ from homeassistant.helpers import entity_registry as er
 
 from .entity import WfRacEntity
 from .wfrac.device import Device
+from .wfrac.rac_parser import SERVICE_DATA_CODE_BY_FIELD
 from .const import (
     ATTR_TARGET_TEMPERATURE,
     ATTR_COMPRESSOR_FREQUENCY,
@@ -105,11 +106,11 @@ async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_e
         entities.append(EnergySensor(device))
         entities.append(EnergyTotalSensor(device))
 
-    # Tied to CONF_SERVICE_DATA rather than merely disabled by default: the
-    # option is what makes Device request these values at all, so without it
-    # the entities could only ever read `unknown`. Changing the option reloads
-    # the entry (see async_update_options), so they appear and disappear with
-    # it.
+    # Tied to CONF_SERVICE_DATA rather than merely disabled by default: it
+    # controls whether these entities exist. Their active coordinator contexts
+    # determine which operation-data segments Device requests. Changing the
+    # option reloads the entry (see async_update_options), so they appear and
+    # disappear with it.
     if entry.options.get(CONF_SERVICE_DATA, False):
         entities += [
             ServiceDataSensor(device, ATTR_COMPRESSOR_FREQUENCY),
@@ -464,9 +465,8 @@ class EnergyTotalSensor(WfRacEntity, RestoreSensor):
 class ServiceDataSensor(WfRacEntity, SensorEntity):
     """Operation-data sensors (compressor frequency, current, hot gas temp,
     EEV pulses/position, coil temperatures) - see rac_parser.SERVICE_DATA_CODES.
-    Only created while CONF_SERVICE_DATA is on, which is what makes Device
-    request these values in the first place - see
-    Device._maybe_request_service_data().
+    Only created while CONF_SERVICE_DATA is on. Active sensors register their
+    segment code with Device, which requests only those segments.
 
     Enabled once they exist: switching the option on is already the opt-in, so
     making the user enable each one on top would be a second hurdle for
@@ -494,8 +494,10 @@ class ServiceDataSensor(WfRacEntity, SensorEntity):
 
     def __init__(self, device: Device, custom_type: str) -> None:
         """Initialize the sensor."""
-        super().__init__(device)
         self._custom_type = custom_type
+        super().__init__(
+            device, context=SERVICE_DATA_CODE_BY_FIELD[self._FIELD_BY_TYPE[custom_type]]
+        )
         self._attr_unique_id = f"{DOMAIN}-{self._device.airco_id}-{custom_type}-sensor"
         self._attr_translation_key = custom_type
         if custom_type == ATTR_COMPRESSOR_FREQUENCY:

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from ..const import DOMAIN, MIN_TIME_BETWEEN_UPDATES
 from .firmware_check import fetch_latest_firmware
 from .models.aircon import Aircon, AirconCommands, AirconStat, HomeLeaveModeSetting
-from .rac_parser import RacParser
+from .rac_parser import RacParser, SERVICE_DATA_CODES
 from .repository import (
     MIN_TIME_BETWEEN_REQUESTS,
     REQUEST_TIMEOUT,
@@ -39,11 +39,11 @@ UPDATE_CONSOLIDATION_PERIOD = timedelta(milliseconds=500)
 # interval instead.
 FIRMWARE_CHECK_INTERVAL = timedelta(hours=24)
 
-# Service data (operation-data codes) is opt-in and costs a second request per
-# poll, but it stays on the local network, changes nothing on the unit (see
-# RacParser.status_request_to_byte) and a batched request answers every code in
-# one round trip, so there's no reason to throttle it below the regular poll
-# cadence. See Device._maybe_request_service_data().
+# Service data is requested for active operation-data entities when the option
+# is enabled, and costs a second request per poll. It stays on the local
+# network and changes nothing on the unit (see RacParser.status_request_to_byte),
+# so there's no reason to throttle it below the regular poll cadence. See
+# Device._maybe_request_service_data().
 SERVICE_DATA_REQUEST_INTERVAL = MIN_TIME_BETWEEN_UPDATES
 
 # The rate limit is a guard against a second request inside the same cycle, not
@@ -338,13 +338,15 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         self.async_set_updated_data(self._airco)
 
     def _maybe_request_service_data(self) -> None:
-        """Kick off a background service-data request if due and enabled (see
-        SERVICE_DATA_MIN_SPACING). Opt-in like the firmware check above, but
-        for a different reason: this stays on the local network, yet it rides
-        on a setAirconStat (see rac_parser.SERVICE_DATA_CODES) and so doubles
-        the traffic the unit has to answer.
+        """Kick off a background request for active service-data segments if
+        due and enabled (see SERVICE_DATA_MIN_SPACING).
         """
         if not self._service_data_enabled:
+            return
+        service_data_codes = tuple(
+            sorted(set(self.async_contexts()).intersection(SERVICE_DATA_CODES))
+        )
+        if not service_data_codes:
             return
         if self._service_data_task is not None and not self._service_data_task.done():
             # A retry from the previous cycle is still in flight; piling a
@@ -364,12 +366,12 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         # waiting out the offset, and HA cancels background tasks at shutdown
         # instead of waiting for them.
         self._service_data_task = self._hass.async_create_background_task(
-            self._async_request_service_data(),
+            self._async_request_service_data(service_data_codes),
             name=f"{DOMAIN} service data request {self._airco_id}",
         )
 
-    async def _async_request_service_data(self) -> None:
-        """Ask the unit for the operation-data block, offset from the poll and
+    async def _async_request_service_data(self, service_data_codes: tuple[int, ...]) -> None:
+        """Ask the unit for operation-data segments, offset from the poll and
         retried once if the unit refuses it (see SERVICE_DATA_REQUEST_OFFSET).
         Sends directly rather than through async_queue_command() so the
         refusal is visible here: a queued command is flushed by a detached
@@ -381,7 +383,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         # RacParser.status_request_to_byte). The offset stays because it is
         # about spacing requests, not about what they contain - a second
         # request too soon after the poll is what the module refuses.
-        params = {AirconCommands.ServiceDataStatusRequest: True}
+        params = {AirconCommands.ServiceDataStatusRequest: service_data_codes}
         for attempt in (1, 2):
             try:
                 await self.set_airco(params, log_failure=False)

--- a/custom_components/mitsubishi_wf_rac/wfrac/models/aircon.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/models/aircon.py
@@ -131,7 +131,7 @@ class AirconStat(AirconBase):
     HomeLeaveModeForCooling: HomeLeaveModeSetting | None = None
     HomeLeaveModeForHeating: HomeLeaveModeSetting | None = None
     # See AirconCommands - only ever set via Device._maybe_request_service_data().
-    ServiceDataStatusRequest: bool = False
+    ServiceDataStatusRequest: tuple[int, ...] = ()
 
     @classmethod
     def from_aircon(cls, aircon: Aircon) -> "AirconStat":

--- a/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
@@ -76,6 +76,15 @@ SERVICE_DATA_CODES: Final = (
     SERVICE_DATA_DISCHARGE_SUPERHEAT_RAW,
     SERVICE_DATA_PROTECTION_RAW,
 )
+SERVICE_DATA_CODE_BY_FIELD: Final = {
+    "CompressorFrequency": SERVICE_DATA_COMPRESSOR_FREQ,
+    "OperatingCurrent": SERVICE_DATA_OPERATING_CURRENT,
+    "HotGasTemp": SERVICE_DATA_HOT_GAS_TEMP,
+    "EevPulses": SERVICE_DATA_EEV_PULSES,
+    "EevPosition": SERVICE_DATA_EEV_PULSES,
+    "IndoorCoilTemp": SERVICE_DATA_INDOOR_COIL_RAW,
+    "IndoorCoilOutletTemp": SERVICE_DATA_INDOOR_COIL_OUTLET_RAW,
+}
 
 # The coil thermistor is the same part as the two air sensors - MHI's manuals
 # print one characteristic for room air, indoor coil, outdoor coil and outdoor
@@ -230,9 +239,11 @@ class RacParser:
 
         if aircon_stat.ServiceDataStatusRequest:
             # OP1=255 means "report the current value" - never 0, which in
-            # this trailer would be a write to the climate MCU. All four
-            # segments answer in the same setAirconStat response.
-            segments = [(code, 255, 255, 255) for code in SERVICE_DATA_CODES]
+            # this trailer would be a write to the climate MCU.
+            segments = [
+                (code, 255, 255, 255)
+                for code in sorted(aircon_stat.ServiceDataStatusRequest)
+            ]
             return cls._build_trailer(segments)
 
         return VARIABLE_SUFFIX

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -25,7 +25,12 @@ from custom_components.mitsubishi_wf_rac.wfrac.models.aircon import (
     Aircon,
     AirconCommands,
 )
-from custom_components.mitsubishi_wf_rac.wfrac.rac_parser import RacParser
+from custom_components.mitsubishi_wf_rac.wfrac.rac_parser import (
+    RacParser,
+    SERVICE_DATA_CODES,
+    SERVICE_DATA_EEV_PULSES,
+    SERVICE_DATA_HOT_GAS_TEMP,
+)
 from custom_components.mitsubishi_wf_rac.wfrac.repository import (
     AirconApiError,
     AirconCommandError,
@@ -83,6 +88,10 @@ def _shorten_service_data_timing(monkeypatch, offset_ms: int = 5) -> None:
     monkeypatch.setattr(
         device_module, "SERVICE_DATA_RETRY_DELAY", timedelta(milliseconds=5)
     )
+
+
+def _activate_service_data_contexts(device, monkeypatch) -> None:
+    monkeypatch.setattr(device, "async_contexts", lambda: set(SERVICE_DATA_CODES))
 
 
 @pytest.fixture
@@ -653,6 +662,7 @@ async def test_update_does_not_request_service_data_when_disabled_by_default(dev
     # poll, so it must stay off unless explicitly enabled via the
     # service_data option (see const.py's CONF_SERVICE_DATA).
     assert device.service_data_enabled is False
+    _activate_service_data_contexts(device, monkeypatch)
     monkeypatch.setattr(device_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
@@ -663,8 +673,24 @@ async def test_update_does_not_request_service_data_when_disabled_by_default(dev
     device._api.send_airco_command.assert_not_awaited()
 
 
+async def test_update_does_not_request_service_data_without_active_entities(
+    device, monkeypatch
+):
+    device._service_data_enabled = True
+    _shorten_service_data_timing(monkeypatch)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
+
+    await device.update()
+    await asyncio.sleep(0.05)
+
+    device._api.send_airco_command.assert_not_awaited()
+    assert device._last_service_data_request is None
+
+
 async def test_update_requests_service_data_when_enabled(device, monkeypatch):
     device._service_data_enabled = True
+    _activate_service_data_contexts(device, monkeypatch)
     _shorten_service_data_timing(monkeypatch)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
@@ -675,11 +701,66 @@ async def test_update_requests_service_data_when_enabled(device, monkeypatch):
     device._api.send_airco_command.assert_awaited_once()
 
 
+async def test_service_data_request_uses_active_segment_codes(device, monkeypatch):
+    device._service_data_enabled = True
+    _shorten_service_data_timing(monkeypatch)
+    monkeypatch.setattr(
+        device,
+        "async_contexts",
+        lambda: {
+            SERVICE_DATA_HOT_GAS_TEMP,
+            SERVICE_DATA_EEV_PULSES,
+            SERVICE_DATA_EEV_PULSES,
+        },
+    )
+    set_airco = AsyncMock()
+    device.set_airco = set_airco
+
+    device._maybe_request_service_data()
+    await asyncio.sleep(0.05)
+
+    set_airco.assert_awaited_once_with(
+        {
+            AirconCommands.ServiceDataStatusRequest: (
+                SERVICE_DATA_EEV_PULSES,
+                SERVICE_DATA_HOT_GAS_TEMP,
+            )
+        },
+        log_failure=False,
+    )
+
+
+async def test_service_data_request_does_not_overlap_an_active_request(device, monkeypatch):
+    device._service_data_enabled = True
+    _activate_service_data_contexts(device, monkeypatch)
+    device._service_data_task = MagicMock()
+    device._service_data_task.done.return_value = False
+
+    device._maybe_request_service_data()
+
+    assert device._last_service_data_request is None
+
+
+async def test_add_account_returns_none_on_api_error(device):
+    device._api.update_account_info.side_effect = AirconApiError("failed")
+
+    assert await device.add_account() is None
+
+
+async def test_set_airco_raises_when_refresh_does_not_provide_state(device):
+    device._airco = None
+    device._api.get_aircon_stats.return_value = None
+
+    with pytest.raises(ValueError, match="Airco object is empty"):
+        await device.set_airco({})
+
+
 async def test_service_data_request_is_offset_from_the_poll(device, monkeypatch):
     """It must not ride straight off the back of the status poll - landing a
     second write that close is what the unit refuses with HTTP 501 (#230).
     """
     device._service_data_enabled = True
+    _activate_service_data_contexts(device, monkeypatch)
     _shorten_service_data_timing(monkeypatch, offset_ms=40)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
@@ -698,6 +779,7 @@ async def test_service_data_request_carries_no_set_bits(device, monkeypatch):
     unit itself from being undone a minute later (#241/#250).
     """
     device._service_data_enabled = True
+    _activate_service_data_contexts(device, monkeypatch)
     _shorten_service_data_timing(monkeypatch, offset_ms=40)
     device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
     sent = []
@@ -733,6 +815,7 @@ async def test_service_data_request_does_not_re_read_before_sending(
     (#247) is unnecessary now that the write applies nothing.
     """
     device._service_data_enabled = True
+    _activate_service_data_contexts(device, monkeypatch)
     _shorten_service_data_timing(monkeypatch, offset_ms=40)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
@@ -751,6 +834,7 @@ async def test_service_data_request_runs_after_a_change_at_the_unit(
     and skipping cost a cycle of every operation-data sensor.
     """
     device._service_data_enabled = True
+    _activate_service_data_contexts(device, monkeypatch)
     _shorten_service_data_timing(monkeypatch)
     changed_at_the_unit = _stats_response(ON_COOL_PAYLOAD) | {"updatedBy": "aircon"}
     device._api.get_aircon_stats.return_value = changed_at_the_unit
@@ -764,6 +848,7 @@ async def test_service_data_request_runs_after_a_change_at_the_unit(
 
 async def test_service_data_request_is_retried_once_when_refused(device, monkeypatch):
     device._service_data_enabled = True
+    _activate_service_data_contexts(device, monkeypatch)
     _shorten_service_data_timing(monkeypatch)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     calls = []
@@ -784,6 +869,7 @@ async def test_service_data_request_is_retried_once_when_refused(device, monkeyp
 
 async def test_service_data_request_gives_up_after_the_retry(device, monkeypatch, caplog):
     device._service_data_enabled = True
+    _activate_service_data_contexts(device, monkeypatch)
     _shorten_service_data_timing(monkeypatch)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     device._api.send_airco_command = AsyncMock(
@@ -804,6 +890,7 @@ async def test_service_data_request_gives_up_after_the_retry(device, monkeypatch
 
 async def test_update_service_data_request_is_rate_limited(device, monkeypatch):
     device._service_data_enabled = True
+    _activate_service_data_contexts(device, monkeypatch)
     _shorten_service_data_timing(monkeypatch)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
@@ -824,6 +911,7 @@ async def test_service_data_survives_a_poll_that_answered_early(device, monkeypa
     reporting unit).
     """
     device._service_data_enabled = True
+    _activate_service_data_contexts(device, monkeypatch)
     _shorten_service_data_timing(monkeypatch)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)

--- a/tests/integration/test_entity.py
+++ b/tests/integration/test_entity.py
@@ -6,7 +6,7 @@ Device.set_available(False) - needs the `hass` fixture (Device is a
 DataUpdateCoordinator), hence tests/integration/ rather than tests/unit/.
 """
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -14,6 +14,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.mitsubishi_wf_rac.button import EnergyTotalResetButton
 from custom_components.mitsubishi_wf_rac.const import DOMAIN
+from custom_components.mitsubishi_wf_rac.entity import WfRacEntity
 from custom_components.mitsubishi_wf_rac.wfrac.device import Device
 
 
@@ -37,3 +38,33 @@ async def test_coordinator_update_does_not_report_failure(device, monkeypatch):
     entity._handle_coordinator_update()
 
     assert reported == []
+
+
+async def test_coordinator_contexts_include_only_contextual_entities(device):
+    contextual_entity = WfRacEntity(device, context="operation-data-code")
+    contextless_entity = WfRacEntity(device)
+    contextual_entity.hass = device.hass
+    contextless_entity.hass = device.hass
+
+    await contextual_entity.async_added_to_hass()
+    await contextless_entity.async_added_to_hass()
+
+    assert set(device.async_contexts()) == {"operation-data-code"}
+
+    await contextual_entity.async_will_remove_from_hass()
+    await contextless_entity.async_will_remove_from_hass()
+    contextual_entity._call_on_remove_callbacks()
+    contextless_entity._call_on_remove_callbacks()
+
+
+async def test_base_entity_marks_device_unavailable_when_state_update_fails(device, monkeypatch):
+    entity = WfRacEntity(device)
+    entity._update_state = MagicMock(side_effect=ValueError)
+    entity.async_write_ha_state = lambda: None
+    set_available = MagicMock()
+    monkeypatch.setattr(device, "set_available", set_available)
+
+    assert entity.available is device.available
+    entity._handle_coordinator_update()
+
+    set_available.assert_called_once_with(False)

--- a/tests/unit/test_rac_parser.py
+++ b/tests/unit/test_rac_parser.py
@@ -281,13 +281,12 @@ def test_home_leave_mode_encode_decode_round_trip(parser):
 
 
 def test_service_data_trailer_status_request(parser):
-    stat = _base_stat(ServiceDataStatusRequest=True)
+    requested_codes = (0x90, 0x13, 0x11)
+    stat = _base_stat(ServiceDataStatusRequest=requested_codes)
     trailer = parser._variable_trailer(stat)
-    assert trailer[0] == 9  # nine 4-byte segments
-    groups = [trailer[1 + i * 4:5 + i * 4] for i in range(9)]
-    for group, code in zip(
-        groups, (0x11, 0x90, 0x85, 0x13, 0x81, 0x82, 0x87, 0xB1, 0x7C)
-    ):
+    assert trailer[0] == len(requested_codes)
+    groups = [trailer[1 + i * 4:5 + i * 4] for i in range(len(requested_codes))]
+    for group, code in zip(groups, sorted(requested_codes)):
         # OP1=OP2=OP3=255 -> "report current value", never 0 (a write to the
         # climate MCU).
         assert list(group) == [code, 255, 255, 255]
@@ -570,7 +569,7 @@ def test_translate_bytes_wraps_failures_in_value_error(parser):
 
 
 def test_status_request_block_leaves_every_set_bit_clear(parser):
-    stat = _base_stat(ServiceDataStatusRequest=True)
+    stat = _base_stat(ServiceDataStatusRequest=(0x11,))
     block = parser.status_request_to_byte(stat)
     # Power DB0[1], mode DB0[5], vane DB0[7]/DB1[7], fan DB1[3], setpoint
     # DB2[7], plus the extended bytes command_to_byte() fills in.
@@ -586,7 +585,7 @@ def test_status_request_block_still_carries_cool_hot_judge(parser):
 
 @pytest.mark.parametrize(
     "request_kwargs",
-    [{"ServiceDataStatusRequest": True}, {"HomeLeaveModeStatusRequest": True}],
+    [{"ServiceDataStatusRequest": (0x11,)}, {"HomeLeaveModeStatusRequest": True}],
 )
 def test_to_base64_sends_no_set_bits_for_a_status_request(parser, request_kwargs):
     stat = _base_stat(Operation=True, PresetTemp=22.0, **request_kwargs)


### PR DESCRIPTION
The operation-data request used to go out on a fixed cadence and ask for all nine segments whenever the "Service Data" option was on, no matter whether anything was there to display them. It is now driven by demand.

Entities can pass a `context` to the coordinator, and an entity disabled in the registry is never added, so it never registers a listener and its context never shows up in `async_contexts()`. The set of active contexts is therefore a live signal of what is actually being shown. Each operation-data sensor now registers its segment code, and `Device` requests exactly the set of codes in use — deduplicated, since EEV Pulses and EEV Position read the same segment. With none of them enabled, no request goes out at all.

`ServiceDataStatusRequest` changed from a `bool` to a tuple of codes. An empty tuple is falsy, so the existing truthiness checks in the parser still read correctly.

The segment codes stay defined only in `rac_parser.py`; the new field-to-code mapping lives next to them rather than in the sensor platform.

The option stays for now — both conditions have to hold. Removing it is a separate change with a migration attached.

250 tests pass, coverage 95%.
