### PR TITLE
Add translation_domain/key to user-facing exceptions

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_CONNECTION_METHOD,
     CONF_FIRMWARE_UPDATE_CHECK,
     CONF_OPERATOR_ID, CONF_CREATE_SWING_MODE_SELECT,
+    DOMAIN,
 )
 from .wfrac.device import AVAILABILITY_FAILURE_LIMIT_MIN, Device
 
@@ -116,7 +117,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEnt
     # device that's unreachable at startup gets HA's automatic retry-with-backoff
     # rather than a silently "loaded" entry with no working entities.
     if not _device.available:
-        raise ConfigEntryNotReady(f"Could not reach device [{device}]")
+        raise ConfigEntryNotReady(
+            f"Could not reach device [{device}]",
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+            translation_placeholders={"device": device},
+        )
 
     # Persist the discovered connection method (http/https) so we can skip
     # protocol discovery (and its potential extra round-trip) after the next

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -158,7 +158,11 @@ class AircoClimate(WfRacEntity, ClimateEntity):
         """Set new target temperature."""
         set_temp = kwargs.get(ATTR_TEMPERATURE)
         if set_temp is None:
-            raise ValueError("Temperature is required")
+            raise ServiceValidationError(
+                "Temperature is required",
+                translation_domain=DOMAIN,
+                translation_key="temperature_required",
+            )
 
         # If this call also switches hvac_mode, the minimum must reflect the mode
         # being switched to, not the (still stale until the next poll) current one.
@@ -168,10 +172,26 @@ class AircoClimate(WfRacEntity, ClimateEntity):
         max_temp = self._max_temp_for_mode(target_hvac_mode)
 
         if set_temp < min_temp:
-            raise ValueError(f"Temperature {set_temp} is below minimum {min_temp}")
+            raise ServiceValidationError(
+                f"Temperature {set_temp} is below minimum {min_temp}",
+                translation_domain=DOMAIN,
+                translation_key="temperature_below_minimum",
+                translation_placeholders={
+                    "temperature": str(set_temp),
+                    "min_temp": str(min_temp),
+                },
+            )
 
         if set_temp > max_temp:
-            raise ValueError(f"Temperature {set_temp} is above maximum {max_temp}")
+            raise ServiceValidationError(
+                f"Temperature {set_temp} is above maximum {max_temp}",
+                translation_domain=DOMAIN,
+                translation_key="temperature_above_maximum",
+                translation_placeholders={
+                    "temperature": str(set_temp),
+                    "max_temp": str(max_temp),
+                },
+            )
 
         # The AC unit's own thermostat logic uses its own indoor sensor reading,
         # subject to the same calibration bias CONF_INDOOR_OFFSET corrects for
@@ -259,7 +279,9 @@ class AircoClimate(WfRacEntity, ClimateEntity):
     def _require_home_leave_mode_capability(self) -> None:
         if not self._device.airco.Capabilities.home_leave_mode:
             raise ServiceValidationError(
-                "This model does not report the HomeLeaveMode capability"
+                "This model does not report the HomeLeaveMode capability",
+                translation_domain=DOMAIN,
+                translation_key="home_leave_mode_not_supported",
             )
 
     async def async_request_home_leave_mode_status(self) -> None:

