### PR TITLE
Clarify ledStat: the unit's LED-ON toggle, not a Wi-Fi status flag

### DIFF
--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -96,9 +96,10 @@ async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_e
         DiagnosticsSensor(device, "Error", CONF_ERROR, True),
         DiagnosticsSensor(device, "Updated By", ATTR_UPDATED_BY, True),
         DiagnosticsSensor(device, "Account Expires", ATTR_ACCOUNT_EXPIRES),
-        # Off until it is understood: reads a constant 1 on both test units
-        # regardless of what the machine is doing, so it does not currently
-        # track the unit's LED.
+        # Off by default: mirrors the unit's own "LED ON" display-light
+        # setting (see wf-rac-module-reference.md §2.8), which nobody has
+        # switched off on either test unit - a constant 1 is the default,
+        # not a broken read.
         DiagnosticsSensor(device, "LED Status", ATTR_LED_STATUS),
         DiagnosticsSensor(device, "Auto Heating", ATTR_AUTO_HEATING, True),
         DiagnosticsSensor(device, "Model Nr", ATTR_MODEL_NR),

--- a/docs/wf-rac-module-reference.md
+++ b/docs/wf-rac-module-reference.md
@@ -215,7 +215,11 @@ The `WCBN4612L` module image contains exactly these JSON key strings and no
 others `[FW]`. **This is closed for that branch only.** The `WF-RAC` and
 `WF-RAC-HTTPS` images are encrypted and could not be inventoried — and a live
 `WF-RAC-HTTPS 025` device returns two fields that are *not* in this list,
-`ledStat` (integer) and `mcu` (object, `{"firmVer": "200"}`) `[HW]`. Expect
+`ledStat` (integer) and `mcu` (object, `{"firmVer": "200"}`) `[HW]`.
+`ledStat` is the unit's own "LED ON" display-light toggle from the app's
+Option Settings screen (`OptionSettingViewModel.java`, gated by the
+`led_light` capability), not a Wi-Fi module status flag — a constant `1`
+just means the setting has never been switched off `[APP]`. Expect
 per-branch additions:
 
 `command`, `apiVer`, `operatorId`, `deviceId`, `timestamp`, `contents`,


### PR DESCRIPTION
## Summary
- `ledStat` reads a constant `1` on both test units, which the existing `sensor.py` comment read as "not tracking the unit's LED" and left the entity off by default pending investigation.
- Traced it through the decompiled app: `OptionSettingViewModel.java` exposes it as the "LED ON" display-light toggle on the Option Settings screen, gated by the `led_light` capability (`WifiInterfaceUseCase.java` confirms it's an AC-side setting, unrelated to Wi-Fi module state).
- A constant `1` is just the untouched default — nobody has switched it off on either test unit. Not a broken read.

## Test plan
- [x] `pytest tests/` passes (262 tests) — comment/doc only, no behavior change