### PR TITLE
Always register the swing selects, and repair strings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The number/select entities above stay `unknown` until the climate entity's "Requ
 
 ## Select
 
-These duplicate the climate entity's swing/fan attributes as standalone entities, useful for dashboards or automations that prefer a plain `select` over a `climate` attribute. Existing installations that had these selects disabled during setup retain them as disabled entities; enable them from the entity registry when wanted.
+These duplicate the climate entity's swing/fan attributes as standalone entities, useful for dashboards or automations that prefer a plain `select` over a `climate` attribute. Installations that declined them during setup get them as disabled entities, to be enabled from the entity list when wanted.
 
 | Entity | Values | Description |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ The unit's own frost-protection/low-power standby mode for when nobody's home, w
 
 The number/select entities above stay `unknown` until the climate entity's "Request Home Leave Mode status" action has been called once - the unit omits these values from a plain poll otherwise. Writing to them before that is refused rather than guessed at. See the `request_home_leave_mode_status`/`set_home_leave_mode` climate actions.
 
-## Select (optional)
+## Select
 
-Only created if "Whether to create an additional swing mode selectors" is enabled in the integration's options — off by default. These duplicate the climate entity's swing/fan attributes as standalone entities, useful for dashboards or automations that prefer a plain `select` over a `climate` attribute.
+These duplicate the climate entity's swing/fan attributes as standalone entities, useful for dashboards or automations that prefer a plain `select` over a `climate` attribute. Existing installations that had these selects disabled during setup retain them as disabled entities; enable them from the entity registry when wanted.
 
 | Entity | Values | Description |
 |---|---|---|

--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -145,7 +145,7 @@ async def create_device_from_entry(entry: ConfigEntry, hass: HomeAssistant) -> D
     operator_id: str = entry.data[CONF_OPERATOR_ID]
     port: int = entry.data[CONF_PORT]
     airco_id: str = entry.data[CONF_AIRCO_ID]
-    create_swing_mode_select: bool = entry.data.get(CONF_CREATE_SWING_MODE_SELECT, True)
+    swing_selects_enabled_default: bool = entry.data.get(CONF_CREATE_SWING_MODE_SELECT, True)
     # Off unless the user explicitly opted in via the options flow - this is
     # the only outbound internet call in the integration (see
     # wfrac/device.py's _maybe_check_firmware_update()).
@@ -157,7 +157,7 @@ async def create_device_from_entry(entry: ConfigEntry, hass: HomeAssistant) -> D
     )
     connection_method: str | None = entry.data.get(CONF_CONNECTION_METHOD)
     _device = Device(hass, entry, name, device, port, device_id, operator_id, airco_id,
-                     create_swing_mode_select,
+                     swing_selects_enabled_default,
                      availability_failure_limit=availability_failure_limit,
                      firmware_update_check_enabled=firmware_update_check_enabled,
                      connection_method=connection_method)

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -25,7 +25,6 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from .const import (
     CONF_AIRCO_ID,
     CONF_AVAILABILITY_RETRY_LIMIT,
-    CONF_CREATE_SWING_MODE_SELECT,
     CONF_FIRMWARE_UPDATE_CHECK,
     CONF_OPERATOR_ID,
     CONF_INDOOR_OFFSET,
@@ -248,7 +247,6 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 field(CONF_HOST, vol.Required): cv.string,
                 field(CONF_PORT, vol.Optional, 51443): cv.port,
                 field(CONF_FORCE_UPDATE, vol.Optional, False): cv.boolean,
-                field(CONF_CREATE_SWING_MODE_SELECT, vol.Optional, True): cv.boolean,
             }
         )
 

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -29,6 +29,8 @@ CONF_AVAILABILITY_RETRY_LIMIT = "availability_retry_limit"
 # availability polling, this isn't required for the integration to work, and
 # some users may not want any cloud call at all - see Device._maybe_check_firmware_update().
 CONF_FIRMWARE_UPDATE_CHECK = "firmware_update_check"