--- a/custom_components/mitsubishi_wf_rac/number.py
+++ b/custom_components/mitsubishi_wf_rac/number.py
@@ -107,7 +107,9 @@ class HomeLeaveModeNumber(WfRacEntity, NumberEntity):
             raise HomeAssistantError(
                 "Home Leave Mode values are unknown yet - call the climate "
                 "entity's 'Request Home Leave Mode status' action once "
-                "first, the unit doesn't include them in a plain poll."
+                "first, the unit doesn't include them in a plain poll.",
+                translation_domain=DOMAIN,
+                translation_key="home_leave_mode_status_unknown",
             )
         if self._mode == "cooling":
             cooling = replace(cooling, **{self._attribute: value})

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -332,7 +332,9 @@ class HomeLeaveAirFlowSelect(WfRacEntity, SelectEntity):
             raise HomeAssistantError(
                 "Home Leave Mode values are unknown yet - call the climate "
                 "entity's 'Request Home Leave Mode status' action once "
-                "first, the unit doesn't include them in a plain poll."
+                "first, the unit doesn't include them in a plain poll.",
+                translation_domain=DOMAIN,
+                translation_key="home_leave_mode_status_unknown",
             )
         air_flow = HOME_LEAVE_AIRFLOW_OPTIONS.index(option)
         if self._mode == "cooling":

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -148,7 +148,10 @@ async def _async_set_energy_total(entity: SensorEntity, call) -> None:
     """
     if not isinstance(entity, EnergyTotalSensor):
         raise ServiceValidationError(
-            f"{entity.entity_id} is not an Energy Usage Total sensor"
+            f"{entity.entity_id} is not an Energy Usage Total sensor",
+            translation_domain=DOMAIN,
+            translation_key="entity_not_energy_total_sensor",
+            translation_placeholders={"entity_id": entity.entity_id},
         )
     await entity.async_set_total(call.data["value"])
 

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -53,6 +53,29 @@
       }
     }
   },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "Could not reach the Airco at {device}."
+    },
+    "temperature_required": {
+      "message": "A target temperature is required."
+    },
+    "temperature_below_minimum": {
+      "message": "{temperature} °C is below the {min_temp} °C minimum for this mode."
+    },
+    "temperature_above_maximum": {
+      "message": "{temperature} °C is above the {max_temp} °C maximum for this mode."
+    },
+    "home_leave_mode_not_supported": {
+      "message": "This model does not report the Home Leave Mode capability."
+    },
+    "home_leave_mode_status_unknown": {
+      "message": "Home Leave Mode values are unknown yet. Call the climate entity's \"Request Home Leave Mode status\" action once first - the unit doesn't include them in a plain poll."
+    },
+    "entity_not_energy_total_sensor": {
+      "message": "{entity_id} is not an Energy Usage Total sensor."
+    }
+  },
   "entity": {
     "sensor": {
       "indoor": {

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -31,6 +31,29 @@
       }
     }
   },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "Die Klimaanlage unter {device} war nicht erreichbar."
+    },
+    "temperature_required": {
+      "message": "Eine Zieltemperatur ist erforderlich."
+    },
+    "temperature_below_minimum": {
+      "message": "{temperature} °C liegt unter dem Minimum von {min_temp} °C für diesen Modus."
+    },
+    "temperature_above_maximum": {
+      "message": "{temperature} °C liegt über dem Maximum von {max_temp} °C für diesen Modus."
+    },
+    "home_leave_mode_not_supported": {
+      "message": "Dieses Modell meldet die Home-Leave-Mode-Fähigkeit nicht."
+    },
+    "home_leave_mode_status_unknown": {
+      "message": "Die Home-Leave-Mode-Werte sind noch nicht bekannt. Rufen Sie zuerst einmal die Aktion \"Home-Leave-Mode-Status abfragen\" der Klima-Entität auf - das Gerät liefert diese Werte nicht bei einer normalen Abfrage."
+    },
+    "entity_not_energy_total_sensor": {
+      "message": "{entity_id} ist kein Energieverbrauch-Gesamt-Sensor."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -31,6 +31,29 @@
       }
     }
   },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "Could not reach the Airco at {device}."
+    },
+    "temperature_required": {
+      "message": "A target temperature is required."
+    },
+    "temperature_below_minimum": {
+      "message": "{temperature} °C is below the {min_temp} °C minimum for this mode."
+    },
+    "temperature_above_maximum": {
+      "message": "{temperature} °C is above the {max_temp} °C maximum for this mode."
+    },
+    "home_leave_mode_not_supported": {
+      "message": "This model does not report the Home Leave Mode capability."
+    },
+    "home_leave_mode_status_unknown": {
+      "message": "Home Leave Mode values are unknown yet. Call the climate entity's \"Request Home Leave Mode status\" action once first - the unit doesn't include them in a plain poll."
+    },
+    "entity_not_energy_total_sensor": {
+      "message": "{entity_id} is not an Energy Usage Total sensor."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -31,6 +31,29 @@
       }
     }
   },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "{device} のエアコンに到達できませんでした。"
+    },
+    "temperature_required": {
+      "message": "目標温度を指定してください。"
+    },
+    "temperature_below_minimum": {
+      "message": "{temperature}°Cはこのモードの最低温度{min_temp}°Cを下回っています。"
+    },
+    "temperature_above_maximum": {
+      "message": "{temperature}°Cはこのモードの最高温度{max_temp}°Cを超えています。"
+    },
+    "home_leave_mode_not_supported": {
+      "message": "この機種はHome Leave Mode機能を報告していません。"
+    },
+    "home_leave_mode_status_unknown": {
+      "message": "Home Leave Modeの値はまだ不明です。エアコンエンティティの「Home Leave Modeステータスを要求」アクションを一度実行してください。通常のポーリングにはこの値は含まれません。"
+    },
+    "entity_not_energy_total_sensor": {
+      "message": "{entity_id} は積算電力量センサーではありません。"
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -31,6 +31,29 @@
       }
     }
   },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "Nepavyko pasiekti kondicionieriaus adresu {device}."
+    },
+    "temperature_required": {
+      "message": "Būtina nurodyti norimą temperatūrą."
+    },
+    "temperature_below_minimum": {
+      "message": "{temperature} °C yra žemiau šio režimo minimumo ({min_temp} °C)."
+    },
+    "temperature_above_maximum": {
+      "message": "{temperature} °C yra virš šio režimo maksimumo ({max_temp} °C)."
+    },
+    "home_leave_mode_not_supported": {
+      "message": "Šis modelis nepraneša apie Home Leave Mode galimybę."
+    },
+    "home_leave_mode_status_unknown": {
+      "message": "Home Leave Mode reikšmės dar nežinomos. Pirmiausia kartą iškvieskite kondicionieriaus veiksmą \"Request Home Leave Mode status\" - įprasta apklausa šių reikšmių negrąžina."
+    },
+    "entity_not_energy_total_sensor": {
+      "message": "{entity_id} nėra bendro energijos suvartojimo jutiklis."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -31,6 +31,29 @@
       }
     }
   },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "Kon de airco op {device} niet bereiken."
+    },
+    "temperature_required": {
+      "message": "Een doeltemperatuur is verplicht."
+    },
+    "temperature_below_minimum": {
+      "message": "{temperature} °C is lager dan het minimum van {min_temp} °C voor deze modus."
+    },
+    "temperature_above_maximum": {
+      "message": "{temperature} °C is hoger dan het maximum van {max_temp} °C voor deze modus."
+    },
+    "home_leave_mode_not_supported": {
+      "message": "Dit model rapporteert de Home Leave Mode functie niet."
+    },
+    "home_leave_mode_status_unknown": {
+      "message": "De Home Leave Mode waarden zijn nog niet bekend. Roep eerst één keer de actie \"Home Leave Mode status opvragen\" van de climate-entiteit aan - het apparaat levert deze waarden niet bij een gewone poll."
+    },
+    "entity_not_energy_total_sensor": {
+      "message": "{entity_id} is geen totaal-energieverbruiksensor."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -31,6 +31,29 @@
       }
     }
   },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "无法连接到位于 {device} 的空调。"
+    },
+    "temperature_required": {
+      "message": "需要指定目标温度。"
+    },
+    "temperature_below_minimum": {
+      "message": "{temperature}°C 低于此模式下的最低温度 {min_temp}°C。"
+    },
+    "temperature_above_maximum": {
+      "message": "{temperature}°C 高于此模式下的最高温度 {max_temp}°C。"
+    },
+    "home_leave_mode_not_supported": {
+      "message": "此型号未报告支持离家模式（Home Leave Mode）功能。"
+    },
+    "home_leave_mode_status_unknown": {
+      "message": "离家模式的数值尚未知晓。请先调用一次空调实体的“请求离家模式状态”操作 —— 常规轮询不包含这些数值。"
+    },
+    "entity_not_energy_total_sensor": {
+      "message": "{entity_id} 不是累计用电量传感器。"
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -31,6 +31,29 @@
       }
     }
   },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "無法連接到位於 {device} 的空調。"
+    },
+    "temperature_required": {
+      "message": "需要指定目標溫度。"
+    },
+    "temperature_below_minimum": {
+      "message": "{temperature}°C 低於此模式下的最低溫度 {min_temp}°C。"
+    },
+    "temperature_above_maximum": {
+      "message": "{temperature}°C 高於此模式下的最高溫度 {max_temp}°C。"
+    },
+    "home_leave_mode_not_supported": {
+      "message": "此型號未回報支援離家模式（Home Leave Mode）功能。"
+    },
+    "home_leave_mode_status_unknown": {
+      "message": "離家模式的數值尚未知曉。請先呼叫一次空調實體的「請求離家模式狀態」操作 —— 常規輪詢不包含這些數值。"
+    },
+    "entity_not_energy_total_sensor": {
+      "message": "{entity_id} 不是累計用電量感測器。"
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant.components.climate.const import HVACAction, HVACMode
 from homeassistant.const import EntityCategory
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry, MockEntityPlatform
 
@@ -212,11 +213,11 @@ async def test_climate_commands_and_state_branches(platform_device):
     await entity.async_set_swing_horizontal_mode(horizontal)
     assert platform_device.async_queue_command.await_args.args[0][AirconCommands.Entrust] is False
 
-    with pytest.raises(ValueError, match="required"):
+    with pytest.raises(ServiceValidationError, match="required"):
         await entity.async_set_temperature()
-    with pytest.raises(ValueError, match="below minimum"):
+    with pytest.raises(ServiceValidationError, match="below minimum"):
         await entity.async_set_temperature(temperature=9, hvac_mode=HVACMode.HEAT)
-    with pytest.raises(ValueError, match="above maximum"):
+    with pytest.raises(ServiceValidationError, match="above maximum"):
         await entity.async_set_temperature(temperature=34, hvac_mode=HVACMode.COOL)
 
     platform_device.airco.Operation = True

--- a/tests/unit/test_translation_keys.py
+++ b/tests/unit/test_translation_keys.py
@@ -8,6 +8,7 @@ adds a language.
 """
 
 import json
