### PR TITLE
Release 2026.9.5-beta3

### DIFF
--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues",
   "requirements": [],
-  "version": "2026.9.5-beta2",
+  "version": "2026.9.5-beta3",
   "zeroconf": [
     "_beaver._tcp.local."
   ]


### PR DESCRIPTION
Version bump only — everything below already merged separately since `beta2`.

## Included since 2026.9.5-beta2

- Reconfigure flow for host/port/name, closing the `reconfiguration-flow` quality-scale gap (#285)
- Repair issue when the airco's account table stays full and re-registration can't succeed (#287)
- Redacted diagnostics download (#280)
- Translated exception messages for user-facing errors (#286)
- The three swing/fan-speed selects are now always created; the old setup option only controls whether they start disabled (#279)
- Missing translations for the raw sensors and target-offset options filled in (#281)
- Corrected the LED status sensor description — it reflects the unit's own LED toggle, not Wi-Fi module state (#282)
- `mypy --strict` passing and wired into CI (#283), catching a couple of real edge-case bugs along the way

275 tests pass locally (`pytest`).