+# Read only for entries created before swing selects were always registered.
+# New entries must not write this key.
 CONF_CREATE_SWING_MODE_SELECT = "create_swing_mode_select"
 CONF_CONNECTION_METHOD = "connection_method"
 ATTR_DEVICE_ID = "device_id"

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -55,11 +55,7 @@ async def async_setup_entry(_hass, entry: MitsubishiWfRacConfigEntry, async_add_
 
     device: Device = entry.runtime_data.device
     _LOGGER.info("Setup Fan, Horizontal and Vertical Select: %s, %s", device.device_name, device.airco_id)
-    if device.create_swing_mode_select:
-        entities = [HorizontalSwingSelect(device), VerticalSwingSelect(device), FanSpeedSelect(device)]
-    else:
-        entities = []
-        _LOGGER.info("No Setup Horizontal Select: %s, %s", device.device_name, device.airco_id)
+    entities = [HorizontalSwingSelect(device), VerticalSwingSelect(device), FanSpeedSelect(device)]
 
     # Same VacantProperty capability gate as OccupancyBinarySensor in
     # binary_sensor.py.
@@ -83,6 +79,7 @@ class HorizontalSwingSelect(WfRacEntity, SelectEntity):
 
     def __init__(self, device: Device) -> None:
         super().__init__(device)
+        self._attr_entity_registry_enabled_default = device.swing_selects_enabled_default
         self._attr_options = SUPPORT_SWING_HORIZONTAL_MODES
         self._attr_icon = "mdi:weather-dust"
         self._attr_unique_id = (
@@ -137,6 +134,7 @@ class VerticalSwingSelect(WfRacEntity, SelectEntity):
 
     def __init__(self, device: Device) -> None:
         super().__init__(device)
+        self._attr_entity_registry_enabled_default = device.swing_selects_enabled_default
         self._attr_options = SUPPORT_SWING_MODES
         self._attr_icon = "mdi:weather-dust"
         self._attr_unique_id = (
@@ -189,6 +187,7 @@ class FanSpeedSelect(WfRacEntity, SelectEntity):
 
     def __init__(self, device: Device) -> None:
         super().__init__(device)
+        self._attr_entity_registry_enabled_default = device.swing_selects_enabled_default
         self._attr_options = SUPPORTED_FAN_MODES
         self._attr_icon = "mdi:fan"
         self._attr_unique_id = f"{DOMAIN}-{self._device.airco_id}-fan-speed"

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -39,6 +39,9 @@
           "host": "[%key:common::config_flow::data::host%]",
           "availability_retry_limit": "Retry limit (minimum 3)",
           "firmware_update_check": "Firmware Update Check (Online)",
+          "indoor_offset": "Indoor Temp. Sensor Offset",
+          "outdoor_offset": "Outdoor Temp. Sensor Offset",
+          "target_offset": "Target Temp. Offset",
           "target_offset_cool": "Target Temp. Offset (Cooling)",
           "target_offset_heat": "Target Temp. Offset (Heating)"
         },
@@ -48,17 +51,86 @@
   },
   "entity": {
     "sensor": {
+      "indoor": {
+        "name": "Indoor"
+      },
+      "outdoor": {
+        "name": "Outdoor"
+      },
+      "target": {
+        "name": "Target"
+      },
+      "airco_id": {
+        "name": "Airco ID"
+      },
+      "operator_id": {
+        "name": "Operator ID"
+      },
+      "device_id": {
+        "name": "Device ID"
+      },
+      "host": {
+        "name": "IP"
+      },
+      "connected_accounts": {
+        "name": "Accounts"
+      },
+      "error": {
+        "name": "Error"
+      },
+      "updated_by": {
+        "name": "Updated By"
+      },
+      "account_expires": {
+        "name": "Account Expires"
+      },
+      "led_status": {
+        "name": "LED Status"
+      },
+      "auto_heating": {
+        "name": "Auto Heating"
+      },
+      "model_nr": {
+        "name": "Model Nr"
+      },
       "cool_hot_judge": {
         "name": "Cool Hot Judge"
+      },
+      "energy_usage": {
+        "name": "Energy Usage (current run)"
+      },
+      "energy_usage_total": {
+        "name": "Energy Usage Total"
+      },
+      "compressor_frequency": {
+        "name": "Compressor Frequency"
       },
       "compressor_frequency_raw": {
         "name": "Compressor Frequency (raw)"
       },
+      "operating_current": {
+        "name": "Operating Current"
+      },
       "operating_current_raw": {
         "name": "Operating Current (raw)"
       },
+      "hot_gas_temp": {
+        "name": "Hot Gas Temperature"
+      },
       "hot_gas_temp_raw": {
         "name": "Hot Gas Temperature (raw)"
+      },
+      "eev_pulses": {
+        "name": "EEV Pulses"
+      },
+      "eev_position": {
+        "name": "EEV Position"
+      },
+      "indoor_coil_temp": {
+        "name": "Indoor Coil Temperature"
+      },
+      "indoor_coil_outlet_temp": {
+        "name": "Indoor Coil Outlet Temperature"
       },
       "indoor_coil_raw": {
         "name": "Indoor Coil Temperature (raw)"
@@ -79,6 +151,139 @@
     "update": {
       "firmware_update": {
         "name": "Firmware Update"
+      }
+    },
+    "climate": {
+      "mitsubishi_wf_rac": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "auto": "Auto",
+              "quiet": "Quiet",
+              "low": "Low",
+              "medium": "Medium",
+              "high": "High"
+            }
+          },
+          "swing_mode": {
+            "state": {
+              "up_down_auto": "Up/Down Auto",
+              "highest": "Highest",
+              "middle": "Middle",
+              "normal": "Normal",
+              "lowest": "Lowest",
+              "3d_auto": "3D Auto"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "left_right_auto": "Left/Right Auto",
+              "left_left": "Left-Left",
+              "left_center": "Left-Center",
+              "center_center": "Center-Center",
+              "center_right": "Center-Right",
+              "right_right": "Right-Right",
+              "left_right": "Left-Right",
+              "right_left": "Right-Left",
+              "3d_auto": "3D Auto"
+            }
+          }
+        }
+      }
+    },
+    "select": {
+      "horizontal_swing": {
+        "name": "Horizontal Swing Direction",
+        "state": {
+          "left_right_auto": "Left/Right Auto",
+          "left_left": "Left-Left",
+          "left_center": "Left-Center",
+          "center_center": "Center-Center",
+          "center_right": "Center-Right",
+          "right_right": "Right-Right",
+          "left_right": "Left-Right",
+          "right_left": "Right-Left",
+          "3d_auto": "3D Auto"
+        }
+      },
+      "vertical_swing": {
+        "name": "Vertical Swing Direction",
+        "state": {
+          "up_down_auto": "Up/Down Auto",
+          "highest": "Highest",
+          "middle": "Middle",
+          "normal": "Normal",
+          "lowest": "Lowest",
+          "3d_auto": "3D Auto"
+        }
+      },
+      "fan_speed": {
+        "name": "Fan Speed",
+        "state": {
+          "auto": "Auto",
+          "quiet": "Quiet",
+          "low": "Low",
+          "medium": "Medium",
+          "high": "High"
+        }
+      },
+      "home_leave_mode": {
+        "name": "Home Leave Mode",
+        "state": {
+          "off": "Off",
+          "away_cool": "Away Cooling",
+          "away_heat": "Away Heating"
+        }
+      },
+      "home_leave_cooling_air_flow": {
+        "name": "Home Leave Cooling Air Flow",
+        "state": {
+          "auto": "Auto",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4"
+        }
+      },
+      "home_leave_heating_air_flow": {
+        "name": "Home Leave Heating Air Flow",
+        "state": {
+          "auto": "Auto",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4"
+        }
+      }
+    },
+    "number": {
+      "home_leave_cooling_temp_rule": {
+        "name": "Home Leave Cooling Outdoor Temp. Threshold"
+      },
+      "home_leave_cooling_temp_setting": {
+        "name": "Home Leave Cooling Target Room Temp."
+      },
+      "home_leave_heating_temp_rule": {
+        "name": "Home Leave Heating Outdoor Temp. Threshold"
+      },
+      "home_leave_heating_temp_setting": {
+        "name": "Home Leave Heating Target Room Temp."
+      }
+    },
+    "binary_sensor": {
+      "problem": {
+        "name": "Problem"
+      },
+      "occupancy": {
+        "name": "Presence"
+      },
+      "compressor": {
+        "name": "Compressor Demand"
+      }
+    },
+    "button": {
+      "reset_energy_total": {
+        "name": "Reset Energy Usage Total"
       }
     }
   }

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -45,7 +45,11 @@
           "target_offset_cool": "Target Temp. Offset (Cooling)",
           "target_offset_heat": "Target Temp. Offset (Heating)"
         },
