### PR TITLE
Make the discovered port editable in the zeroconf confirm dialog

### DIFF
--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -227,8 +227,8 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         }
 
         if user_input:
-            for key in [CONF_HOST, CONF_PORT]:
-                user_input[key] = self._discovery_info[key]
+            user_input[CONF_HOST] = self._discovery_info[CONF_HOST]
+            user_input.setdefault(CONF_PORT, self._discovery_info[CONF_PORT])
 
         field = partial(self._field, user_input)
         data_schema = vol.Schema(
@@ -236,6 +236,9 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 field(
                     CONF_NAME, vol.Required, f"Airco {self._discovery_info[CONF_NAME]}"
                 ): str,
+                field(
+                    CONF_PORT, vol.Optional, self._discovery_info[CONF_PORT]
+                ): cv.port,
             }
         )
 

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -12,10 +12,11 @@
         "title": "WF-RAC AC connection info"
       },
       "discovery_confirm": {
-        "description": "The airco with id: {id}, IP: {host} and port: {port} was discovered. Please give it a name.",
+        "description": "The airco with id: {id}, IP: {host} and port: {port} was discovered. The port is normally 51443 — correct it below if it looks different. Please give it a name.",
         "title": "Discovered WF-RAC airco",
         "data": {
-          "name": "[%key:common::config_flow::data::name%]"
+          "name": "[%key:common::config_flow::data::name%]",
+          "port": "[%key:common::config_flow::data::port%]"
         }
       },
       "reconfigure": {

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -24,10 +24,11 @@
         "title": "WF-RAC AC Verbindungs-Info"
       },
       "discovery_confirm": {
-        "description": "Die Klima mit der ID: {id}, IP: {host} und Port: {port} wurde gefunden. Bitte vergeben Sie einen Namen.",
+        "description": "Die Klima mit der ID: {id}, IP: {host} und Port: {port} wurde gefunden. Der Port ist normalerweise 51443 — bei Abweichung unten korrigieren. Bitte vergeben Sie einen Namen.",
         "title": "WF-RAC Klima gefunden",
         "data": {
-          "name": "Klima Name"
+          "name": "Klima Name",
+          "port": "Port"
         }
       },
       "reconfigure": {

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -24,10 +24,11 @@
         "title": "WF-RAC AC connection info"
       },
       "discovery_confirm": {
-        "description": "The airco with id: {id}, IP: {host} and port: {port} was discovered. Please give it a name.",
+        "description": "The airco with id: {id}, IP: {host} and port: {port} was discovered. The port is normally 51443 — correct it below if it looks different. Please give it a name.",
         "title": "Discovered WF-RAC airco",
         "data": {
-          "name": "Airco Name"
+          "name": "Airco Name",
+          "port": "Port"
         }
       },
       "reconfigure": {

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -24,10 +24,11 @@
         "title": "WF-RACエアコン接続情報"
       },
       "discovery_confirm": {
-        "description": "ID: {id}、IP: {host}、ポート: {port} のエアコンが見つかりました。名前を付けてください。",
+        "description": "ID: {id}、IP: {host}、ポート: {port} のエアコンが見つかりました。通常このポートは51443です。異なる場合は下で修正してください。名前を付けてください。",
         "title": "検出されたWF-RACエアコン",
         "data": {
-          "name": "エアコン名"
+          "name": "エアコン名",
+          "port": "ポート"
         }
       },
       "reconfigure": {

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -24,10 +24,11 @@
         "title": "WF-RAC AC susijungimo informacija"
       },
       "discovery_confirm": {
-        "description": "Rastas kondicionierius, kurio id: {id}, IP: {host} ir portas: {port}. Suteikite jam pavadinimą.",
+        "description": "Rastas kondicionierius, kurio id: {id}, IP: {host} ir portas: {port}. Paprastai šis portas yra 51443 — jei kitoks, pataisykite žemiau. Suteikite jam pavadinimą.",
         "title": "Atrastas WF-RAC kondicionierius",
         "data": {
-          "name": "Kondicionieriaus pavadinimas"
+          "name": "Kondicionieriaus pavadinimas",
+          "port": "Portas"
         }
       },
       "reconfigure": {

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -24,10 +24,11 @@
         "title": "WF-RAC AC verbinding info"
       },
       "discovery_confirm": {
-        "description": "De airco met id: {id}, IP: {host} en poort: {port} is ontdekt. Hoe heet deze airco?",
+        "description": "De airco met id: {id}, IP: {host} en poort: {port} is ontdekt. Dit is normaal gesproken 51443 — corrigeer het hieronder als het afwijkt. Hoe heet deze airco?",
         "title": " WF-RAC Airco ontdekt ",
         "data": {
-          "name": "Airco naam"
+          "name": "Airco naam",
+          "port": "Poort"
         }
       },
       "reconfigure": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -24,10 +24,11 @@
         "title": "WF-RAC 空调连接信息"
       },
       "discovery_confirm": {
-        "description": "发现了空调，ID: {id}，IP: {host}，端口: {port}。请为其命名。",
+        "description": "发现了空调，ID: {id}，IP: {host}，端口: {port}。通常应为 51443——如不同请在下方更正。请为其命名。",
         "title": "发现的 WF-RAC 空调",
         "data": {
-          "name": "空调名称"
+          "name": "空调名称",
+          "port": "端口"
         }
       },
       "reconfigure": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -24,10 +24,11 @@
         "title": "WF-RAC 空調連接資訊"
       },
       "discovery_confirm": {
-        "description": "發現了空調，ID: {id}，IP: {host}，埠號: {port}。請為其命名。",
+        "description": "發現了空調，ID: {id}，IP: {host}，埠號: {port}。通常應為 51443——如不同請在下方更正。請為其命名。",
         "title": "發現的 WF-RAC 空調",
         "data": {
-          "name": "空調名稱"
+          "name": "空調名稱",
+          "port": "埠號"
         }
       },
       "reconfigure": {

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -422,6 +422,27 @@ async def test_zeroconf_discovery_confirm_creates_entry(hass: HomeAssistant):
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["options"]["host"] == "192.168.1.50"
+    assert result["data"]["port"] == 51443
+
+
+async def test_zeroconf_discovery_confirm_port_can_be_overridden(hass: HomeAssistant):
+    """A bad mDNS advertisement (see #290: port 5353, the mDNS port itself,
+    instead of the fixed 51443) must be correctable in the confirm step
+    rather than silently trusted.
+    """
+    repo = _mock_repository()
+    with _patch_repository(repo):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=_zeroconf_info(port=5353),
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"name": "Living Room AC", "port": 51443}
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"]["port"] == 51443
 
 
 # --- options flow --------------------------------------------------------


### PR DESCRIPTION
## Summary
- The zeroconf `discovery_confirm` step trusted whatever port the mDNS advertisement reported and showed it only as read-only text — #290 hit a real case where the device advertised `5353` (the mDNS port itself) instead of the fixed `51443` every firmware branch uses, and the only way out was dismissing the discovered entry and adding the airco manually.
- The port field is now editable in that dialog, pre-filled with the discovered value, and the description notes that 51443 is the expected default so a wrong value is easy to spot at a glance.
- Updated `strings.json` and all 7 translation files.

## Test plan
- [x] `pytest` (276 passed) — added `test_zeroconf_discovery_confirm_port_can_be_overridden`, covering the exact #290 scenario (discovered port 5353, corrected to 51443)
- [x] `mypy` clean on `config_flow.py`
- [x] All translation JSON files validated for syntax

Closes the follow-up from #290.