### PR TITLE
Raise a repair issue when the airco's account table stays full

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -6,6 +6,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import issue_registry as ir
 
 from homeassistant.const import (
     CONF_HOST,
@@ -24,7 +25,7 @@ from .const import (
     CONF_OPERATOR_ID, CONF_CREATE_SWING_MODE_SELECT,
     DOMAIN,
 )
-from .wfrac.device import AVAILABILITY_FAILURE_LIMIT_MIN, Device
+from .wfrac.device import AVAILABILITY_FAILURE_LIMIT_MIN, Device, registration_full_issue_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -215,3 +216,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEn
             temp_device.operator_id,
             temp_device.airco_id,
         )
+
+    # Entry-scoped, so it would otherwise dangle in the repair list forever
+    # pointing at an entry_id that no longer resolves to anything.
+    ir.async_delete_issue(hass, DOMAIN, registration_full_issue_id(entry.entry_id))

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -41,6 +41,12 @@
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
+  "issues": {
+    "too_many_devices": {
+      "title": "Too many devices registered on {device_name}",
+      "description": "Home Assistant could not register itself with this Airco because the module's account table is full. Open the Smart M-Air app and remove another registered device, or do a factory reset of the module, then reload this integration."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -64,6 +64,12 @@
       "message": "{entity_id} ist kein Energieverbrauch-Gesamt-Sensor."
     }
   },
+  "issues": {
+    "too_many_devices": {
+      "title": "Zu viele Geräte an {device_name} registriert",
+      "description": "Home Assistant konnte sich bei dieser Klimaanlage nicht registrieren, weil die Konten-Tabelle des Moduls voll ist. Öffnen Sie die Smart-M-Air-App und entfernen Sie ein anderes registriertes Gerät, oder setzen Sie das Modul auf Werkseinstellungen zurück, und laden Sie diese Integration anschließend neu."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -64,6 +64,12 @@
       "message": "{entity_id} is not an Energy Usage Total sensor."
     }
   },
+  "issues": {
+    "too_many_devices": {
+      "title": "Too many devices registered on {device_name}",
+      "description": "Home Assistant could not register itself with this Airco because the module's account table is full. Open the Smart M-Air app and remove another registered device, or do a factory reset of the module, then reload this integration."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -64,6 +64,12 @@
       "message": "{entity_id} は積算電力量センサーではありません。"
     }
   },
+  "issues": {
+    "too_many_devices": {
+      "title": "{device_name} に登録されているデバイスが多すぎます",
+      "description": "モジュールのアカウントテーブルが一杯のため、Home Assistantはこのエアコンに登録できませんでした。Smart M-Airアプリで登録済みの別のデバイスを削除するか、モジュールを工場出荷時設定にリセットしてから、このインテグレーションを再読み込みしてください。"
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -64,6 +64,12 @@
       "message": "{entity_id} nėra bendro energijos suvartojimo jutiklis."
     }
   },
+  "issues": {
+    "too_many_devices": {
+      "title": "Prie {device_name} užregistruota per daug įrenginių",
+      "description": "\"Home Assistant\" negalėjo užsiregistruoti šiame kondicionieriuje, nes modulio paskyrų lentelė pilna. Atidarykite \"Smart M-Air\" programėlę ir pašalinkite kitą užregistruotą įrenginį, arba atstatykite modulį į gamyklinę būseną, tada iš naujo įkelkite šią integraciją."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -64,6 +64,12 @@
       "message": "{entity_id} is geen totaal-energieverbruiksensor."
     }
   },
+  "issues": {
+    "too_many_devices": {
+      "title": "Te veel apparaten geregistreerd op {device_name}",
+      "description": "Home Assistant kon zich niet registreren bij deze airco omdat de accounttabel van de module vol is. Open de Smart M-Air-app en verwijder een ander geregistreerd apparaat, of reset de module naar de fabrieksinstellingen, en herlaad daarna deze integratie."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -64,6 +64,12 @@
       "message": "{entity_id} 不是累计用电量传感器。"
     }
   },
+  "issues": {
+    "too_many_devices": {
+      "title": "{device_name} 上注册的设备过多",
+      "description": "由于模块的账户表已满，Home Assistant 无法在此空调上注册。请在 Smart M-Air 应用中删除另一个已注册的设备，或对模块进行出厂重置，然后重新加载此集成。"
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -64,6 +64,12 @@
       "message": "{entity_id} 不是累計用電量感測器。"
     }
   },