-        "title": "WF-RAC AC connection info"
+        "title": "WF-RAC options",
+        "data_description": {
+          "target_offset_cool": "Leave empty to use the general target temperature offset.",
+          "target_offset_heat": "Leave empty to use the general target temperature offset."
+        }
       }
     }
   },

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -17,8 +17,7 @@
           "name": "Klima Name",
           "host": "Host (IP) Adresse",
           "port": "Port",
-          "force_update": "Doppelte IP ignorieren (kann/wird Fehler verursachen, überprüfen Sie daher das Fehlerprotokoll)",
-          "create_swing_mode_select": "Ob zusätzliche Schwenkmodus-Auswahlen erstellt werden sollen."
+          "force_update": "Doppelte IP ignorieren (kann/wird Fehler verursachen, überprüfen Sie daher das Fehlerprotokoll)"
         },
         "description": "Bitte geben Sie die korrekten Informationen ein, um die Klimaanlage manuell hinzuzufügen",
         "title": "WF-RAC AC Verbindungs-Info"
@@ -40,7 +39,6 @@
           "host": "Host (IP) Adresse",
           "availability_retry_limit": "max. Anzahl Wiederholungen (mind. 3)",
           "firmware_update_check": "Firmware-Update-Prüfung (Online)",
-          "create_swing_mode_select": "Ob zusätzliche Schwenkmodus-Auswahlen erstellt werden sollen.",
           "indoor_offset": "Innentemperatur Sensor-Offset",
           "outdoor_offset": "Außentemperatur Sensor-Offset",
           "target_offset": "Zieltemperatur-Offset",

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -45,7 +45,7 @@
           "target_offset_cool": "Zieltemperatur-Offset (Kühlen)",
           "target_offset_heat": "Zieltemperatur-Offset (Heizen)"
         },
