### PR TITLE
Re-register and retry once when setAirconStat is refused for an unregistered account

### DIFF
--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -22,6 +22,7 @@ from .repository import (
     AirconApiError,
     AirconCommandError,
     AirconConnectionError,
+    AirconRegistrationError,
     Repository,
 )
 
@@ -589,7 +590,23 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
 
             try:
                 command = self._parser.to_base64(airco_stat)
-                response = await self._api.send_airco_command(self._airco_id, command)
+                try:
+                    response = await self._api.send_airco_command(
+                        self._airco_id, command
+                    )
+                except AirconRegistrationError:
+                    # Our operator id fell out of the airco's small account
+                    # table - most likely evicted by the Smart M-Air app or
+                    # another client registering around the same time (#294).
+                    # getAirconStat's own eviction already self-heals via
+                    # update()'s add_account() retry; do the same here instead
+                    # of losing the command outright. One retry only - if the
+                    # table is genuinely full rather than just evicted,
+                    # add_account() has already raised the repair issue for it.
+                    await self.add_account()
+                    response = await self._api.send_airco_command(
+                        self._airco_id, command
+                    )
                 new_airco = self._parser.translate_bytes(response)
                 self._carry_forward_home_leave_mode(new_airco)
                 self._carry_forward_service_data(new_airco)

