### PR TITLE
Fill missing translations for raw sensors and target offset options

### DIFF
--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -45,7 +45,11 @@
           "target_offset_cool": "Zieltemperatur-Offset (Kühlen)",
           "target_offset_heat": "Zieltemperatur-Offset (Heizen)"
         },
-        "title": "WF-RAC Optionen"
+        "title": "WF-RAC Optionen",
+        "data_description": {
+          "target_offset_cool": "Leer lassen, um den allgemeinen Zieltemperatur-Offset zu verwenden.",
+          "target_offset_heat": "Leer lassen, um den allgemeinen Zieltemperatur-Offset zu verwenden."
+        }
       }
     }
   },
@@ -222,11 +226,20 @@
       "compressor_frequency": {
         "name": "Kompressorfrequenz"
       },
+      "compressor_frequency_raw": {
+        "name": "Kompressorfrequenz (roh)"
+      },
       "operating_current": {
         "name": "Betriebsstrom"
       },
+      "operating_current_raw": {
+        "name": "Betriebsstrom (roh)"
+      },
       "hot_gas_temp": {
         "name": "Heißgastemperatur"
+      },
+      "hot_gas_temp_raw": {
+        "name": "Heißgastemperatur (roh)"
       },
       "eev_pulses": {
         "name": "EEV-Pulse"
@@ -239,6 +252,21 @@
       },
       "indoor_coil_outlet_temp": {
         "name": "Innen-Wärmetauscher Austritt Temperatur"
+      },
+      "indoor_coil_raw": {
+        "name": "Innen-Wärmetauscher Temperatur (roh)"
+      },
+      "indoor_coil_outlet_raw": {
+        "name": "Innen-Wärmetauscher Austritt Temperatur (roh)"
+      },
+      "outdoor_coil_raw": {
+        "name": "Außen-Wärmetauscher Temperatur (roh)"
+      },
+      "discharge_superheat_raw": {
+        "name": "Druckgas-Überhitzung (roh)"
+      },
+      "protection_raw": {
+        "name": "Schutznummer (roh)"
       }
     },
     "binary_sensor": {
@@ -252,7 +280,6 @@
         "name": "Kompressoranforderung"
       }
     },
-    "switch": {},
     "update": {
       "firmware_update": {
         "name": "Firmware-Update"
@@ -262,6 +289,7 @@
       "reset_energy_total": {
         "name": "Energieverbrauch gesamt zurücksetzen"
       }
-    }
+    },
+    "switch": {}
   }
 }

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -227,19 +227,19 @@
         "name": "Kompressorfrequenz"
       },
       "compressor_frequency_raw": {
-        "name": "Kompressorfrequenz (roh)"
+        "name": "Kompressorfrequenz (Rohwert)"
       },
       "operating_current": {
         "name": "Betriebsstrom"
       },
       "operating_current_raw": {
-        "name": "Betriebsstrom (roh)"
+        "name": "Betriebsstrom (Rohwert)"
       },
       "hot_gas_temp": {
         "name": "Heißgastemperatur"
       },
       "hot_gas_temp_raw": {
-        "name": "Heißgastemperatur (roh)"
+        "name": "Heißgastemperatur (Rohwert)"
       },
       "eev_pulses": {
         "name": "EEV-Pulse"
@@ -254,19 +254,19 @@
         "name": "Innen-Wärmetauscher Austritt Temperatur"
       },
       "indoor_coil_raw": {
-        "name": "Innen-Wärmetauscher Temperatur (roh)"
+        "name": "Innen-Wärmetauscher Temperatur (Rohwert)"
       },
       "indoor_coil_outlet_raw": {
-        "name": "Innen-Wärmetauscher Austritt Temperatur (roh)"
+        "name": "Innen-Wärmetauscher Austritt Temperatur (Rohwert)"
       },
       "outdoor_coil_raw": {
-        "name": "Außen-Wärmetauscher Temperatur (roh)"
+        "name": "Außen-Wärmetauscher Temperatur (Rohwert)"
       },
       "discharge_superheat_raw": {
-        "name": "Druckgas-Überhitzung (roh)"
+        "name": "Druckgas-Überhitzung (Rohwert)"
       },
       "protection_raw": {
-        "name": "Schutznummer (roh)"
+        "name": "Schutznummer (Rohwert)"
       }
     },
     "binary_sensor": {

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -45,7 +45,11 @@
           "target_offset_cool": "設定オフセット（冷房時）",
           "target_offset_heat": "設定オフセット（暖房時）"
         },
-        "title": "WF-RAC の設定"
+        "title": "WF-RAC の設定",
+        "data_description": {
+          "target_offset_cool": "空欄の場合は、共通の設定オフセットが使用されます。",
+          "target_offset_heat": "空欄の場合は、共通の設定オフセットが使用されます。"
+        }
       }
     }
   },