-        "title": "WF-RAC AC Verbindungs-Info"
+        "title": "WF-RAC Optionen"
       }
     }
   },

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -17,8 +17,7 @@
           "name": "Airco Name",
           "host": "Host (IP) address",
           "port": "Port",
-          "force_update": "Ignore Duplicate IP (can/will cause Errors so check error log)",
-          "create_swing_mode_select": "Whether to create an additional swing mode selectors."
+          "force_update": "Ignore Duplicate IP (can/will cause Errors so check error log)"
         },
         "description": "Please fill in the correct information to add the Airco Manually",
         "title": "WF-RAC AC connection info"
@@ -40,7 +39,6 @@
           "host": "Host (IP) address",
           "availability_retry_limit": "Retry limit (minimum 3)",
           "firmware_update_check": "Firmware Update Check (Online)",
-          "create_swing_mode_select": "Whether to create an additional swing mode selectors.",
           "indoor_offset": "Indoor Temp. Sensor Offset",
           "outdoor_offset": "Outdoor Temp. Sensor Offset",
           "target_offset": "Target Temp. Offset",

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -45,7 +45,11 @@
           "target_offset_cool": "Target Temp. Offset (Cooling)",
           "target_offset_heat": "Target Temp. Offset (Heating)"
         },
-        "title": "WF-RAC AC connection info"
+        "title": "WF-RAC options",
+        "data_description": {
+          "target_offset_cool": "Leave empty to use the general target temperature offset.",
+          "target_offset_heat": "Leave empty to use the general target temperature offset."
+        }
       }
     }
   },

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -17,8 +17,7 @@
           "name": "エアコン名",
           "host": "ホスト（IP）アドレス",
           "port": "ポート",
-          "force_update": "重複IPを無視（エラーが発生する可能性があるため、エラーログを確認してください）",
-          "create_swing_mode_select": "追加のスイングモードセレクターを作成するかどうか。"
+          "force_update": "重複IPを無視（エラーが発生する可能性があるため、エラーログを確認してください）"
         },
         "description": "エアコンを手動で追加するために正しい情報を入力してください。",
         "title": "WF-RACエアコン接続情報"
@@ -40,7 +39,6 @@
           "host": "ホスト（IP）アドレス",
           "availability_retry_limit": "リトライ回数の上限（最小 3）",
           "firmware_update_check": "ファームウェア更新の確認 (オンライン)",
-          "create_swing_mode_select": "追加のスイングモードセレクターを作成するかどうか。",
           "indoor_offset": "室内オフセット",
           "outdoor_offset": "室外オフセット",
           "target_offset": "設定オフセット",

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -45,7 +45,7 @@
           "target_offset_cool": "設定オフセット（冷房時）",
           "target_offset_heat": "設定オフセット（暖房時）"
         },
-        "title": "WF-RACエアコン接続情報"
+        "title": "WF-RAC の設定"
       }
     }
   },

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -45,7 +45,7 @@
           "target_offset_cool": "Tikslinis poslinkis (vėsinimas)",
           "target_offset_heat": "Tikslinis poslinkis (šildymas)"
         },
-        "title": "WF-RAC oro kondicionieriaus prisijungimo informacija"
+        "title": "WF-RAC parinktys"
       }
     }
   },

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -17,8 +17,7 @@
           "name": "Kondicionieriaus pavadinimas",
           "host": "Host (IP) adresas",
           "port": "Portas",