+import re
 from pathlib import Path
 
 import custom_components.mitsubishi_wf_rac as component
@@ -21,6 +22,25 @@ def test_entity_keys_match_english_translation():
     """Both files carry the same English text, so they must carry the same keys."""
     for domain, entries in ENGLISH["entity"].items():
         assert set(STRINGS["entity"].get(domain, {})) == set(entries), domain
+
+
+def test_exception_keys_match_english_translation():
+    assert set(STRINGS["exceptions"]) == set(ENGLISH["exceptions"])
+
+
+def test_raised_translation_keys_exist_in_strings():
+    """Every `translation_key="..."` passed to a HomeAssistantError subclass
+    must resolve somewhere - a typo here fails silently at runtime (HA falls
+    back to the plain message arg) rather than raising, so nothing else would
+    catch it.
+    """
+    used_keys = set()
+    for path in COMPONENT.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        used_keys.update(re.findall(r'translation_key="([a-z_]+)"', text))
+
+    assert used_keys, "expected to find at least one translation_key in the source"
+    assert used_keys <= set(STRINGS["exceptions"])
 
 
 def test_step_data_keys_match_english_translation():


### PR DESCRIPTION
Closes the `exception-translations` gap on the [quality scale](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/exception-translations/) standortbestimmung.

- `translation_domain`/`translation_key` (+ placeholders) added to every `HomeAssistantError`/`ServiceValidationError`/`ConfigEntryNotReady` raised from entity services and setup, resolved against a new `exceptions` block in `strings.json` and all seven `translations/*.json` files.
- `climate.py`'s temperature-validation checks (required / below minimum / above maximum) move from a bare `ValueError` to `ServiceValidationError` while touching this method anyway - a raw `ValueError` out of an entity service handler wasn't a graceful, translatable failure either, same gap.
- Two new guard tests in `test_translation_keys.py`, matching the existing parity-checking style: `exceptions` keys match between `strings.json` and `translations/en.json`, and every `translation_key` actually raised in the source resolves to a real entry (a typo here would otherwise fail silently at runtime - HA just falls back to the plain message).

264 tests pass locally (`pytest`).