+  "issues": {
+    "too_many_devices": {
+      "title": "{device_name} 上註冊的裝置過多",
+      "description": "由於模組的帳戶表已滿，Home Assistant 無法在此空調上註冊。請在 Smart M-Air 應用程式中刪除另一個已註冊的裝置，或對模組進行出廠重置，然後重新載入此整合。"
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -135,6 +136,16 @@ POLL_TIMEOUT = 2 * REQUEST_TIMEOUT + MIN_TIME_BETWEEN_REQUESTS + timedelta(secon
 AVAILABILITY_FAILURE_LIMIT_MIN = 3
 
 
+def registration_full_issue_id(entry_id: str) -> str:
+    """Repair-issue id for a full account table on this entry's airco.
+
+    Shared between Device (which raises/clears it) and async_unload_entry
+    (which clears it on removal, so a deleted entry doesn't leave a dangling
+    issue behind) - one format, so the two can never drift apart.
+    """
+    return f"too_many_devices_{entry_id}"
+
+
 class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instance-attributes
     """Device Class"""
 
@@ -218,6 +229,12 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         """
         assert self.config_entry is not None
         return self.config_entry.options
+
+    @property
+    def entry_id(self) -> str:
+        """Id of the config entry that owns this device - see options above."""
+        assert self.config_entry is not None
+        return self.config_entry.entry_id
 
     async def update(self) -> bool:
         """Update the device information from API.
@@ -501,12 +518,42 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
     async def add_account(self) -> dict[str, Any] | None:
         """Add account (operator id) from the airco"""
         try:
-            return await self._api.update_account_info(
+            result = await self._api.update_account_info(
                 self._airco_id, self._hass.config.time_zone
             )
         except (AirconApiError, KeyError, TypeError):
             _LOGGER.warning("Could not add account from airco %s", self._airco_id)
             return None
+
+        # result:2 means the airco's fixed-size account table is genuinely
+        # full (see the retry this backs in update() above) - re-registering
+        # cannot succeed on its own until a slot frees up elsewhere (the
+        # official app, or another integration instance), which is nothing
+        # HA can do for the user. That is a standing condition worth a repair
+        # issue rather than a warning that scrolls out of the log every
+        # cycle; a normal-looking response means whatever caused it is gone,
+        # so the issue (if any) clears itself.
+        if result and int(result.get("result", 0)) == 2:
+            self._report_registration_full()
+        else:
+            self._clear_registration_full_issue()
+        return result
+
+    def _report_registration_full(self) -> None:
+        ir.async_create_issue(
+            self._hass,
+            DOMAIN,
+            registration_full_issue_id(self.entry_id),
+            is_fixable=False,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="too_many_devices",
+            translation_placeholders={"device_name": self.device_name},
+        )
+
+    def _clear_registration_full_issue(self) -> None:
+        ir.async_delete_issue(
+            self._hass, DOMAIN, registration_full_issue_id(self.entry_id)
+        )
 
     async def set_airco(
         self, params: dict[AirconCommands, Any], *, log_failure: bool = True

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from homeassistant.helpers import issue_registry as ir
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.mitsubishi_wf_rac.const import DOMAIN
@@ -137,7 +138,7 @@ async def test_update_none_response_marks_unavailable(device):
 
 async def test_update_api_error_marks_unavailable_and_reregisters(device):
     device._api.get_aircon_stats.side_effect = AirconApiError("boom")
-    device._api.update_account_info = AsyncMock()
+    device._api.update_account_info = AsyncMock(return_value={"result": 0})
     assert await device.update() is False
     assert device.available is False
     device._api.update_account_info.assert_awaited_once()
@@ -154,7 +155,7 @@ async def test_update_transient_unreachable_is_debug_only(device, caplog):
     caplog.clear()
 
     device._api.get_aircon_stats.side_effect = AirconConnectionError("no route")
-    device._api.update_account_info = AsyncMock()
+    device._api.update_account_info = AsyncMock(return_value={"result": 0})
     await device.update()
 
     assert device.available is True
@@ -178,7 +179,7 @@ async def test_update_sustained_unreachable_logs_one_transition(device, caplog):
     caplog.clear()
 
     device._api.get_aircon_stats.side_effect = AirconConnectionError("no route")
-    device._api.update_account_info = AsyncMock()
+    device._api.update_account_info = AsyncMock(return_value={"result": 0})
     for _ in range(10):
         await device.update()
 
@@ -205,7 +206,7 @@ async def test_update_initially_unreachable_logs_threshold_once(device, caplog):
     even though its public availability flag starts out false.
     """
     device._api.get_aircon_stats.side_effect = AirconConnectionError("no route")
-    device._api.update_account_info = AsyncMock()
+    device._api.update_account_info = AsyncMock(return_value={"result": 0})
     for _ in range(5):
         await device.update()
 
@@ -245,7 +246,7 @@ async def test_update_refused_command_reregisters(device):
     out, so this path keeps the re-registration attempt.
     """
     device._api.get_aircon_stats.side_effect = AirconCommandError("refused")
-    device._api.update_account_info = AsyncMock()
+    device._api.update_account_info = AsyncMock(return_value={"result": 0})
     await device.update()
     assert device.available is False
     device._api.update_account_info.assert_awaited_once()
@@ -497,7 +498,7 @@ async def test_availability_tolerates_failures_below_limit(hass):
     assert dev.available is True
 
     dev._api.get_aircon_stats.side_effect = AirconApiError("boom")
-    dev._api.update_account_info = AsyncMock()
+    dev._api.update_account_info = AsyncMock(return_value={"result": 0})
 
     await dev.update()
     assert dev.available is True  # 1st failure - within tolerance
@@ -526,7 +527,7 @@ async def test_availability_limit_can_be_raised_but_not_lowered(hass):
     assert lowered._availability_failure_limit == AVAILABILITY_FAILURE_LIMIT_MIN
 
     lowered._api = AsyncMock()
-    lowered._api.update_account_info = AsyncMock()
+    lowered._api.update_account_info = AsyncMock(return_value={"result": 0})
     lowered._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await lowered.update()
 
@@ -544,7 +545,7 @@ async def test_availability_recovers_and_resets_the_failure_count(hass):
         swing_selects_enabled_default=True,
     )
     dev._api = AsyncMock()
-    dev._api.update_account_info = AsyncMock()
+    dev._api.update_account_info = AsyncMock(return_value={"result": 0})
     dev._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await dev.update()
 
@@ -756,6 +757,51 @@ async def test_add_account_returns_none_on_api_error(device):
     device._api.update_account_info.side_effect = AirconApiError("failed")
 
     assert await device.add_account() is None
+
+
+# --- add_account() / registration-full repair issue -----------------------
+
+
+def _issue(device):
+    return ir.async_get(device._hass).async_get_issue(
+        DOMAIN, device_module.registration_full_issue_id(device.config_entry.entry_id)
+    )
+
+
+async def test_add_account_reports_repair_issue_when_table_is_full(device):
+    device._api.update_account_info.return_value = {"result": 2}
+
+    await device.add_account()
+
+    assert _issue(device) is not None
+
+
+async def test_add_account_clears_repair_issue_once_registration_succeeds(device):
+    device._api.update_account_info.return_value = {"result": 2}
+    await device.add_account()
+    assert _issue(device) is not None
+
+    device._api.update_account_info.return_value = {"result": 0}
+    await device.add_account()
+
+    assert _issue(device) is None
+
+
+async def test_add_account_does_not_report_an_issue_on_ordinary_success(device):
+    device._api.update_account_info.return_value = {"result": 0}
+
+    await device.add_account()
+
+    assert _issue(device) is None
+
+
+async def test_update_reregister_reports_repair_issue_when_table_stays_full(device):
+    device._api.get_aircon_stats.side_effect = AirconApiError("evicted")
+    device._api.update_account_info.return_value = {"result": 2}
+
+    await device.update()
+
+    assert _issue(device) is not None
 
 
 async def test_set_airco_raises_when_refresh_does_not_provide_state(device):

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -5,16 +5,24 @@ because entries created under those versions carry the keys, but nothing reads
 them at runtime any more - the migration's job is to leave no trace of them.
 """
 
+from unittest.mock import AsyncMock, patch
+
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.mitsubishi_wf_rac import async_migrate_entry, create_device_from_entry
+from custom_components.mitsubishi_wf_rac import (
+    async_migrate_entry,
+    async_remove_entry,
+    create_device_from_entry,
+)
 from custom_components.mitsubishi_wf_rac.const import (
     CONF_AVAILABILITY_CHECK,
     CONF_AVAILABILITY_RETRY_LIMIT,
     DOMAIN,
 )
+from custom_components.mitsubishi_wf_rac.wfrac.device import registration_full_issue_id
 
 _DATA = {
     "name": "Living Room AC",
@@ -111,3 +119,31 @@ async def test_device_is_built_without_availability_options(hass: HomeAssistant)
     device = await create_device_from_entry(entry, hass)
 
     assert device._consecutive_failures == 0  # pylint: disable=protected-access
+
+
+async def test_remove_entry_clears_the_registration_full_repair_issue(hass: HomeAssistant):
+    """A repair issue is entry-scoped (see wfrac/device.py's add_account) - it
+    must not survive the entry it was raised against, or it stays in the
+    Repairs list forever pointing at nothing.
+    """
+    entry = _entry(hass, _CURRENT_VERSION, _DATA, {CONF_HOST: "192.168.1.50"})
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        registration_full_issue_id(entry.entry_id),
+        is_fixable=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="too_many_devices",
+        translation_placeholders={"device_name": "Living Room AC"},
+    )
+
+    with patch(
+        "custom_components.mitsubishi_wf_rac.wfrac.device.Repository",
+        return_value=AsyncMock(),
+    ):
+        await async_remove_entry(hass, entry)
+
+    assert (
+        ir.async_get(hass).async_get_issue(DOMAIN, registration_full_issue_id(entry.entry_id))
+        is None
+    )

--- a/tests/unit/test_translation_keys.py
+++ b/tests/unit/test_translation_keys.py
@@ -28,11 +28,15 @@ def test_exception_keys_match_english_translation():
     assert set(STRINGS["exceptions"]) == set(ENGLISH["exceptions"])
 
 
+def test_issue_keys_match_english_translation():
+    assert set(STRINGS["issues"]) == set(ENGLISH["issues"])
+
+
 def test_raised_translation_keys_exist_in_strings():
     """Every `translation_key="..."` passed to a HomeAssistantError subclass
-    must resolve somewhere - a typo here fails silently at runtime (HA falls
-    back to the plain message arg) rather than raising, so nothing else would
-    catch it.
+    or to ir.async_create_issue() must resolve somewhere - a typo here fails
+    silently at runtime (HA falls back to the plain message arg, or the issue
+    just never shows up) rather than raising, so nothing else would catch it.
     """
     used_keys = set()
     for path in COMPONENT.rglob("*.py"):
@@ -40,7 +44,7 @@ def test_raised_translation_keys_exist_in_strings():
         used_keys.update(re.findall(r'translation_key="([a-z_]+)"', text))
 
     assert used_keys, "expected to find at least one translation_key in the source"
-    assert used_keys <= set(STRINGS["exceptions"])
+    assert used_keys <= set(STRINGS["exceptions"]) | set(STRINGS["issues"])
 
 
 def test_step_data_keys_match_english_translation():


### PR DESCRIPTION
Closes the `repair-issues` gap on the [quality scale](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/repair-issues/) standortbestimmung.

`add_account()` already re-registers automatically on a poll failure, on the theory that HA got evicted from the module's small, fixed-size account table (opening the official app or adding a phone can do that). That part already worked. What it didn't handle: if the table is genuinely full rather than just evicted, `update_account_info` comes back `result:2`, and the integration silently kept retrying and failing every poll forever - nothing beyond a debug-level log line said why, and nothing about it is something HA can fix on its own.

- A repair issue is raised on `result:2`, cleared the moment registration next succeeds, and cleaned up in `async_remove_entry` so a deleted config entry doesn't leave a dangling issue in the Repairs list. `registration_full_issue_id()` lives in `device.py` so both call sites format the entry-scoped id the same way.
- Not fixable from within HA (the fix is in the Smart M-Air app or a factory reset), so it's `is_fixable=False` - informational with clear next steps, not a repair flow.
- Fixes a fresh mypy-strict gap the new code would otherwise have added: reading `config_entry.entry_id` needs `self.config_entry` narrowed from `ConfigEntry | None` at every call site, so `Device` now also keeps `self._entry`, a non-Optional reference set once in `__init__` (it's never actually None for this integration).
- Tests: repair issue created on `result:2`, cleared on the next successful `add_account()`, not raised on ordinary success, raised end-to-end through `update()`'s re-registration path, and cleaned up on entry removal.

268 tests pass locally (`pytest`).