@@ -222,11 +226,20 @@
       "compressor_frequency": {
         "name": "圧縮機周波数"
       },
+      "compressor_frequency_raw": {
+        "name": "圧縮機周波数 (生値)"
+      },
       "operating_current": {
         "name": "運転電流"
       },
+      "operating_current_raw": {
+        "name": "運転電流 (生値)"
+      },
       "hot_gas_temp": {
         "name": "吐出ガス温度"
+      },
+      "hot_gas_temp_raw": {
+        "name": "吐出ガス温度 (生値)"
       },
       "eev_pulses": {
         "name": "電子膨張弁パルス"
@@ -239,6 +252,21 @@
       },
       "indoor_coil_outlet_temp": {
         "name": "室内熱交換器出口温度"
+      },
+      "indoor_coil_raw": {
+        "name": "室内熱交換器温度 (生値)"
+      },
+      "indoor_coil_outlet_raw": {
+        "name": "室内熱交換器出口温度 (生値)"
+      },
+      "outdoor_coil_raw": {
+        "name": "室外熱交換器温度 (生値)"
+      },
+      "discharge_superheat_raw": {
+        "name": "吐出過熱度 (生値)"
+      },
+      "protection_raw": {
+        "name": "保護番号 (生値)"
       }
     },
     "binary_sensor": {

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -45,7 +45,11 @@
           "target_offset_cool": "Tikslinis poslinkis (vėsinimas)",
           "target_offset_heat": "Tikslinis poslinkis (šildymas)"
         },
-        "title": "WF-RAC parinktys"
+        "title": "WF-RAC parinktys",
+        "data_description": {
+          "target_offset_cool": "Palikite tuščią, jei norite naudoti bendrą tikslinės temperatūros poslinkį.",
+          "target_offset_heat": "Palikite tuščią, jei norite naudoti bendrą tikslinės temperatūros poslinkį."
+        }
       }
     }
   },
@@ -222,11 +226,20 @@
       "compressor_frequency": {
         "name": "Kompresoriaus dažnis"
       },
+      "compressor_frequency_raw": {
+        "name": "Kompresoriaus dažnis (neapdorota)"
+      },
       "operating_current": {
         "name": "Darbinė srovė"
       },
+      "operating_current_raw": {
+        "name": "Darbinė srovė (neapdorota)"
+      },
       "hot_gas_temp": {
         "name": "Karštų dujų temperatūra"
+      },
+      "hot_gas_temp_raw": {
+        "name": "Karštų dujų temperatūra (neapdorota)"
       },
       "eev_pulses": {
         "name": "EEV impulsai"
@@ -239,6 +252,21 @@
       },
       "indoor_coil_outlet_temp": {
         "name": "Vidaus šilumokaičio išėjimo temperatūra"
+      },
+      "indoor_coil_raw": {
+        "name": "Vidaus šilumokaičio temperatūra (neapdorota)"
+      },
+      "indoor_coil_outlet_raw": {
+        "name": "Vidaus šilumokaičio išėjimo temperatūra (neapdorota)"
+      },
+      "outdoor_coil_raw": {
+        "name": "Lauko šilumokaičio temperatūra (neapdorota)"
+      },
+      "discharge_superheat_raw": {
+        "name": "Išleidimo dujų perkaitimas (neapdorota)"
+      },
+      "protection_raw": {
+        "name": "Apsaugos numeris (neapdorota)"
       }
     },
     "binary_sensor": {

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -45,7 +45,11 @@
           "target_offset_cool": "Doel offset (Koelen)",
           "target_offset_heat": "Doel offset (Verwarmen)"
         },
-        "title": "WF-RAC opties"
+        "title": "WF-RAC opties",
+        "data_description": {
+          "target_offset_cool": "Laat leeg om de algemene doeltemperatuur-offset te gebruiken.",
+          "target_offset_heat": "Laat leeg om de algemene doeltemperatuur-offset te gebruiken."
+        }
       }
     }
   },
@@ -222,11 +226,20 @@
       "compressor_frequency": {
         "name": "Compressorfrequentie"
       },
+      "compressor_frequency_raw": {
+        "name": "Compressorfrequentie (onbewerkt)"
+      },
       "operating_current": {
         "name": "Bedrijfsstroom"
       },
