### PR TITLE
Make the integration pass mypy --strict, wire it into CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,3 +40,16 @@ jobs:
         run: pip install -r requirements-dev.txt
       - name: Run tests
         run: pytest
+
+  mypy:
+    name: Mypy
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.14"
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Run mypy
+        run: mypy

--- a/custom_components/mitsubishi_wf_rac/binary_sensor.py
+++ b/custom_components/mitsubishi_wf_rac/binary_sensor.py
@@ -9,6 +9,8 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MitsubishiWfRacConfigEntry
 from .entity import WfRacEntity
@@ -20,7 +22,11 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 1
 
 
-async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MitsubishiWfRacConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Setup binary sensor entries"""
 
     device: Device = entry.runtime_data.device

--- a/custom_components/mitsubishi_wf_rac/button.py
+++ b/custom_components/mitsubishi_wf_rac/button.py
@@ -6,7 +6,9 @@ import logging
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MitsubishiWfRacConfigEntry
 from .entity import WfRacEntity
@@ -17,7 +19,11 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 1
 
 
-async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MitsubishiWfRacConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Setup button entries"""
 
     device: Device = entry.runtime_data.device

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -8,14 +8,21 @@ from . import MitsubishiWfRacConfigEntry
 import voluptuous as vol
 
 from homeassistant.components.climate import ClimateEntity
-from homeassistant.components.climate.const import HVACMode, HVACAction, FAN_AUTO
+from homeassistant.components.climate.const import (
+    ClimateEntityFeature,
+    HVACMode,
+    HVACAction,
+    FAN_AUTO,
+)
 from homeassistant.const import UnitOfTemperature, ATTR_TEMPERATURE
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import WfRacEntity
 from .wfrac.device import Device