-          "force_update": "Ignoruoti dubliuot1 IP (tikėtinai bus klaidos. Patikrinkite log failus)",
-          "create_swing_mode_select": "Ar kurti papildomus svyravimo režimo pasirinkiklius."
+          "force_update": "Ignoruoti dubliuot1 IP (tikėtinai bus klaidos. Patikrinkite log failus)"
         },
         "description": "Užpildykite teisingą informaciją norėdami pridėti kondicionių rankiniu būdu",
         "title": "WF-RAC AC susijungimo informacija"
@@ -40,7 +39,6 @@
           "host": "Host (IP) adresas",
           "availability_retry_limit": "Pakartotinio bandymo limitas (min. 3)",
           "firmware_update_check": "Programinės įrangos atnaujinimų tikrinimas (internetu)",
-          "create_swing_mode_select": "Ar kurti papildomus svyravimo režimo pasirinkiklius.",
           "indoor_offset": "Vidaus poslinkis",
           "outdoor_offset": "Lauko poslinkis",
           "target_offset": "Tikslinis poslinkis",

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -45,7 +45,7 @@
           "target_offset_cool": "Doel offset (Koelen)",
           "target_offset_heat": "Doel offset (Verwarmen)"
         },
-        "title": "WF-RAC AC connectie info"
+        "title": "WF-RAC opties"
       }
     }
   },

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -17,8 +17,7 @@
           "name": "Airco Naam",
           "host": "Host (IP) adres",
           "port": "Poort",
-          "force_update": "Negeer dubbel IP (kan en zal fouten veroorzaken, dus controleer het foutlog)",
-          "create_swing_mode_select": "Of er extra zwaaimodus-selectors moeten worden aangemaakt."
+          "force_update": "Negeer dubbel IP (kan en zal fouten veroorzaken, dus controleer het foutlog)"
         },
         "description": "Voer de juiste informatie toe om de airco handmatig toe te voegen ",
         "title": "WF-RAC AC verbinding info"
@@ -40,7 +39,6 @@
           "host": "Host (IP) adres",
           "availability_retry_limit": "Herhaal limiet (minimaal 3)",
           "firmware_update_check": "Firmware-updatecontrole (online)",
-          "create_swing_mode_select": "Of er extra zwaaimodus-selectors moeten worden aangemaakt.",
           "indoor_offset": "Binnen offset",
           "outdoor_offset": "Buiten offset",
           "target_offset": "Doel offset",

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -17,8 +17,7 @@
           "name": "空调名称",
           "host": "主机（IP）地址",
           "port": "端口",
-          "force_update": "忽略重复 IP（可能/将会引发错误，请检查错误日志）",
-          "create_swing_mode_select": "是否创建额外的摆风模式选择器。"
+          "force_update": "忽略重复 IP（可能/将会引发错误，请检查错误日志）"
         },
         "description": "请填写正确的信息以手动添加空调",
         "title": "WF-RAC 空调连接信息"
@@ -40,7 +39,6 @@
           "host": "主机（IP）地址",
           "availability_retry_limit": "重试次数上限（最少 3）",
           "firmware_update_check": "固件更新检查（在线）",
-          "create_swing_mode_select": "是否创建额外的摆风模式选择器。",
           "indoor_offset": "室内偏移",
           "outdoor_offset": "室外偏移",
           "target_offset": "目标偏移",

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -45,7 +45,7 @@
           "target_offset_cool": "目标偏移（制冷）",
           "target_offset_heat": "目标偏移（制热）"
         },
-        "title": "WF-RAC 空调连接信息"
+        "title": "WF-RAC 选项"
       }
     }
   },

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -17,8 +17,7 @@
           "name": "空調名稱",
           "host": "主機（IP）地址",
           "port": "埠號",
-          "force_update": "忽略重複 IP（可能/將會引發錯誤，請檢查錯誤日誌）",
-          "create_swing_mode_select": "是否建立額外的擺風模式選擇器。"
+          "force_update": "忽略重複 IP（可能/將會引發錯誤，請檢查錯誤日誌）"
         },
         "description": "請填寫正確的信息以手動新增空調",
         "title": "WF-RAC 空調連接資訊"
@@ -40,7 +39,6 @@
           "host": "主機（IP）地址",
           "availability_retry_limit": "重試次數上限（最少 3）",
           "firmware_update_check": "韌體更新檢查（線上）",