+      "operating_current_raw": {
+        "name": "Bedrijfsstroom (onbewerkt)"
+      },
       "hot_gas_temp": {
         "name": "Heetgastemperatuur"
+      },
+      "hot_gas_temp_raw": {
+        "name": "Heetgastemperatuur (onbewerkt)"
       },
       "eev_pulses": {
         "name": "EEV-pulsen"
@@ -239,6 +252,21 @@
       },
       "indoor_coil_outlet_temp": {
         "name": "Binnenunit warmtewisselaar uitlaattemperatuur"
+      },
+      "indoor_coil_raw": {
+        "name": "Binnenunit warmtewisselaar temperatuur (onbewerkt)"
+      },
+      "indoor_coil_outlet_raw": {
+        "name": "Binnenunit warmtewisselaar uitlaattemperatuur (onbewerkt)"
+      },
+      "outdoor_coil_raw": {
+        "name": "Buitenunit warmtewisselaar temperatuur (onbewerkt)"
+      },
+      "discharge_superheat_raw": {
+        "name": "Persgas oververhitting (onbewerkt)"
+      },
+      "protection_raw": {
+        "name": "Beveiligingsnummer (onbewerkt)"
       }
     },
     "binary_sensor": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -45,7 +45,11 @@
           "target_offset_cool": "目标偏移（制冷）",
           "target_offset_heat": "目标偏移（制热）"
         },
-        "title": "WF-RAC 选项"
+        "title": "WF-RAC 选项",
+        "data_description": {
+          "target_offset_cool": "留空以使用通用的目标温度偏移。",
+          "target_offset_heat": "留空以使用通用的目标温度偏移。"
+        }
       }
     }
   },
@@ -222,11 +226,20 @@
       "compressor_frequency": {
         "name": "压缩机频率"
       },
+      "compressor_frequency_raw": {
+        "name": "压缩机频率（原始）"
+      },
       "operating_current": {
         "name": "运行电流"
       },
+      "operating_current_raw": {
+        "name": "运行电流（原始）"
+      },
       "hot_gas_temp": {
         "name": "排气温度"
+      },
+      "hot_gas_temp_raw": {
+        "name": "排气温度（原始）"
       },
       "eev_pulses": {
         "name": "电子膨胀阀脉冲"
@@ -239,6 +252,21 @@
       },
       "indoor_coil_outlet_temp": {
         "name": "室内换热器出口温度"
+      },
+      "indoor_coil_raw": {
+        "name": "室内换热器温度（原始）"
+      },
+      "indoor_coil_outlet_raw": {
+        "name": "室内换热器出口温度（原始）"
+      },
+      "outdoor_coil_raw": {
+        "name": "室外换热器温度（原始）"
+      },
+      "discharge_superheat_raw": {
+        "name": "排气过热度（原始）"
+      },
+      "protection_raw": {
+        "name": "保护编号（原始）"
       }
     },
     "binary_sensor": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -45,7 +45,11 @@
           "target_offset_cool": "目標偏移（製冷）",
           "target_offset_heat": "目標偏移（製熱）"
         },
-        "title": "WF-RAC 選項"
+        "title": "WF-RAC 選項",
+        "data_description": {
+          "target_offset_cool": "留空以使用通用的目標溫度偏移。",
+          "target_offset_heat": "留空以使用通用的目標溫度偏移。"
+        }
       }
     }
   },
@@ -222,11 +226,20 @@
       "compressor_frequency": {
         "name": "壓縮機頻率"
       },
+      "compressor_frequency_raw": {
+        "name": "壓縮機頻率（原始）"
+      },
       "operating_current": {
         "name": "運轉電流"
       },
+      "operating_current_raw": {
+        "name": "運轉電流（原始）"
+      },
       "hot_gas_temp": {
         "name": "排氣溫度"
+      },
+      "hot_gas_temp_raw": {
+        "name": "排氣溫度（原始）"
       },
       "eev_pulses": {
         "name": "電子膨脹閥脈衝"
@@ -239,6 +252,21 @@
       },
       "indoor_coil_outlet_temp": {
         "name": "室內熱交換器出口溫度"
+      },
+      "indoor_coil_raw": {
+        "name": "室內熱交換器溫度（原始）"
+      },
+      "indoor_coil_outlet_raw": {
+        "name": "室內熱交換器出口溫度（原始）"
+      },
+      "outdoor_coil_raw": {
+        "name": "室外熱交換器溫度（原始）"
+      },
+      "discharge_superheat_raw": {
+        "name": "排氣過熱度（原始）"
+      },
+      "protection_raw": {
+        "name": "保護編號（原始）"
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
## Summary
- de/ja/lt/nl/zh-Hans/zh-Hant were missing 10 keys each, falling back to English: the 8 raw-value sensors (Compressor Frequency/Operating Current/Hot Gas Temp/Indoor+Outdoor Coil/Discharge Superheat/Protection Number, all "(raw)") and the `target_offset_cool`/`_heat` option descriptions added in #279.
- Filled using existing sibling terms already translated in each file for consistency (e.g. the non-raw `Compressor Frequency`/`Hot Gas Temperature` entries), own phrasing for terms without a sibling.

## Test plan
- [x] `pytest tests/unit/test_translation_keys.py` passes (no missing/extra keys per language)
- [x] Full `pytest tests/` passes (262 tests)