-from .wfrac.models.aircon import AirconCommands, HomeLeaveModeSetting
+from .wfrac.models.aircon import Aircon, AirconCommands, HomeLeaveModeSetting
 from .const import (
     DOMAIN,
     FAN_MODE_TRANSLATION,
@@ -41,7 +48,11 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 1
 
 
-async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MitsubishiWfRacConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Setup climate entities"""
     device: Device = entry.runtime_data.device
     _LOGGER.info("Setup climate for: %s, %s", device.device_name, device.airco_id)
@@ -94,7 +105,7 @@ async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_e
 class AircoClimate(WfRacEntity, ClimateEntity):
     """Representation of a climate entity"""
 
-    _attr_supported_features: int = SUPPORT_FLAGS
+    _attr_supported_features: ClimateEntityFeature = SUPPORT_FLAGS
     _attr_temperature_unit: str = UnitOfTemperature.CELSIUS
     _attr_hvac_modes: list[HVACMode] = SUPPORTED_HVAC_MODES
     _attr_fan_modes: list[str] = SUPPORTED_FAN_MODES
@@ -154,7 +165,7 @@ class AircoClimate(WfRacEntity, ClimateEntity):
     def max_temp(self) -> float:
         return self._max_temp_for_mode(self._attr_hvac_mode)
 
-    async def async_set_temperature(self, **kwargs) -> None:
+    async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         set_temp = kwargs.get(ATTR_TEMPERATURE)
         if set_temp is None:
@@ -185,7 +196,7 @@ class AircoClimate(WfRacEntity, ClimateEntity):
         target_temp = set_temp - target_offset
         target_temp = max(min_temp, min(max_temp, target_temp))
 
-        opts: dict[str, Any] = {AirconCommands.PresetTemp: target_temp}
+        opts: dict[AirconCommands, Any] = {AirconCommands.PresetTemp: target_temp}
 
         if "hvac_mode" in kwargs:
             opts.update(
@@ -297,7 +308,7 @@ class AircoClimate(WfRacEntity, ClimateEntity):
         airco = self._device.airco
 
         # Apply indoor offset
-        indoor_offset = self._device.config_entry.options.get(CONF_INDOOR_OFFSET, 0.0)
+        indoor_offset = self._device.options.get(CONF_INDOOR_OFFSET, 0.0)
         # Both the displayed hvac_mode and the target_offset resolution need
         # the underlying cool/heat mode, so it's computed once here and shared
         # between them.
@@ -345,7 +356,7 @@ class AircoClimate(WfRacEntity, ClimateEntity):
             # Determine hvac_action based on operation mode and state
             self._attr_hvac_action = self._determine_hvac_action(airco)
 
-    def _determine_hvac_action(self, airco) -> HVACAction:
+    def _determine_hvac_action(self, airco: Aircon) -> HVACAction:
         """Determine the current HVAC action from operation mode and state.
 
         CoolHotJudge (content[8] & 8) reflects what the unit's own AUTO logic

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from functools import partial
 from typing import Any
 from uuid import uuid4
@@ -45,7 +46,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 5
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
-    _discovery_info = {}
+    _discovery_info: dict[str, Any] = {}
     DOMAIN = DOMAIN
 
     def is_matching(self, other_flow: "WfRacConfigFlow") -> bool:
@@ -56,14 +57,18 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # For flows without unique IDs, consider them non-matching
         return False
 
-    def _find_entry_matching(self, key, matches):
+    def _find_entry_matching(
+        self, key: str, matches: Callable[[Any], bool]
+    ) -> config_entries.ConfigEntry | None:
         """Returns the first entry where matches(entry.data[key]) returns True"""
         for entry in self._async_current_entries():
             if key in entry.data and matches(entry.data[key]):
                 return entry
         return None
 
-    def _find_entry_matching_option(self, key, matches):
+    def _find_entry_matching_option(
+        self, key: str, matches: Callable[[Any], bool]
+    ) -> config_entries.ConfigEntry | None:
         """Returns the first entry where matches(entry.options[key]) returns True"""
         for entry in self._async_current_entries():
             if key in entry.options and matches(entry.options[key]):
@@ -71,7 +76,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return None
 
     async def _async_register_airco(
-            self, hass: HomeAssistant, data: dict
+            self, hass: HomeAssistant, data: dict[str, Any]
     ) -> dict[str, Any]:
         """Validate the user input allows us to connect, and register with the airco device"""
         if len(data[CONF_HOST]) < 3:
@@ -99,11 +104,11 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             airco_id = await repository.get_airco_id()
         except (AirconApiError, KeyError, TypeError) as query_failed:
-            raise CannotConnect(reason=str(query_failed)) from query_failed  # type: ignore
+            raise CannotConnect(reason=str(query_failed)) from query_failed
 
         data[CONF_AIRCO_ID] = airco_id
         if not airco_id:
-            raise CannotConnect(reason="unknown reason")  # type: ignore
+            raise CannotConnect(reason="unknown reason")
 
         _LOGGER.info(
             "Trying to register OperatorId[%s] on Airco[%s]",
@@ -118,18 +123,18 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return data
 
-    async def _async_fetch_operator_id(self):
+    async def _async_fetch_operator_id(self) -> str:
         """Fetch UUID operator id if exists otherwise create it"""
         entry = self._find_entry_matching(CONF_OPERATOR_ID, bool)
         if entry:
-            return entry.data[CONF_OPERATOR_ID]
+            return str(entry.data[CONF_OPERATOR_ID])
         return f"hassio-{str(uuid4())[7:]}"
 
-    async def _async_fetch_device_id(self):
+    async def _async_fetch_device_id(self) -> str:
         """Fetch unique device id if exists otherwise create it"""
         entry = self._find_entry_matching(CONF_DEVICE_ID, bool)
         if entry:
-            return entry.data[CONF_DEVICE_ID]
+            return str(entry.data[CONF_DEVICE_ID])
         return f"homeassistant-device-{uuid4().hex[21:]}"
 
     async def _async_create_common(
@@ -138,9 +143,9 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema: vol.Schema,
             user_input: dict[str, Any] | None = None,
             description_placeholders: dict[str, str] | None = None,
-    ):
+    ) -> ConfigFlowResult:
         """Create a new entry"""
-        errors = {}
+        errors: dict[str, str] = {}
         description_placeholders = description_placeholders or {}
 
         if user_input:
@@ -192,7 +197,12 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     @staticmethod
-    def _field(user_input, name, which, default=None):
+    def _field(
+        user_input: dict[str, Any] | None,
+        name: str,
+        which: Callable[..., Any],
+        default: Any = None,
+    ) -> Any:
         """Helper for creating schema fields"""
         value = user_input.get(name, default) if user_input else default
         description = None
@@ -200,7 +210,9 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             description = {"suggested_value": value}
         return which(name, description=description)
 
-    async def async_step_discovery_confirm(self, user_input=None):
+    async def async_step_discovery_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle adding device discovered by zeroconf."""
 
         description_placeholders = {
@@ -237,7 +249,9 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Create the options flow."""
         return WfRacOptionsFlowHandler()
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle adding device manually."""
 
         field = partial(self._field, user_input)
@@ -288,7 +302,8 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @property
     def _name(self) -> str | None:
-        return self.context.get(CONF_NAME)
+        name = self.context.get(CONF_NAME)
+        return name if isinstance(name, str) else None
 
 
 class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
@@ -296,7 +311,7 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(
             self, user_input: dict[str, Any] | None = None
-    ):
+    ) -> ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
@@ -308,10 +323,10 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
         # fallback-to-target_offset resolution in climate.py. suggested_value
         # (not default=) pre-fills the displayed value without forcing one
         # when absent.
-        per_mode_offset_fields = {
+        per_mode_offset_fields: dict[Any, Any] = {
             vol.Optional(
                 key,
-                description={"suggested_value": self.config_entry.options.get(key)},  # type: ignore
+                description={"suggested_value": self.config_entry.options.get(key)},
             ): vol.Any(None, offset_range_validator)
             for key in (CONF_TARGET_OFFSET_COOL, CONF_TARGET_OFFSET_HEAT)
         }
@@ -322,32 +337,32 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Required(
                         CONF_HOST,
-                        default=self.config_entry.options.get(CONF_HOST),  # type: ignore
+                        default=self.config_entry.options.get(CONF_HOST),
                     ): str,
                     # Floor, not a free number: values below the minimum were
                     # the reason this option kept needing correcting in
                     # migrations. Raising it stays available for weak links.
                     vol.Required(
                         CONF_AVAILABILITY_RETRY_LIMIT,
-                        default=self.config_entry.options.get(  # type: ignore
+                        default=self.config_entry.options.get(
                             CONF_AVAILABILITY_RETRY_LIMIT, AVAILABILITY_FAILURE_LIMIT_MIN
                         ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=AVAILABILITY_FAILURE_LIMIT_MIN)),
                     vol.Required(
                         CONF_FIRMWARE_UPDATE_CHECK,
-                        default=self.config_entry.options.get(CONF_FIRMWARE_UPDATE_CHECK, False),  # type: ignore
+                        default=self.config_entry.options.get(CONF_FIRMWARE_UPDATE_CHECK, False),
                     ): bool,
                     vol.Optional(
                         CONF_INDOOR_OFFSET,
-                        default=self.config_entry.options.get(CONF_INDOOR_OFFSET, 0.0), # type: ignore
+                        default=self.config_entry.options.get(CONF_INDOOR_OFFSET, 0.0),
                     ): vol.All(vol.Coerce(float), vol.Range(min=-15.0, max=15.0)),
                     vol.Optional(
                         CONF_OUTDOOR_OFFSET,
-                        default=self.config_entry.options.get(CONF_OUTDOOR_OFFSET, 0.0), # type: ignore
+                        default=self.config_entry.options.get(CONF_OUTDOOR_OFFSET, 0.0),
                     ): vol.All(vol.Coerce(float), vol.Range(min=-15.0, max=15.0)),
                     vol.Optional(
                         CONF_TARGET_OFFSET,
-                        default=self.config_entry.options.get(CONF_TARGET_OFFSET, 0.0), # type: ignore
+                        default=self.config_entry.options.get(CONF_TARGET_OFFSET, 0.0),
                     ): offset_range_validator,
                     **per_mode_offset_fields,
                 },
@@ -371,11 +386,13 @@ class KnownError(exceptions.HomeAssistantError):
     error_name = "unknown_error"
     applies_to_field = CONF_BASE
 
-    def __init__(self, *args: object, **kwargs: dict[str, str]) -> None:
+    def __init__(self, *args: object, **kwargs: str) -> None:
         super().__init__(*args)
         self._extra_info = kwargs
 
-    def get_errors_and_placeholders(self, schema):
+    def get_errors_and_placeholders(
+        self, schema: Any
+    ) -> tuple[dict[str, str], dict[str, str]]:
         """Return dicts of errors and description_placeholders, for adding to async_show_form"""
         key = self.applies_to_field
         # Errors will only be displayed to the user if the key is actually in the form (or

--- a/custom_components/mitsubishi_wf_rac/entity.py
+++ b/custom_components/mitsubishi_wf_rac/entity.py
@@ -57,7 +57,7 @@ class WfRacEntity(CoordinatorEntity[Device]):
         resolve a different offset for the same mode (see beta2: that
         divergence is what caused the target_temperature re-send loop).
         """
-        options = self._device.config_entry.options
+        options = self._device.options
         base_offset = options.get(CONF_TARGET_OFFSET, 0.0)
         if hvac_mode in (HVACMode.COOL, HVACMode.DRY):
             override = options.get(CONF_TARGET_OFFSET_COOL)
@@ -65,7 +65,7 @@ class WfRacEntity(CoordinatorEntity[Device]):
             override = options.get(CONF_TARGET_OFFSET_HEAT)
         else:
             override = None
-        return base_offset if override is None else override
+        return float(base_offset if override is None else override)
 
     @property
     def available(self) -> bool:
@@ -75,6 +75,12 @@ class WfRacEntity(CoordinatorEntity[Device]):
         # coordinator successful on purpose, so this is the only thing that
         # decides whether entities go unavailable.
         return self._device.available
+
+    def _update_state(self) -> None:
+        """Refresh entity state from the coordinator. Every concrete
+        subclass overrides this; never invoked through this base
+        implementation."""
+        raise NotImplementedError
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/mitsubishi_wf_rac/number.py
+++ b/custom_components/mitsubishi_wf_rac/number.py
@@ -7,7 +7,9 @@ import logging
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MitsubishiWfRacConfigEntry
 from .entity import WfRacEntity
@@ -25,7 +27,11 @@ HOME_LEAVE_TEMP_MAX = 50.0
 HOME_LEAVE_TEMP_STEP = 0.5
 
 
-async def async_setup_entry(_hass, entry: MitsubishiWfRacConfigEntry, async_add_entities):
+async def async_setup_entry(
+    _hass: HomeAssistant,
+    entry: MitsubishiWfRacConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Setup number entries"""
 
     device: Device = entry.runtime_data.device
@@ -109,10 +115,20 @@ class HomeLeaveModeNumber(WfRacEntity, NumberEntity):
                 "entity's 'Request Home Leave Mode status' action once "
                 "first, the unit doesn't include them in a plain poll."
             )
-        if self._mode == "cooling":
-            cooling = replace(cooling, **{self._attribute: value})
+        # Named kwargs rather than replace(setting, **{self._attribute: value}):
+        # HomeLeaveModeSetting also has an AirFlow: int field, so a dynamic
+        # **{str: float} unpacking can't statically prove it only ever
+        # touches the two float fields this class is instantiated for.
+        if self._attribute == "TempRule":
+            if self._mode == "cooling":
+                cooling = replace(cooling, TempRule=value)
+            else:
+                heating = replace(heating, TempRule=value)
         else:
-            heating = replace(heating, **{self._attribute: value})
+            if self._mode == "cooling":
+                cooling = replace(cooling, TempSetting=value)
+            else:
+                heating = replace(heating, TempSetting=value)
         await self._device.async_set_home_leave_mode(cooling, heating)
         self._attr_native_value = value
         self.async_write_ha_state()

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -7,10 +7,12 @@ from dataclasses import replace
 from . import MitsubishiWfRacConfigEntry
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import WfRacEntity
-from .wfrac.models.aircon import AirconCommands
+from .wfrac.models.aircon import AirconCommands, HomeLeaveModeSetting
 from .wfrac.device import Device
 from .const import (
     DOMAIN,
@@ -50,7 +52,11 @@ HOME_LEAVE_MODE_AWAY_HEAT = "away_heat"
 HOME_LEAVE_AIRFLOW_OPTIONS = ["auto", "1", "2", "3", "4"]
 
 
-async def async_setup_entry(_hass, entry: MitsubishiWfRacConfigEntry, async_add_entities):
+async def async_setup_entry(
+    _hass: HomeAssistant,
+    entry: MitsubishiWfRacConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Setup select entries"""
 
     device: Device = entry.runtime_data.device
@@ -311,7 +317,7 @@ class HomeLeaveAirFlowSelect(WfRacEntity, SelectEntity):
         )
         self._update_state()
 
-    def _current_setting(self):
+    def _current_setting(self) -> HomeLeaveModeSetting | None:
         return (
             self._device.airco.HomeLeaveModeForCooling
             if self._mode == "cooling"

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 from dataclasses import dataclass
+from decimal import Decimal
 import logging
 from typing import Any, Self
 
@@ -15,9 +16,11 @@ from homeassistant.components.sensor import (
     SensorExtraStoredData,
 )
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.const import (
     PERCENTAGE,
     UnitOfElectricCurrent,
@@ -73,7 +76,11 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 1
 
 
-async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MitsubishiWfRacConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Setup sensor entries"""
 
     device: Device = entry.runtime_data.device
@@ -139,7 +146,7 @@ async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_e
     )
 
 
-async def _async_set_energy_total(entity: SensorEntity, call) -> None:
+async def _async_set_energy_total(entity: SensorEntity, call: ServiceCall) -> None:
     """Entity-service handler for SERVICE_SET_ENERGY_TOTAL.
 
     Registered as a callable rather than a method name so targeting any other
@@ -153,7 +160,7 @@ async def _async_set_energy_total(entity: SensorEntity, call) -> None:
     await entity.async_set_total(call.data["value"])
 
 
-def _async_remove_home_leave_mode_sensors(hass, device: Device) -> None:
+def _async_remove_home_leave_mode_sensors(hass: HomeAssistant, device: Device) -> None:
     """Drop the former Home Leave Mode diagnostic sensors from the entity
     registry.
 
@@ -181,7 +188,7 @@ class DiagnosticsSensor(WfRacEntity, SensorEntity):
     _attr_has_entity_name: bool = True
 
     def __init__(
-        self, device: Device, name: str, custom_type: str, enable=False
+        self, device: Device, name: str, custom_type: str, enable: bool = False
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device)
@@ -253,7 +260,7 @@ class TemperatureSensor(WfRacEntity, SensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_has_entity_name: bool = True
 
-    def __init__(self, device: Device, name: str, custom_type: str, enable=True) -> None:
+    def __init__(self, device: Device, name: str, custom_type: str, enable: bool = True) -> None:
         """Initialize the sensor."""
         super().__init__(device)
         self._custom_type = custom_type
@@ -272,10 +279,10 @@ class TemperatureSensor(WfRacEntity, SensorEntity):
 
     def _update_state(self) -> None:
         if self._custom_type == ATTR_INSIDE_TEMPERATURE:
-            indoor_offset = self._device.config_entry.options.get(CONF_INDOOR_OFFSET, 0.0)
+            indoor_offset = self._device.options.get(CONF_INDOOR_OFFSET, 0.0)
             self._attr_native_value = self._device.airco.IndoorTemp + indoor_offset
         elif self._custom_type == ATTR_OUTSIDE_TEMPERATURE:
-            outdoor_offset = self._device.config_entry.options.get(CONF_OUTDOOR_OFFSET, 0.0)
+            outdoor_offset = self._device.options.get(CONF_OUTDOOR_OFFSET, 0.0)
             self._attr_native_value = self._device.airco.OutdoorTemp + outdoor_offset
         elif self._custom_type == ATTR_TARGET_TEMPERATURE:
             # Kept symmetric with climate.py's target_temperature by going
@@ -290,8 +297,8 @@ class EnergySensor(WfRacEntity, SensorEntity):
 
     _attr_translation_key = "energy_usage"
     _attr_native_unit_of_measurement: str | None = UnitOfEnergy.KILO_WATT_HOUR
-    _attr_device_class: SensorDeviceClass | str | None = SensorDeviceClass.ENERGY
-    _attr_state_class: SensorStateClass | str | None = SensorStateClass.TOTAL_INCREASING
+    _attr_device_class: SensorDeviceClass | None = SensorDeviceClass.ENERGY
+    _attr_state_class: SensorStateClass | None = SensorStateClass.TOTAL_INCREASING
     _attr_has_entity_name: bool = True
 
     def __init__(self, device: Device) -> None:
@@ -345,8 +352,8 @@ class EnergyTotalSensor(WfRacEntity, RestoreSensor):
 
     _attr_translation_key = "energy_usage_total"
     _attr_native_unit_of_measurement: str | None = UnitOfEnergy.KILO_WATT_HOUR
-    _attr_device_class: SensorDeviceClass | str | None = SensorDeviceClass.ENERGY
-    _attr_state_class: SensorStateClass | str | None = SensorStateClass.TOTAL_INCREASING
+    _attr_device_class: SensorDeviceClass | None = SensorDeviceClass.ENERGY
+    _attr_state_class: SensorStateClass | None = SensorStateClass.TOTAL_INCREASING
     _attr_has_entity_name: bool = True
     _attr_suggested_display_precision: int | None = 2
 
@@ -371,7 +378,13 @@ class EnergyTotalSensor(WfRacEntity, RestoreSensor):
 
         if (stored := await self.async_get_last_extra_data()) is not None:
             restored = EnergyTotalExtraStoredData.from_dict(stored.as_dict())
-            if restored is not None and restored.native_value is not None:
+            # native_value's declared type also allows date/datetime, which
+            # this sensor never stores but float() can't convert - restrict
+            # to what a restored total can actually be instead of crashing
+            # async_added_to_hass() on an unexpected stored type.
+            if restored is not None and isinstance(
+                restored.native_value, (int, float, str, Decimal)
+            ):
                 self._total = float(restored.native_value)
                 self._last_raw = restored.last_raw
                 self._attr_native_value = round(self._total, 2)

--- a/custom_components/mitsubishi_wf_rac/switch.py
+++ b/custom_components/mitsubishi_wf_rac/switch.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MitsubishiWfRacConfigEntry
 from .wfrac.device import Device
@@ -15,7 +17,11 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 1
 
 
-async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MitsubishiWfRacConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Setup switch entries"""
 
     device: Device = entry.runtime_data.device
@@ -28,7 +34,7 @@ async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_e
     async_add_entities(entities)
 
 
-def _async_remove_home_leave_mode_switch(hass, device: Device) -> None:
+def _async_remove_home_leave_mode_switch(hass: HomeAssistant, device: Device) -> None:
     """Drop the former Home Leave Mode switch from the entity registry.
 
     That switch only ever faked Home Leave mode by pushing the heat target
@@ -46,7 +52,7 @@ def _async_remove_home_leave_mode_switch(hass, device: Device) -> None:
         registry.async_remove(entity_id)
 
 
-def _async_remove_self_clean_switch(hass, device: Device) -> None:
+def _async_remove_self_clean_switch(hass: HomeAssistant, device: Device) -> None:
     """Drop the former Self Clean switch from the entity registry.
 
     The unit's real self-clean cycle can only be started locally via the IR

--- a/custom_components/mitsubishi_wf_rac/update.py
+++ b/custom_components/mitsubishi_wf_rac/update.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.update import UpdateDeviceClass, UpdateEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MitsubishiWfRacConfigEntry
 from .entity import WfRacEntity
@@ -15,7 +17,11 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 1
 
 
-async def async_setup_entry(hass, entry: MitsubishiWfRacConfigEntry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MitsubishiWfRacConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Setup update entries"""
 
     device: Device = entry.runtime_data.device

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -134,7 +135,7 @@ POLL_TIMEOUT = 2 * REQUEST_TIMEOUT + MIN_TIME_BETWEEN_REQUESTS + timedelta(secon
 AVAILABILITY_FAILURE_LIMIT_MIN = 3
 
 
-class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attributes
+class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instance-attributes
     """Device Class"""
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -182,7 +183,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         self._last_service_data_request: datetime | None = None
         self._last_service_data_response: datetime | None = None
         self._service_data_expired = False
-        self._service_data_task: asyncio.Task | None = None
+        self._service_data_task: asyncio.Task[None] | None = None
         self._consecutive_failures = 0
         # Clamped rather than validated: an entry can carry a lower value from
         # an older version, and refusing to set up over it would be worse than
@@ -196,8 +197,8 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         # snapshot that's stale because another set_airco() is still in
         # flight - see set_airco() below.
         self._send_lock = asyncio.Lock()
-        self._consolidated_params: dict[str, Any] = {}
-        self._consolidation_task: asyncio.Task | None = None
+        self._consolidated_params: dict[AirconCommands, Any] = {}
+        self._consolidation_task: asyncio.Task[None] | None = None
 
         super().__init__(
             hass,
@@ -206,6 +207,17 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             name=name,
             update_interval=MIN_TIME_BETWEEN_UPDATES,
         )
+
+    @property
+    def options(self) -> Mapping[str, Any]:
+        """Options of the config entry that owns this device.
+
+        DataUpdateCoordinator.config_entry is typed as optional because a
+        coordinator need not have one - this integration always constructs a
+        Device with one, passed to super().__init__() above.
+        """
+        assert self.config_entry is not None
+        return self.config_entry.options
 
     async def update(self) -> bool:
         """Update the device information from API.
@@ -310,12 +322,18 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         ):
             return
         self._last_firmware_check = now
-        self._hass.async_create_task(self._async_check_firmware_update())
+        self._hass.async_create_task(
+            self._async_check_firmware_update(
+                self._firm_type, self._wireless_firmware_ver
+            )
+        )
 
-    async def _async_check_firmware_update(self) -> None:
+    async def _async_check_firmware_update(
+        self, firm_type: str, wireless_firmware_ver: str
+    ) -> None:
         """Compare the locally-reported wireless firmware version against the
         manufacturer's latest for this firmType."""
-        latest = await fetch_latest_firmware(self._hass, self._firm_type)
+        latest = await fetch_latest_firmware(self._hass, firm_type)
         if latest is None or latest.get("wireless") is None:
             return
 
@@ -324,11 +342,11 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             # firmVer <= its current one as "nothing to do" and returns 200 OK
             # without flashing - a `!=` check would misreport that harmless
             # case as an available downgrade.
-            update_available = int(latest["wireless"]) > int(self._wireless_firmware_ver)
+            update_available = int(latest["wireless"]) > int(wireless_firmware_ver)
         except (TypeError, ValueError):
             _LOGGER.debug(
                 "Could not compare firmware versions: local=%r latest=%r",
-                self._wireless_firmware_ver,
+                wireless_firmware_ver,
                 latest["wireless"],
             )
             return
@@ -472,7 +490,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             SERVICE_DATA_MAX_AGE.total_seconds(),
         )
 
-    async def delete_account(self):
+    async def delete_account(self) -> dict[str, Any] | None:
         """Delete account (operator id) from the airco"""
         try:
             return await self._api.del_account_info(self._airco_id)
@@ -480,7 +498,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             _LOGGER.warning("Could not delete account from airco %s", self._airco_id)
             return None
 
-    async def add_account(self):
+    async def add_account(self) -> dict[str, Any] | None:
         """Add account (operator id) from the airco"""
         try:
             return await self._api.update_account_info(
@@ -491,7 +509,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
             return None
 
     async def set_airco(
-        self, params: dict[str, Any], *, log_failure: bool = True
+        self, params: dict[AirconCommands, Any], *, log_failure: bool = True
     ) -> None:
         """Method to send airco command.
 
@@ -534,7 +552,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
                     _LOGGER.warning("Could not send airco data: %s", str(ex))
                 raise
 
-    async def async_queue_command(self, params: dict[str, Any]) -> None:
+    async def async_queue_command(self, params: dict[AirconCommands, Any]) -> None:
         """Queue an airco command, coalescing with any other calls made within
         UPDATE_CONSOLIDATION_PERIOD into a single set_airco() call. Used by all
         entities instead of calling set_airco() directly, so that e.g. a fan
@@ -675,7 +693,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
                 "Could not reach the airco [%s]: %s", self.device_name, error
             )
 
-    def set_available(self, available: bool):
+    def set_available(self, available: bool) -> None:
         """Set available status"""
         self._set_availability(available)
 
@@ -787,7 +805,7 @@ class Device(DataUpdateCoordinator):  # pylint: disable=too-many-instance-attrib
         """Return the discovered/persisted communication method (http/https), if known."""
         return self._api.method
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> Aircon:
         """Update data via library.
 
         A missed poll is not an update failure. These modules restart their

--- a/custom_components/mitsubishi_wf_rac/wfrac/repository.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/repository.py
@@ -10,7 +10,7 @@ import os
 import ssl
 import time
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, cast
 
 import aiohttp
 from aiohttp import ClientConnectionError
@@ -208,7 +208,7 @@ class Repository:
                         raise AirconCommandError(
                             f"Aircon returned HTTP {resp.status} for {command!r}: {body}"
                         )
-                    return json.loads(body)
+                    return cast(dict[str, Any], json.loads(body))
             except (ClientConnectionError, asyncio.TimeoutError) as ex:
                 raise AirconConnectionError(f"Aircon returned error: {ex}") from ex
 
@@ -253,7 +253,7 @@ class Repository:
             # If we haven't yet determined if https is required, find out
             else:
                 _LOGGER.debug("No stored method; attempting discovery...")
-                methods = (
+                methods: tuple[str, ...] = (
                     (self._preferred_method,)
                     if self._preferred_method in ("http", "https")
                     else ()
@@ -311,6 +311,8 @@ class Repository:
         would otherwise fill the log with a message the user has already read.
         """
         raw = response.get("result")
+        if raw is None:
+            return
         try:
             code = int(raw)
         except (TypeError, ValueError):
@@ -330,13 +332,15 @@ class Repository:
             RESULT_CODES.get(code, "meaning unknown"),
         )
 
-    async def get_info(self) -> dict:
+    async def get_info(self) -> dict[str, Any]:
         """Simple command to get aircon details"""
-        return (await self._post("getDeviceInfo"))["contents"]
+        response = await self._post("getDeviceInfo")
+        return cast(dict[str, Any], response["contents"])
 
     async def get_airco_id(self) -> str:
         """Simple command to get aircon ID"""
-        return (await self.get_info())["airconId"]
+        info = await self.get_info()
+        return cast(str, info["airconId"])
 
     async def update_account_info(
         self, airco_id: str, time_zone: str
@@ -350,12 +354,14 @@ class Repository:
         }
         return await self._post("updateAccountInfo", contents)
 
-    async def del_account_info(self, airco_id: str) -> dict:
+    async def del_account_info(self, airco_id: str) -> dict[str, Any]:
         """delete the account info on the airco"""
         contents = {"accountId": self._operator_id, "airconId": airco_id}
         return await self._post("deleteAccountInfo", contents)
 
-    async def get_aircon_stats(self, airco_id: str | None = None, raw=False) -> dict:
+    async def get_aircon_stats(
+        self, airco_id: str | None = None, raw: bool = False
+    ) -> dict[str, Any]:
         """Get the Aricon Stats from the Airco
 
         Sends the airconId in the request body. The official Smart M-Air app and
@@ -369,10 +375,10 @@ class Repository:
         """
         contents = {"airconId": airco_id} if airco_id is not None else None
         result = await self._post("getAirconStat", contents)
-        return result if raw else result["contents"]
+        return result if raw else cast(dict[str, Any], result["contents"])
 
     async def send_airco_command(self, airco_id: str, command: str) -> str:
         """send command to the Airco"""
         contents = {"airconId": airco_id, "airconStat": command}
         result = await self._post("setAirconStat", contents)
-        return result["contents"]["airconStat"]
+        return cast(str, result["contents"]["airconStat"])

--- a/custom_components/mitsubishi_wf_rac/wfrac/utils.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/utils.py
@@ -1,7 +1,7 @@
 """Module that contains Utils that are used in codebase"""
 
 
-def find_match(content, *inputMatrix):
+def find_match(content: int, *inputMatrix: int) -> int:
     """Simple method for finding a match from inputMatrix"""
     i = 0
     for value in inputMatrix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[tool.mypy]
+# Scoped to the integration itself, not tests/ - the Quality Scale's
+# strict-typing rule is about the shipped code. Homeassistant, voluptuous and
+# aiohttp all resolve cleanly here, so nothing needs ignore_missing_imports.
+files = ["custom_components/mitsubishi_wf_rac"]
+strict = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@
 # pulls a much more current homeassistant pin.
 homeassistant>=2025.12.0
 pytest-homeassistant-custom-component
+mypy


### PR DESCRIPTION
## Summary
- Closes the Platinum Quality Scale `strict-typing` gap: `py.typed` has existed since #270, but nothing ever ran mypy against the code - it had 99 `--strict` errors.
- Mechanical: annotate every `async_setup_entry(hass, entry, async_add_entities)`, a handful of other untyped helpers, and parameterize `Device(DataUpdateCoordinator[Aircon])` instead of leaving it bare (which cascaded into false `arg-type` errors elsewhere in `device.py`).
- A few of the errors were real bugs mypy caught, not just missing annotations:
  - `number.py`'s dynamic `replace(setting, **{self._attribute: value})` couldn't be proven safe against `HomeLeaveModeSetting`'s `int` `AirFlow` field - split into explicit `TempRule`/`TempSetting` branches.
  - `EnergyTotalSensor.async_added_to_hass()` called `float()` on a restored value whose declared type also allows `date`/`datetime`; a stored value of that shape would have crashed restore. Now checked with `isinstance` first.
  - `Device._async_check_firmware_update()` re-read `self._firm_type`/`self._wireless_firmware_ver` instead of the values its caller had already null-checked - passed as arguments instead.
  - `repository.py`'s `_report_result_code()` called `int()` on a value that could be `None` before the `try`/`except` got a chance to catch it.
- Added a `Device.options` property (`self.config_entry.options`, narrowed past `DataUpdateCoordinator`'s `Optional` typing) instead of exposing `config_entry` itself - it's a writable attribute on the base class, so overriding it as a read-only property doesn't type-check.
- `mypy` is now a CI job (`validate.yml`) and configured in `pyproject.toml`, scoped to `custom_components/mitsubishi_wf_rac`. homeassistant, voluptuous and aiohttp all resolve cleanly here, no `ignore_missing_imports` needed.

## Test plan
- [x] `pytest` - 262 passed, coverage unchanged at 95%
- [x] `mypy` - 0 errors across 23 source files (was 99)