-          "create_swing_mode_select": "是否建立額外的擺風模式選擇器。",
           "indoor_offset": "室內偏移",
           "outdoor_offset": "室外偏移",
           "target_offset": "目標偏移",

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -45,7 +45,7 @@
           "target_offset_cool": "目標偏移（製冷）",
           "target_offset_heat": "目標偏移（製熱）"
         },
-        "title": "WF-RAC 空調連接資訊"
+        "title": "WF-RAC 選項"
       }
     }
   },

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -147,7 +147,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             device_id: str,
             operator_id: str,
             airco_id: str,
-            create_swing_mode_select: bool,
+            swing_selects_enabled_default: bool,
             availability_failure_limit: int = AVAILABILITY_FAILURE_LIMIT_MIN,
             firmware_update_check_enabled: bool = False,
             connection_method: str | None = None,
@@ -190,7 +190,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         self._availability_failure_limit = max(
             AVAILABILITY_FAILURE_LIMIT_MIN, availability_failure_limit
         )
-        self._create_swing_mode_select = create_swing_mode_select
+        self._swing_selects_enabled_default = swing_selects_enabled_default
         # Serializes set_airco() calls end-to-end (snapshot build through
         # self._airco update) so a call can never build its diff from a
         # snapshot that's stale because another set_airco() is still in
@@ -778,9 +778,9 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         return self._available
 
     @property
-    def create_swing_mode_select(self) -> bool:
-        """Create swing mode select"""
-        return self._create_swing_mode_select
+    def swing_selects_enabled_default(self) -> bool:
+        """Return the registry default for the standalone swing selects."""
+        return self._swing_selects_enabled_default
 
     @property
     def connection_method(self) -> str | None:

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -54,7 +54,7 @@ async def device(hass):
         "device-id",
         "operator-id",
         "airco-id",
