### PR TITLE
Add a reconfigure flow for the connection details

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,13 @@ These duplicate the climate entity's swing/fan attributes as standalone entities
 
 ## Options
 
-Configurable via the integration's "Configure" (options) flow.
+Configurable via the integration's "Configure" (options) flow. The host/IP
+address itself isn't here - it's connection-critical, so changing it goes
+through "Reconfigure" instead, which re-validates the new address against the
+device before saving it.
 
 | Option | Range | Description |
 |---|---|---|
-| Host (IP) address | IP or hostname | Address of the WF-RAC module. |
 | Retry limit | 3 or higher, default 3 | Consecutive failed polls before the device is marked unavailable. At the 60 s poll interval, `3` is about 3 minutes - enough to ride through the module's hourly WiFi reassociation. Raise it on a weak link; it cannot be set lower. |
 | Indoor Temp. Sensor Offset | -15..15 °C | Added to the unit's own indoor-sensor reading before it's shown as `current_temperature` / the Indoor Temperature sensor - display-only, doesn't change what the unit does. |
 | Outdoor Temp. Sensor Offset | -15..15 °C | Same, for the Outdoor Temperature sensor. |

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -76,7 +76,10 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return None
 
     async def _async_register_airco(
-            self, hass: HomeAssistant, data: dict[str, Any]
+            self,
+            hass: HomeAssistant,
+            data: dict[str, Any],
+            exclude_entry_id: str | None = None,
     ) -> dict[str, Any]:
         """Validate the user input allows us to connect, and register with the airco device"""
         if len(data[CONF_HOST]) < 3:
@@ -86,11 +89,13 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             raise InvalidName
 
         if not data.get(CONF_FORCE_UPDATE):
-            # Is this hostname or IP address already configured?
+            # Is this hostname or IP address already configured on a *different*
+            # entry? During reconfigure, the entry being edited already owns
+            # this host among its own options, so it must not flag itself.
             existing_entry = self._find_entry_matching_option(
                 CONF_HOST, lambda h: h == data[CONF_HOST]
             )
-            if existing_entry:
+            if existing_entry and existing_entry.entry_id != exclude_entry_id:
                 raise HostAlreadyConfigured(error_name=existing_entry.data[CONF_NAME])
 
         repository = Repository(
@@ -268,6 +273,68 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=data_schema, user_input=user_input
         )
 
+    async def async_step_reconfigure(
+            self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle changing an existing entry's connection details (host/port/name)."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        current = {
+            CONF_NAME: reconfigure_entry.data[CONF_NAME],
+            CONF_HOST: reconfigure_entry.options[CONF_HOST],
+            CONF_PORT: reconfigure_entry.data[CONF_PORT],
+        }
+
+        field = partial(self._field, user_input or current)
+        data_schema = vol.Schema(
+            {
+                field(CONF_NAME, vol.Required): cv.string,
+                field(CONF_HOST, vol.Required): cv.string,
+                field(CONF_PORT, vol.Optional, 51443): cv.port,
+            }
+        )
+
+        errors: dict[str, str] = {}
+        description_placeholders: dict[str, str] = {}
+
+        if user_input:
+            try:
+                data = dict(user_input)
+                data[CONF_OPERATOR_ID] = reconfigure_entry.data[CONF_OPERATOR_ID]
+                data[CONF_DEVICE_ID] = reconfigure_entry.data[CONF_DEVICE_ID]
+
+                info = await self._async_register_airco(
+                    self.hass, data, exclude_entry_id=reconfigure_entry.entry_id
+                )
+
+                new_data = {**reconfigure_entry.data, **data}
+                new_options = {**reconfigure_entry.options, CONF_HOST: new_data.pop(CONF_HOST)}
+
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    title=info[CONF_NAME],
+                    data=new_data,
+                    options=new_options,
+                )
+            except KnownError as error:
+                errors, placeholders = error.get_errors_and_placeholders(
+                    data_schema.schema
+                )
+                description_placeholders.update(
+                    {k: str(v) for k, v in placeholders.items()}
+                )
+            except Exception:  # pylint: disable=broad-except
+                # Same outermost boundary as _async_create_common: a bug here
+                # should surface as "unexpected_error", not crash the flow.
+                _LOGGER.error("Unexpected exception", exc_info=True)
+                errors[CONF_BASE] = "unexpected_error"
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=data_schema,
+            errors=errors,
+            description_placeholders=description_placeholders,
+        )
+
     async def async_step_zeroconf(
             self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -314,7 +381,12 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
     ) -> ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            # Host moved to the reconfigure flow (validated against the