--- a/custom_components/mitsubishi_wf_rac/wfrac/repository.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/repository.py
@@ -91,6 +91,19 @@ class AirconCommandError(AirconApiError):
     """
 
 
+class AirconRegistrationError(AirconCommandError):
+    """Raised when setAirconStat is refused because our operator id isn't (or
+    no longer is) registered in the airco's account table (result 1/2).
+
+    A distinct subtype so callers can tell this apart from an ordinary
+    refusal and re-register before giving up: the account table has only
+    four slots, and opening the Smart M-Air app or adding a phone can evict
+    an existing registration from it (#294). getAirconStat's own eviction
+    already self-heals via Device.update()'s add_account() retry; this gives
+    the write path the same recovery instead of silently losing the command.
+    """
+
+
 class AirconConnectionError(AirconApiError):
     """Raised when the unit could not be reached at all.
 
@@ -381,4 +394,13 @@ class Repository:
         """send command to the Airco"""
         contents = {"airconId": airco_id, "airconStat": command}
         result = await self._post("setAirconStat", contents)
+        try:
+            code = int(result.get("result", 0))
+        except (TypeError, ValueError):
+            code = 0
+        if code in (1, 2):
+            raise AirconRegistrationError(
+                f"Aircon refused setAirconStat with result {code} "
+                f"({RESULT_CODES.get(code, 'meaning unknown')})"
+            )
         return cast(str, result["contents"]["airconStat"])

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -44,6 +44,7 @@ from custom_components.mitsubishi_wf_rac.wfrac.repository import (
     AirconApiError,
     AirconCommandError,
     AirconConnectionError,
+    AirconRegistrationError,
 )
 
 from ..unit.live_captures import LIVE_CAPTURES
@@ -304,6 +305,53 @@ async def test_set_airco_raises_and_logs_on_send_failure(device):
 
     with pytest.raises(AirconApiError):
         await device.set_airco({AirconCommands.Operation: True})
+
+
+async def test_set_airco_reregisters_and_retries_once_on_registration_error(device):
+    """A write refused because our account fell out of the airco's table
+    (#294 - most likely evicted by the Smart M-Air app registering around the
+    same time) should self-heal like the read path already does, instead of
+    losing the command outright.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    device._api.update_account_info = AsyncMock(return_value={"result": 0})
+
+    calls = {"n": 0}
+
+    async def _fail_once_then_echo(airco_id, command):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise AirconRegistrationError("result 1")
+        return await _echo_send_airco_command(airco_id, command)
+
+    device._api.send_airco_command = AsyncMock(side_effect=_fail_once_then_echo)
+
+    await device.set_airco({AirconCommands.Operation: True})
+
+    device._api.update_account_info.assert_awaited_once()
+    assert device._api.send_airco_command.await_count == 2
+    assert device.airco.Operation is True
+
+
+async def test_set_airco_gives_up_after_one_retry_if_still_refused(device):
+    """The table can be genuinely full rather than just evicted - retrying
+    forever would just hammer the unit. add_account() already raises the
+    repair issue for that case (#287); this should still fail (and log) like
+    any other refused write, not loop.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    device._api.update_account_info = AsyncMock(return_value={"result": 2})
+    device._api.send_airco_command = AsyncMock(
+        side_effect=AirconRegistrationError("result 2")
+    )
+
+    with pytest.raises(AirconRegistrationError):
+        await device.set_airco({AirconCommands.Operation: True})
+
+    device._api.update_account_info.assert_awaited_once()
+    assert device._api.send_airco_command.await_count == 2
 
 
 async def test_set_airco_fetches_state_first_if_unset(device):

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -20,6 +20,7 @@ from custom_components.mitsubishi_wf_rac.wfrac.repository import (
     REQUEST_TIMEOUT,
     AirconCommandError,
     AirconConnectionError,
+    AirconRegistrationError,
     Repository,
 )
 
@@ -232,6 +233,33 @@ async def test_refusal_in_the_result_field_is_reported_once(repository, caplog):
     await repo.get_aircon_stats("airco-id")
 
     assert len([r for r in caplog.records if r.levelname == "WARNING"]) == 2
+
+
+@pytest.mark.parametrize("code", [1, 2])
+async def test_send_airco_command_raises_on_registration_result_codes(
+    repository, code
+):
+    """Unlike getAirconStat (asserted above), setAirconStat refusing because
+    our account isn't registered (result 1/2) must be visible to the caller
+    rather than swallowed - Device.set_airco() relies on this to re-register
+    and retry instead of losing the command (#294).
+    """
+    refused = json.dumps({"result": code, "contents": {"airconStat": "AAA="}})
+    repo, _ = repository([_FakeResponse(200, refused)])
+
+    with pytest.raises(AirconRegistrationError):
+        await repo.send_airco_command("airco-id", "cmd")
+
+
+async def test_send_airco_command_does_not_raise_on_unrelated_result_code(repository):
+    """Result 12 ("operation prohibited") isn't a registration problem, so it
+    must not trigger the re-register-and-retry path - just the existing
+    logged-but-not-acted-on refusal.
+    """
+    refused = json.dumps({"result": 12, "contents": {"airconStat": "AAA="}})
+    repo, _ = repository([_FakeResponse(200, refused)])
+
+    assert await repo.send_airco_command("airco-id", "cmd") == "AAA="
 
 
 async def test_unknown_result_code_is_still_reported(repository, caplog):


### PR DESCRIPTION
Closes the write-path half of the account-table eviction story (#294).

`Device.update()` already re-registers automatically when `getAirconStat` fails because our account fell out of the airco's small (4-slot) account table - most likely evicted by the Smart M-Air app or another client registering around the same time. `setAirconStat` didn't have the same recovery: a refusal there comes back as HTTP 200 with `result: 1` or `2` embedded, which `_report_result_code()` only logs (deliberately, since #212 - non-zero results on other commands aren't established to always mean failure). The command was silently dropped.

- `send_airco_command()` now raises a distinct `AirconRegistrationError` for `result` `1`/`2` specifically (not `12`, which is unrelated to the account table and shouldn't trigger a re-register).
- `set_airco()` catches it, calls `add_account()`, and retries the write once before falling back to the existing failure path (log + raise).
- Composes with the existing repair issue (#287): if the table is genuinely full rather than just evicted, the retry fails too and the repair issue (raised inside `add_account()`) is already there to explain why.

Tests: registration-error retry succeeds, retry still fails and propagates (no infinite loop), and `send_airco_command` doesn't raise for the unrelated `result: 12` case. 281 tests pass, mypy strict clean.