-        create_swing_mode_select=True,
+        swing_selects_enabled_default=True,
     )
     dev._api = AsyncMock()
     return dev

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -2,6 +2,8 @@
 options flow. Repository (the HTTP layer) is patched out - no real network.
 """
 
+import json
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -495,6 +497,30 @@ async def test_options_flow_leaves_per_mode_offsets_unset_when_omitted(hass: Hom
     assert CONF_TARGET_OFFSET_HEAT not in result["data"]
     assert result["data"].get(CONF_TARGET_OFFSET_COOL) is None
     assert result["data"].get(CONF_TARGET_OFFSET_HEAT) is None
+
+
+async def test_options_form_fields_all_have_a_label(hass: HomeAssistant):
+    """A field without an entry in strings.json renders as its raw key.
+
+    That is not a crash and no test catches it downstream, so the form can
+    grow a field and show the user "availability_retry_limit" indefinitely.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room AC"},
+        options={"host": "192.168.1.50"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    fields = {str(key.schema) for key in result["data_schema"].schema}
+
+    strings = json.loads(
+        Path("custom_components/mitsubishi_wf_rac/strings.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert set(strings["options"]["step"]["init"]["data"]) == fields
 
 
 # --- WfRacConfigFlow.is_matching() / _name ------------------------------

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components import mitsubishi_wf_rac
 from custom_components.mitsubishi_wf_rac.const import (
     CONF_AIRCO_ID,
     CONF_AVAILABILITY_RETRY_LIMIT,
@@ -515,11 +516,8 @@ async def test_options_form_fields_all_have_a_label(hass: HomeAssistant):
     result = await hass.config_entries.options.async_init(entry.entry_id)
     fields = {str(key.schema) for key in result["data_schema"].schema}
 
-    strings = json.loads(
-        Path("custom_components/mitsubishi_wf_rac/strings.json").read_text(
-            encoding="utf-8"
-        )
-    )
+    strings_file = Path(mitsubishi_wf_rac.__file__).parent / "strings.json"
+    strings = json.loads(strings_file.read_text(encoding="utf-8"))
     assert set(strings["options"]["step"]["init"]["data"]) == fields
 
 

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -113,7 +113,7 @@ async def device(hass):
         "device-id",
         "operator-id",
         "airco-id",
-        create_swing_mode_select=True,
+        swing_selects_enabled_default=True,
     )
     dev._api = AsyncMock()
     return dev
@@ -466,7 +466,7 @@ async def test_properties_reflect_constructor_args(device):
     assert device.port == 51443
     assert device.device_id == "device-id"
     assert device.airco_id == "airco-id"
-    assert device.create_swing_mode_select is True
+    assert device.swing_selects_enabled_default is True
     assert device.device_info["name"] == "Test AC"
     assert device.device_info["identifiers"] == {("mitsubishi_wf_rac", "airco-id")}
 
@@ -489,7 +489,7 @@ async def test_availability_tolerates_failures_below_limit(hass):
     dev = Device(
         hass, MockConfigEntry(domain=DOMAIN), "Test AC", "127.0.0.1", 51443,
         "device-id", "operator-id", "airco-id",
-        create_swing_mode_select=True,
+        swing_selects_enabled_default=True,
     )
     dev._api = AsyncMock()
     dev._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
@@ -514,14 +514,14 @@ async def test_availability_limit_can_be_raised_but_not_lowered(hass):
     raised = Device(
         hass, MockConfigEntry(domain=DOMAIN), "Test AC", "127.0.0.1", 51443,
         "device-id", "operator-id", "airco-id",
-        create_swing_mode_select=True, availability_failure_limit=5,
+        swing_selects_enabled_default=True, availability_failure_limit=5,
     )
     assert raised._availability_failure_limit == 5
 
     lowered = Device(
         hass, MockConfigEntry(domain=DOMAIN), "Test AC", "127.0.0.1", 51443,
         "device-id", "operator-id", "airco-id",
-        create_swing_mode_select=True, availability_failure_limit=1,
+        swing_selects_enabled_default=True, availability_failure_limit=1,
     )
     assert lowered._availability_failure_limit == AVAILABILITY_FAILURE_LIMIT_MIN
 
@@ -541,7 +541,7 @@ async def test_availability_recovers_and_resets_the_failure_count(hass):
     dev = Device(
         hass, MockConfigEntry(domain=DOMAIN), "Test AC", "127.0.0.1", 51443,
         "device-id", "operator-id", "airco-id",
-        create_swing_mode_select=True,
+        swing_selects_enabled_default=True,
     )
     dev._api = AsyncMock()
     dev._api.update_account_info = AsyncMock()

--- a/tests/integration/test_entity.py
+++ b/tests/integration/test_entity.py
@@ -23,7 +23,7 @@ async def device(hass):
     dev = Device(
         hass, MockConfigEntry(domain=DOMAIN), "Test AC", "127.0.0.1", 51443,
         "device-id", "operator-id", "airco-id",
-        create_swing_mode_select=True,
+        swing_selects_enabled_default=True,
     )
     dev._api = AsyncMock()
     return dev

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -38,7 +38,7 @@ from ..unit.live_captures import LIVE_CAPTURES
 async def platform_device(hass):
     entry = MockConfigEntry(domain=DOMAIN, options={})
     entry.add_to_hass(hass)
-    device = Device(hass, entry, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id", create_swing_mode_select=True)
+    device = Device(hass, entry, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id", swing_selects_enabled_default=True)
     device._api = AsyncMock()
     device._api.get_aircon_stats.return_value = {"numOfAccount": 1, "airconStat": LIVE_CAPTURES["on_cool"][0]}
     await device.update()
@@ -123,11 +123,12 @@ async def test_platform_option_and_capability_gates(hass, platform_device):
     entry = _entry(platform_device)
     platform_device.airco.Electric = None
     platform_device.airco.Capabilities = replace(platform_device.airco.Capabilities, vacant_property=False, home_leave_mode=False)
-    platform_device._create_swing_mode_select = False
+    platform_device._swing_selects_enabled_default = False
     assert await _entities(binary_sensor.async_setup_entry, hass, entry)
     assert await _entities(button.async_setup_entry, hass, entry) == []
     assert await _entities(number.async_setup_entry, hass, entry) == []
-    assert await _entities(select.async_setup_entry, hass, entry) == []
+    swing_entities = await _entities(select.async_setup_entry, hass, entry)
+    assert [entity.entity_registry_enabled_default for entity in swing_entities] == [False, False, False]
     assert await _entities(switch.async_setup_entry, hass, entry) == []
 
     platform_device._firmware_update_check_enabled = False

--- a/tests/unit/test_translation_keys.py
+++ b/tests/unit/test_translation_keys.py
@@ -1,0 +1,31 @@
+"""Guards strings.json against drifting away from the code and from en.json.
+
+strings.json is the source Home Assistant's own tooling reads: hassfest
+validates against it, and new translations are generated from it. Nothing at
+runtime reads it - the UI is served from translations/, so a key that is
+missing here still renders correctly and the gap stays invisible until someone
+adds a language.
+"""
+
+import json
+from pathlib import Path
+
+COMPONENT = Path("custom_components/mitsubishi_wf_rac")
+STRINGS = json.loads((COMPONENT / "strings.json").read_text(encoding="utf-8"))
+ENGLISH = json.loads((COMPONENT / "translations/en.json").read_text(encoding="utf-8"))
+
+
+def test_entity_keys_match_english_translation():
+    """Both files carry the same English text, so they must carry the same keys."""
+    for domain, entries in ENGLISH["entity"].items():
+        assert set(STRINGS["entity"].get(domain, {})) == set(entries), domain
+
+
+def test_step_data_keys_match_english_translation():
+    for section in ("config", "options"):
+        for step, body in ENGLISH[section]["step"].items():
+            expected = set(body.get("data", {}))
+            actual = set(STRINGS[section]["step"].get(step, {}).get("data", {}))
+            assert actual == expected, f"{section}.{step}"
+
+

--- a/tests/unit/test_translation_keys.py
+++ b/tests/unit/test_translation_keys.py
@@ -10,7 +10,9 @@ adds a language.
 import json
 from pathlib import Path
 
-COMPONENT = Path("custom_components/mitsubishi_wf_rac")
+import custom_components.mitsubishi_wf_rac as component
+
+COMPONENT = Path(component.__file__).parent
 STRINGS = json.loads((COMPONENT / "strings.json").read_text(encoding="utf-8"))
 ENGLISH = json.loads((COMPONENT / "translations/en.json").read_text(encoding="utf-8"))
 

--- a/tests/unit/test_translation_keys.py
+++ b/tests/unit/test_translation_keys.py
@@ -29,3 +29,23 @@ def test_step_data_keys_match_english_translation():
             assert actual == expected, f"{section}.{step}"
 
 
+def test_setup_and_options_steps_have_distinct_titles():
+    """The options form grew out of a copy of the setup step and kept its
+    heading while the fields diverged - it now holds offsets and polling
+    behaviour, none of which is connection info.
+    """
+    setup = STRINGS["config"]["step"]["user"]["title"]
+    options = STRINGS["options"]["step"]["init"]["title"]
+    assert setup != options
+
+
+def test_per_mode_offsets_explain_that_blank_means_the_general_offset():
+    """These two fields carry no default on purpose: blank resolves to the
+    general target offset (see climate.py). Without a description the form
+    gives the user no way to know that.
+    """
+    described = STRINGS["options"]["step"]["init"]["data_description"]
+    assert "target_offset_cool" in described
+    assert "target_offset_heat" in described
+
+


### PR DESCRIPTION
The swing/fan selects duplicate what the climate entity already exposes as `swing_mode`, `swing_horizontal_mode` and `fan_mode` — they use literally the same option lists. That made them a reasonable thing to opt out of, but the opt-out was built as "don't create the entities", which destroys `entity_id`, friendly name and every dashboard/automation reference when it flips.

It was also close to invisible: the field only appeared in the manual setup step, so anyone who added their unit through discovery never saw it, and since it lives in `entry.data` it could not be changed afterwards by anyone.

So the option goes away, the same way the service-data option did in #274, and visibility moves to the entity registry where it is lossless.

### Always register the selects

`CONF_CREATE_SWING_MODE_SELECT` is gone from the setup form, the README and all seven translation files. The key is still read from `entry.data` for one purpose only: an installation that declined the selects during setup gets them as *disabled* entities rather than suddenly gaining three enabled ones. `Device.create_swing_mode_select` is renamed to `swing_selects_enabled_default` to say what it now means.

### Carry every translatable key in `strings.json`

`strings.json` is what hassfest validates and what new translations are generated from, but nothing reads it at runtime — so it had drifted badly without any symptom: **10 of 48 entity keys**, with `climate`, `select`, `number`, `binary_sensor` and `button` empty altogether, and 5 of 8 option fields. It now mirrors `translations/en.json`, and three tests keep the two in step.

### Give the options form its own title

Both the setup step and the options form were titled "WF-RAC AC connection info". It fits the setup step; the options form has since grown offsets, a retry limit and the firmware check, none of which is connection info.

`target_offset_cool` and `target_offset_heat` also get a `data_description`. These two deliberately carry no default — blank means "use the general target offset", and the form gave no hint of that. English only for now; the other six languages follow with the new sensor names.

### Note

`tests/` gains 5 tests (261 total, coverage stays at 95%). This renames a `Device` constructor argument, so #280 will need a one-line rebase if this lands first.