+            # device) - keep the entry's existing value, since this form no
+            # longer collects it and async_create_entry replaces options
+            # wholesale rather than merging.
+            data = {**user_input, CONF_HOST: self.config_entry.options[CONF_HOST]}
+            return self.async_create_entry(title="", data=data)
 
         offset_range_validator = vol.All(vol.Coerce(float), vol.Range(min=-5.0, max=5.0))
         # target_offset_cool/heat are optional per-mode overrides that must
@@ -335,10 +407,6 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Required(
-                        CONF_HOST,
-                        default=self.config_entry.options.get(CONF_HOST),
-                    ): str,
                     # Floor, not a free number: values below the minimum were
                     # the reason this option kept needing correcting in
                     # migrations. Raising it stays available for weak links.

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -17,6 +17,15 @@
         "data": {
           "name": "[%key:common::config_flow::data::name%]"
         }
+      },
+      "reconfigure": {
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "description": "Update the connection details for this Airco.",
+        "title": "Reconfigure WF-RAC AC connection"
       }
     },
     "error": {
@@ -28,7 +37,8 @@
     },
     "abort": {
       "existing_instance_updated": "Updated existing configuration.",
-      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
   "options": {
@@ -36,7 +46,6 @@
       "init": {
         "description": "Below are the options you can change for this airco.",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
           "availability_retry_limit": "Retry limit (minimum 3)",
           "firmware_update_check": "Firmware Update Check (Online)",
           "indoor_offset": "Indoor Temp. Sensor Offset",

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -9,7 +9,8 @@
     },
     "abort": {
       "existing_instance_updated": "Vorhandene Konfiguration aktualisiert.",
-      "already_configured": "Klima ist bereits konfiguriert"
+      "already_configured": "Klima ist bereits konfiguriert",
+      "reconfigure_successful": "Neukonfiguration erfolgreich"
     },
     "step": {
       "user": {
@@ -28,6 +29,15 @@
         "data": {
           "name": "Klima Name"
         }
+      },
+      "reconfigure": {
+        "data": {
+          "name": "Klima Name",
+          "host": "Host (IP) Adresse",
+          "port": "Port"
+        },
+        "description": "Aktualisieren Sie die Verbindungsdaten für diese Klimaanlage.",
+        "title": "WF-RAC-Verbindung neu konfigurieren"
       }
     }
   },
@@ -59,7 +69,6 @@
       "init": {
         "description": "Nachfolgend finden Sie die Optionen, die Sie für diese Klimaanlage ändern können.",
         "data": {
-          "host": "Host (IP) Adresse",
           "availability_retry_limit": "max. Anzahl Wiederholungen (mind. 3)",
           "firmware_update_check": "Firmware-Update-Prüfung (Online)",
           "indoor_offset": "Innentemperatur Sensor-Offset",

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -9,7 +9,8 @@
     },
     "abort": {
       "existing_instance_updated": "Updated existing configuration.",
-      "already_configured": "Airco is already configured"
+      "already_configured": "Airco is already configured",
+      "reconfigure_successful": "Re-configuration was successful"
     },
     "step": {
       "user": {
@@ -28,6 +29,15 @@
         "data": {
           "name": "Airco Name"
         }
+      },
+      "reconfigure": {
+        "data": {
+          "name": "Airco Name",
+          "host": "Host (IP) address",
+          "port": "Port"
+        },
+        "description": "Update the connection details for this Airco.",
+        "title": "Reconfigure WF-RAC AC connection"
       }
     }
   },
@@ -59,7 +69,6 @@
       "init": {
         "description": "Below are the options you can change for this airco.",
         "data": {
-          "host": "Host (IP) address",
           "availability_retry_limit": "Retry limit (minimum 3)",
           "firmware_update_check": "Firmware Update Check (Online)",
           "indoor_offset": "Indoor Temp. Sensor Offset",

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -9,7 +9,8 @@
     },
     "abort": {
       "existing_instance_updated": "既存の設定が更新されました。",
-      "already_configured": "エアコンは既に設定されています。"
+      "already_configured": "エアコンは既に設定されています。",
+      "reconfigure_successful": "再設定が完了しました"
     },
     "step": {
       "user": {
@@ -28,6 +29,15 @@
         "data": {
           "name": "エアコン名"
         }
+      },
+      "reconfigure": {
+        "data": {
+          "name": "エアコン名",
+          "host": "ホスト（IP）アドレス",
+          "port": "ポート"
+        },
+        "description": "このエアコンの接続情報を更新してください。",
+        "title": "WF-RACエアコン接続の再設定"
       }
     }
   },
@@ -59,7 +69,6 @@
       "init": {
         "description": "以下は、このエアコンの変更可能なオプションです。",
         "data": {
-          "host": "ホスト（IP）アドレス",
           "availability_retry_limit": "リトライ回数の上限（最小 3）",
           "firmware_update_check": "ファームウェア更新の確認 (オンライン)",
           "indoor_offset": "室内オフセット",

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -9,7 +9,8 @@
     },
     "abort": {
       "existing_instance_updated": "Esami nustatymai atnaujinti.",
-      "already_configured": "Kondicionierius jau nustatytas"
+      "already_configured": "Kondicionierius jau nustatytas",
+      "reconfigure_successful": "Perkonfigūravimas sėkmingas"
     },
     "step": {
       "user": {
@@ -28,6 +29,15 @@
         "data": {
           "name": "Kondicionieriaus pavadinimas"
         }
+      },
+      "reconfigure": {
+        "data": {
+          "name": "Kondicionieriaus pavadinimas",
+          "host": "Host (IP) adresas",
+          "port": "Portas"
+        },
+        "description": "Atnaujinkite šio kondicionieriaus prisijungimo duomenis.",
+        "title": "Iš naujo konfigūruoti WF-RAC AC ryšį"
       }
     }
   },
@@ -59,7 +69,6 @@
       "init": {
         "description": "Žemiau pateikiamos parinktys, kurias galite keisti šiam oro kondicionieriui.",
         "data": {
-          "host": "Host (IP) adresas",
           "availability_retry_limit": "Pakartotinio bandymo limitas (min. 3)",
           "firmware_update_check": "Programinės įrangos atnaujinimų tikrinimas (internetu)",
           "indoor_offset": "Vidaus poslinkis",

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -9,7 +9,8 @@
     },
     "abort": {
       "existing_instance_updated": "Huidige configuratie is geüpdatet.",
-      "already_configured": "Airco is al geconfigureerd"
+      "already_configured": "Airco is al geconfigureerd",
+      "reconfigure_successful": "Herconfiguratie geslaagd"
     },
     "step": {
       "user": {
@@ -28,6 +29,15 @@
         "data": {
           "name": "Airco naam"
         }
+      },
+      "reconfigure": {
+        "data": {
+          "name": "Airco Naam",
+          "host": "Host (IP) adres",
+          "port": "Poort"
+        },
+        "description": "Werk de verbindingsgegevens voor deze airco bij.",
+        "title": "WF-RAC AC verbinding herconfigureren"
       }
     }
   },
@@ -59,7 +69,6 @@
       "init": {
         "description": "Hieronder zijn instellingen die je kan aanpassen voor deze airco.",
         "data": {
-          "host": "Host (IP) adres",
           "availability_retry_limit": "Herhaal limiet (minimaal 3)",
           "firmware_update_check": "Firmware-updatecontrole (online)",
           "indoor_offset": "Binnen offset",

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -9,7 +9,8 @@
     },
     "abort": {
       "existing_instance_updated": "已更新现有配置。",
-      "already_configured": "空调已配置"
+      "already_configured": "空调已配置",
+      "reconfigure_successful": "重新配置成功"
     },
     "step": {
       "user": {
@@ -28,6 +29,15 @@
         "data": {
           "name": "空调名称"
         }
+      },
+      "reconfigure": {
+        "data": {
+          "name": "空调名称",
+          "host": "主机（IP）地址",
+          "port": "端口"
+        },
+        "description": "更新此空调的连接信息。",
+        "title": "重新配置 WF-RAC 空调连接"
       }
     }
   },
@@ -59,7 +69,6 @@
       "init": {
         "description": "以下是你可以为此空调更改的选项。",
         "data": {
-          "host": "主机（IP）地址",
           "availability_retry_limit": "重试次数上限（最少 3）",
           "firmware_update_check": "固件更新检查（在线）",
           "indoor_offset": "室内偏移",

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -9,7 +9,8 @@
     },
     "abort": {
       "existing_instance_updated": "已更新現有配置。",
-      "already_configured": "空調已配置"
+      "already_configured": "空調已配置",
+      "reconfigure_successful": "重新配置成功"
     },
     "step": {
       "user": {
@@ -28,6 +29,15 @@
         "data": {
           "name": "空調名稱"
         }
+      },
+      "reconfigure": {
+        "data": {
+          "name": "空調名稱",
+          "host": "主機（IP）地址",
+          "port": "埠號"
+        },
+        "description": "更新此空調的連接資訊。",
+        "title": "重新配置 WF-RAC 空調連接"
       }
     }
   },
@@ -59,7 +69,6 @@
       "init": {
         "description": "以下是你可以為此空調更改的選項。",
         "data": {
-          "host": "主機（IP）地址",
           "availability_retry_limit": "重試次數上限（最少 3）",
           "firmware_update_check": "韌體更新檢查（線上）",
           "indoor_offset": "室內偏移",

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -256,6 +256,117 @@ async def test_user_flow_reuses_operator_and_device_id_from_existing_entry(hass:
     assert result["data"][CONF_DEVICE_ID] == "shared-device-id"
 
 
+# --- reconfigure flow ---------------------------------------------------
+
+
+def _existing_entry(
+    hass: HomeAssistant, name="Living Room AC", host="192.168.1.50", port=51443
+):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": name,
+            "port": port,
+            CONF_AIRCO_ID: "airco-1",
+            CONF_OPERATOR_ID: "operator-1",
+            CONF_DEVICE_ID: "device-1",
+        },
+        options={"host": host, CONF_FIRMWARE_UPDATE_CHECK: False},
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_reconfigure_flow_shows_form_with_current_values(hass: HomeAssistant):
+    entry = _existing_entry(hass, name="Living Room AC", host="192.168.1.50", port=51443)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    suggested = {
+        key.schema: key.description["suggested_value"] for key in result["data_schema"].schema
+    }
+    assert suggested == {"name": "Living Room AC", "host": "192.168.1.50", "port": 51443}
+
+
+async def test_reconfigure_flow_updates_host_and_reloads(hass: HomeAssistant):
+    entry = _existing_entry(hass, host="192.168.1.50")
+
+    repo = _mock_repository(airco_id="airco-1")
+    with _patch_repository(repo):
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"name": "Living Room AC", "host": "192.168.1.60", "port": 51443},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.options["host"] == "192.168.1.60"
+    # Everything not touched by the form survives the update.
+    assert entry.data[CONF_OPERATOR_ID] == "operator-1"
+    assert entry.data[CONF_DEVICE_ID] == "device-1"
+    assert entry.options[CONF_FIRMWARE_UPDATE_CHECK] is False
+
+
+async def test_reconfigure_flow_allows_resubmitting_the_same_host(hass: HomeAssistant):
+    # The entry being reconfigured already "owns" this host among its own
+    # options - the duplicate-host check must exclude it, not just every
+    # *other* entry, or every reconfigure with an unchanged host would fail.
+    entry = _existing_entry(hass, host="192.168.1.50")
+
+    repo = _mock_repository(airco_id="airco-1")
+    with _patch_repository(repo):
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"name": "Living Room AC", "host": "192.168.1.50", "port": 51443},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+
+async def test_reconfigure_flow_rejects_another_entrys_host(hass: HomeAssistant):
+    MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Bedroom AC"},
+        options={"host": "192.168.1.99"},
+    ).add_to_hass(hass)
+    entry = _existing_entry(hass, host="192.168.1.50")
+
+    repo = _mock_repository()
+    with _patch_repository(repo):
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"name": "Living Room AC", "host": "192.168.1.99", "port": 51443},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"host": "host_already_configured"}
+    assert entry.options["host"] == "192.168.1.50"
+
+
+async def test_reconfigure_flow_cannot_connect_shows_error(hass: HomeAssistant):
+    entry = _existing_entry(hass, host="192.168.1.50")
+
+    repo = _mock_repository()
+    repo.get_airco_id.side_effect = AirconApiError("timeout")
+    with _patch_repository(repo):
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"name": "Living Room AC", "host": "192.168.1.60", "port": 51443},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+    assert entry.options["host"] == "192.168.1.50"
+
+
 # --- zeroconf discovery -------------------------------------------------
 
 
@@ -341,7 +452,6 @@ async def test_options_flow_saves_submitted_values(hass: HomeAssistant):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {
-            "host": "192.168.1.50",
             CONF_INDOOR_OFFSET: 1.0,
             CONF_OUTDOOR_OFFSET: -1.0,
             CONF_TARGET_OFFSET: 0.5,
@@ -350,6 +460,9 @@ async def test_options_flow_saves_submitted_values(hass: HomeAssistant):
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_TARGET_OFFSET] == 0.5
+    # host isn't a form field anymore (moved to the reconfigure flow), but
+    # the entry's existing value must survive an options save regardless.
+    assert result["data"]["host"] == "192.168.1.50"
 
 
 @pytest.mark.parametrize(
@@ -380,7 +493,7 @@ async def test_options_flow_enforces_offset_range(hass: HomeAssistant, key, valu
     schema = result["data_schema"]
 
     with pytest.raises(vol.MultipleInvalid):
-        schema({"host": "192.168.1.50", key: value})
+        schema({key: value})
 
 
 async def test_options_flow_rejects_a_retry_limit_below_the_floor(hass: HomeAssistant):
@@ -399,9 +512,9 @@ async def test_options_flow_rejects_a_retry_limit_below_the_floor(hass: HomeAssi
     schema = result["data_schema"]
 
     with pytest.raises(vol.MultipleInvalid):
-        schema({"host": "192.168.1.50", CONF_AVAILABILITY_RETRY_LIMIT: 1})
+        schema({CONF_AVAILABILITY_RETRY_LIMIT: 1})
 
-    assert schema({"host": "192.168.1.50", CONF_AVAILABILITY_RETRY_LIMIT: 5})[
+    assert schema({CONF_AVAILABILITY_RETRY_LIMIT: 5})[
         CONF_AVAILABILITY_RETRY_LIMIT
     ] == 5
 
@@ -422,7 +535,7 @@ async def test_options_flow_defaults_firmware_update_check_to_off(hass: HomeAssi
     result = await hass.config_entries.options.async_init(entry.entry_id)
     schema = result["data_schema"]
 
-    validated = schema({"host": "192.168.1.50"})
+    validated = schema({})
     assert validated[CONF_FIRMWARE_UPDATE_CHECK] is False
 
 
@@ -438,7 +551,6 @@ async def test_options_flow_saves_submitted_firmware_update_check(hass: HomeAssi
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {
-            "host": "192.168.1.50",
             CONF_FIRMWARE_UPDATE_CHECK: True,
         },
     )
@@ -459,7 +571,6 @@ async def test_options_flow_saves_submitted_per_mode_offsets(hass: HomeAssistant
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {
-            "host": "192.168.1.50",
             CONF_TARGET_OFFSET: 0.5,
             CONF_TARGET_OFFSET_COOL: 1.5,
             CONF_TARGET_OFFSET_HEAT: -1.5,
@@ -488,7 +599,6 @@ async def test_options_flow_leaves_per_mode_offsets_unset_when_omitted(hass: Hom
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {
-            "host": "192.168.1.50",
             CONF_TARGET_OFFSET: 0.5,
         },
     )


### PR DESCRIPTION
Adds `async_step_reconfigure`, closing the `reconfiguration-flow` gap on the [quality scale](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/reconfiguration-flow/) standortbestimmung.

- Host/port/name can now be changed via "Reconfigure" without removing and re-adding the integration, reusing the same registration/validation path as the user and discovery flows.
- The duplicate-host check excludes the entry being reconfigured itself, so re-submitting an unchanged host doesn't self-conflict; it still catches pointing at a host another entry already owns.
- Host moves out of the options flow, which previously let it be changed with **zero validation** - a typo or stale IP there just surfaced as retries failing later, with nothing to say why. It's still stored the same way (`entry.options[CONF_HOST]`); the options flow now preserves the existing value on save instead of collecting it.
- README's Options table updated to match, with a pointer to Reconfigure.
- 5 new tests for the reconfigure flow (current-values prefill, successful update, self-host resubmission, another entry's host rejected, connection failure); 6 existing options-flow tests updated for the removed field.

267 tests pass locally (`pytest`).