### PR TITLE
2026.9.6-beta1: stand down when another client holds the unit's write lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ Already installed? Jump straight to setup:
 Clone or copy this repository and copy the folder `custom_components/mitsubishi_wf_rac` into
 `/custom_components/mitsubishi_wf_rac`.
 
+### Removing the integration
+
+This integration follows standard integration removal — no extra steps (like disabling a cloud
+account) are required.
+
+1. Go to **Settings** > **Devices & Services**.
+2. Find the **Mitsubishi WF-RAC** integration and select it.
+3. Select the three-dot menu next to the entry, then **Delete**.
+
+If you installed manually rather than through HACS, also delete the
+`custom_components/mitsubishi_wf_rac` folder and restart Home Assistant.
+
 # Entities
 
 This integration creates one device per airco with the following entities.

--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -25,7 +25,7 @@ from .const import (
     CONF_OPERATOR_ID, CONF_CREATE_SWING_MODE_SELECT,
     DOMAIN,
 )
-from .wfrac.device import AVAILABILITY_FAILURE_LIMIT_MIN, Device, registration_full_issue_id
+from .coordinator import AVAILABILITY_FAILURE_LIMIT_MIN, Device, registration_full_issue_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -114,7 +114,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEnt
 
     await _device.update()  # initial update to get fresh values
     # update() catches its own errors and reflects them via .available instead
-    # of raising (see wfrac/device.py) - check that instead of try/except so a
+    # of raising (see coordinator.py) - check that instead of try/except so a
     # device that's unreachable at startup gets HA's automatic retry-with-backoff
     # rather than a silently "loaded" entry with no working entities.
     if not _device.available:
@@ -155,7 +155,7 @@ async def create_device_from_entry(entry: ConfigEntry, hass: HomeAssistant) -> D
     swing_selects_enabled_default: bool = entry.data.get(CONF_CREATE_SWING_MODE_SELECT, True)
     # Off unless the user explicitly opted in via the options flow - this is
     # the only outbound internet call in the integration (see
-    # wfrac/device.py's _maybe_check_firmware_update()).
+    # coordinator.py's _maybe_check_firmware_update()).
     firmware_update_check_enabled: bool = entry.options.get(CONF_FIRMWARE_UPDATE_CHECK, False)
     # Floored in Device itself, so an entry that predates the v4 -> v5
     # migration can't run with less tolerance than the module needs.
@@ -200,7 +200,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEn
 
     temp_device = await create_device_from_entry(entry, hass)
     # delete_account() catches its own errors and returns None on failure (see
-    # wfrac/device.py) rather than raising, so check the result instead of
+    # coordinator.py) rather than raising, so check the result instead of
     # try/except - the previous try/except here could never actually trigger,
     # and the "Deleted" log below used to fire unconditionally even on failure.
     result = await temp_device.delete_account()

--- a/custom_components/mitsubishi_wf_rac/binary_sensor.py
+++ b/custom_components/mitsubishi_wf_rac/binary_sensor.py
@@ -34,6 +34,7 @@ async def async_setup_entry(
     entities = [
         ProblemBinarySensor(device),
         CompressorBinarySensor(device),
+        ExternalControlBinarySensor(device),
     ]
     # Occupancy ("vacant") detection is only reported by units whose capability
     # table has VacantProperty=true - includes ZT-2025 (raw=3), which the
@@ -92,6 +93,31 @@ class CompressorBinarySensor(WfRacEntity, BinarySensorEntity):
 
     def _update_state(self) -> None:
         self._attr_is_on = self._device.airco.CompressorRunning
+
+
+class ExternalControlBinarySensor(WfRacEntity, BinarySensorEntity):
+    """On while another client is using the unit and this integration is
+    holding back because of it.
+
+    The unit grants whoever wrote last 60 seconds of exclusive write access,
+    so the operation-data request - itself a write - is paused while someone
+    else is active (see Device.foreign_activity). Without this entity the
+    only visible effect would be the operation-data sensors going unknown,
+    with nothing to explain why.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_has_entity_name = True
+    _attr_translation_key = "external_control"
+
+    def __init__(self, device: Device) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(device)
+        self._attr_unique_id = f"{DOMAIN}-{device.airco_id}-external-control"
+        self._update_state()
+
+    def _update_state(self) -> None:
+        self._attr_is_on = self._device.foreign_activity
 
 
 class OccupancyBinarySensor(WfRacEntity, BinarySensorEntity):

--- a/custom_components/mitsubishi_wf_rac/binary_sensor.py
+++ b/custom_components/mitsubishi_wf_rac/binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MitsubishiWfRacConfigEntry
 from .entity import WfRacEntity
-from .wfrac.device import Device
+from .coordinator import Device
 from .wfrac.error_codes import describe_error_code
 from .const import DOMAIN
 

--- a/custom_components/mitsubishi_wf_rac/button.py
+++ b/custom_components/mitsubishi_wf_rac/button.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MitsubishiWfRacConfigEntry
 from .entity import WfRacEntity
-from .wfrac.device import Device
+from .coordinator import Device
 from .const import DOMAIN, SIGNAL_SET_ENERGY_TOTAL
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -21,7 +21,7 @@ from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import WfRacEntity
-from .wfrac.device import Device
+from .coordinator import Device
 from .wfrac.models.aircon import Aircon, AirconCommands, HomeLeaveModeSetting
 from .const import (
     DOMAIN,

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -35,7 +35,7 @@ from .const import (
     CONF_TARGET_OFFSET_HEAT,
     DOMAIN,
 )
-from .wfrac.device import AVAILABILITY_FAILURE_LIMIT_MIN
+from .coordinator import AVAILABILITY_FAILURE_LIMIT_MIN
 from .wfrac.repository import AirconApiError, Repository
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -22,7 +22,7 @@ CONF_AIRCO_ID = "airco_id"
 # that predate v5. Nothing outside the migration reads it.
 CONF_AVAILABILITY_CHECK = "availability_check"
 # Consecutive failed polls before the device is reported unavailable; floored
-# at wfrac/device.py's AVAILABILITY_FAILURE_LIMIT_MIN.
+# at coordinator.py's AVAILABILITY_FAILURE_LIMIT_MIN.
 CONF_AVAILABILITY_RETRY_LIMIT = "availability_retry_limit"
 # Gates all outbound internet traffic (as opposed to local-network device
 # polling) - the manufacturer's getFirmware endpoint. Off by default: unlike

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -12,11 +12,11 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from ..const import DOMAIN, MIN_TIME_BETWEEN_UPDATES
-from .firmware_check import fetch_latest_firmware
-from .models.aircon import Aircon, AirconCommands, AirconStat, HomeLeaveModeSetting
-from .rac_parser import RacParser, SERVICE_DATA_CODES
-from .repository import (
+from .const import DOMAIN, MIN_TIME_BETWEEN_UPDATES
+from .wfrac.firmware_check import fetch_latest_firmware
+from .wfrac.models.aircon import Aircon, AirconCommands, AirconStat, HomeLeaveModeSetting
+from .wfrac.rac_parser import RacParser, SERVICE_DATA_CODES
+from .wfrac.repository import (
     MIN_TIME_BETWEEN_REQUESTS,
     REQUEST_TIMEOUT,
     AirconApiError,

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -23,6 +23,7 @@ from .wfrac.repository import (
     AirconCommandError,
     AirconConnectionError,
     AirconRegistrationError,
+    AirconWriteRefusedError,
     Repository,
 )
 
@@ -72,6 +73,28 @@ SERVICE_DATA_REQUEST_OFFSET = SERVICE_DATA_REQUEST_INTERVAL / 2
 # A refused request costs a full cycle of every operation-data sensor, and
 # these refusals are transient, so one retry is worth the extra request.
 SERVICE_DATA_RETRY_DELAY = timedelta(seconds=5)
+
+# How long another client's last write keeps us from sending operation-data
+# requests. Every successful setAirconStat grants its sender 60 seconds of
+# exclusive write access and locks everyone else out, and the operation-data
+# request is a setAirconStat - it changes nothing on the unit, but it renews
+# that lock all the same. At one request per 60s poll against a 60s lock, an
+# enabled operation-data entity holds the lock permanently and leaves the
+# Smart M-Air app unable to control the unit at all (#294).
+#
+# So when someone else writes, we stand down. Three minutes covers a typical
+# app session. The operation-data sensors hold their last values throughout -
+# a pause we chose is not the stale-data case SERVICE_DATA_MAX_AGE guards
+# against, and External Control says plainly that it is happening. See
+# _settle_service_data_pause().
+FOREIGN_ACTIVITY_BACKOFF = timedelta(minutes=3)
+
+# One retry for a user command refused because someone else holds the lock.
+# Short on purpose: a service call should not sit there for the full lock
+# duration, and the common case is an app action that is already most of the
+# way through its 60s. A retry that still fails is reported rather than
+# repeated - two clients are genuinely fighting over the unit at that point.
+WRITE_LOCK_RETRY_DELAY = timedelta(seconds=10)
 
 # The unit answers these segments only when asked, so they are carried across
 # the polls in between (see Device._carry_forward_service_data()) - but not
@@ -195,6 +218,13 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         self._last_service_data_request: datetime | None = None
         self._last_service_data_response: datetime | None = None
         self._service_data_expired = False
+        # Foreign-write detection, see _detect_foreign_activity(). The flag is
+        # set by our own successful writes and consumed by the next poll, so a
+        # rise in `expires` can be attributed to us or to someone else.
+        self._wrote_since_last_poll = False
+        self._foreign_activity_until: datetime | None = None
+        self._foreign_activity_reported = False
+        self._foreign_activity_since: datetime | None = None
         self._service_data_task: asyncio.Task[None] | None = None
         self._consecutive_failures = 0
         # Clamped rather than validated: an entry can carry a lower value from
@@ -293,6 +323,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             # response. Tolerate absence (.get()) since it's undocumented and
             # could be missing on older firmware.
             self._updated_by = response.get("updatedBy")
+            self._detect_foreign_activity(response.get("expires"))
             self._account_expires = response.get("expires")
             self._led_status = response.get("ledStat")
             self._auto_heating = response.get("autoHeating")
@@ -373,6 +404,107 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         self._firmware_update_available = update_available
         self.async_set_updated_data(self._airco)
 
+    def _detect_foreign_activity(self, expires: Any) -> None:
+        """Notice when someone else has written to the unit, from `expires`.
+
+        The module reports the moment its 60-second write lock lapses, and
+        that moment only moves when a setAirconStat succeeds. So a higher
+        `expires` than the previous poll saw means a write happened in
+        between - ours if we sent one, somebody else's if we did not. That is
+        the whole detector: no extra request, and no dependence on the
+        module's clock agreeing with ours, because only the difference is
+        read.
+
+        `updatedBy` cannot do this job. It reports the literal "local" for
+        any account registered with remote=0, which is how this integration
+        registers (remote=1 is what makes the module open its cloud
+        connection, so it is not an option) - and a locally paired Smart
+        M-Air app registers the same way. Both therefore show up as "local"
+        and cannot be told apart.
+
+        Known blind spot: someone else writing in the same gap in which we
+        did hides behind our own write, and this poll says nothing. The next
+        one catches them as soon as they act again, which for anyone actually
+        using the app is seconds away.
+        """
+        wrote = self._wrote_since_last_poll
+        self._wrote_since_last_poll = False
+
+        if (
+            isinstance(expires, int)
+            and isinstance(self._account_expires, int)
+            and expires > self._account_expires
+            and not wrote
+        ):
+            if self._foreign_activity_since is None:
+                self._foreign_activity_since = datetime.now()
+            self._foreign_activity_until = datetime.now() + FOREIGN_ACTIVITY_BACKOFF
+            _LOGGER.debug(
+                "Another client wrote to [%s]: expires moved %s -> %s",
+                self.device_name,
+                self._account_expires,
+                expires,
+            )
+        self._report_foreign_activity()
+
+    def _report_foreign_activity(self) -> None:
+        """Say so, once, when we start and stop holding back.
+
+        Worth a log line rather than only the binary sensor: while this is on,
+        the operation-data sensors report unknown, and someone reading the log
+        to find out why deserves to find the reason there.
+        """
+        active = self.foreign_activity
+        if active == self._foreign_activity_reported:
+            return
+        self._foreign_activity_reported = active
+        if active:
+            _LOGGER.info(
+                "Another client is controlling [%s]; pausing operation-data "
+                "requests for up to %.0fs so it keeps working. Its sensors "
+                "hold their last values meanwhile.",
+                self.device_name,
+                FOREIGN_ACTIVITY_BACKOFF.total_seconds(),
+            )
+        else:
+            _LOGGER.info(
+                "No other client active on [%s]; resuming operation-data requests",
+                self.device_name,
+            )
+
+    def _settle_service_data_pause(self) -> None:
+        """Once a stand-down ends, move the operation-data age anchor forward
+        by however long it lasted.
+
+        Without this the readings would expire on the very first poll after
+        resuming: the gap is one we chose, so counting it against
+        SERVICE_DATA_MAX_AGE would throw away values that are perfectly good
+        and about to be refreshed anyway.
+
+        Kept out of _report_foreign_activity() on purpose - that one only
+        logs, and runs after _carry_forward_service_data() has already
+        decided. This has to have happened before that decision.
+        """
+        if self._foreign_activity_since is None or self.foreign_activity:
+            return
+        if (
+            self._last_service_data_response is not None
+            and self._foreign_activity_until is not None
+        ):
+            self._last_service_data_response += (
+                self._foreign_activity_until - self._foreign_activity_since
+            )
+        self._foreign_activity_since = None
+
+    @property
+    def foreign_activity(self) -> bool:
+        """Whether another client wrote to the unit recently enough that we
+        are still standing down - see FOREIGN_ACTIVITY_BACKOFF."""
+        return (
+            self._foreign_activity_until is not None
+            and datetime.now() < self._foreign_activity_until
+        )
+
     def _maybe_request_service_data(self) -> None:
         """Kick off a background request for active operation-data segments
         when due (see SERVICE_DATA_MIN_SPACING).
@@ -381,6 +513,11 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             sorted(set(self.async_contexts()).intersection(SERVICE_DATA_CODES))
         )
         if not service_data_codes:
+            return
+        if self.foreign_activity:
+            # Skipped entirely rather than deferred: this request would take
+            # the write lock for another 60s and is worth far less than
+            # leaving the unit controllable from whatever is using it.
             return
         if self._service_data_task is not None and not self._service_data_task.done():
             # A retry from the previous cycle is still in flight; piling a
@@ -424,6 +561,18 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 if attempt > 1:
                     _LOGGER.debug("Service data request succeeded on retry")
                 return
+            except AirconWriteRefusedError as ex:
+                # Someone else may hold the write lock. Unlike a user command
+                # this is not worth contesting: give the cycle up immediately
+                # rather than retrying into a lock we would only be renewing
+                # for ourselves if we won it.
+                _LOGGER.debug(
+                    "Service data request declined for [%s], skipping this "
+                    "cycle: %s",
+                    self.device_name,
+                    ex,
+                )
+                return
             except AirconCommandError as ex:
                 if attempt == 1:
                     _LOGGER.debug("Service data request refused (%s); retrying", ex)
@@ -453,10 +602,18 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         sensors would flash the real value for one update cycle and then
         revert to unknown.
 
-        Unlike home/leave mode this expires: see SERVICE_DATA_MAX_AGE.
+        Unlike home/leave mode this expires: see SERVICE_DATA_MAX_AGE. Time
+        spent standing down for another client is not counted against that
+        age, though - see foreign_activity. SERVICE_DATA_MAX_AGE guards
+        against a value frozen by a unit that stopped answering, which is
+        indistinguishable from a live one; a pause we chose ourselves is
+        neither indistinguishable nor a fault, and External Control says so
+        while it lasts. Dropping perfectly good readings for it would be a
+        worse answer than carrying them a few minutes longer.
         """
         if self._airco is None:
             return
+        self._settle_service_data_pause()
         now = datetime.now()
         if any(getattr(new_airco, name) is not None for name in SERVICE_DATA_FIELDS):
             self._last_service_data_response = now
@@ -466,6 +623,8 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                     "Operation data from [%s] is being reported again",
                     self.device_name,
                 )
+        elif self.foreign_activity:
+            pass  # Not stale, just paused - carry the values below.
         elif (
             self._last_service_data_response is None
             or now - self._last_service_data_response > SERVICE_DATA_MAX_AGE
@@ -594,19 +753,28 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                     response = await self._api.send_airco_command(
                         self._airco_id, command
                     )
+                except AirconWriteRefusedError:
+                    # Most likely another client's 60-second write lock - the
+                    # Smart M-Air app was used moments ago (#294). Waiting is
+                    # the only thing that helps: our registration is fine, so
+                    # re-registering would just cost a request. One retry, see
+                    # WRITE_LOCK_RETRY_DELAY.
+                    await asyncio.sleep(WRITE_LOCK_RETRY_DELAY.total_seconds())
+                    response = await self._api.send_airco_command(
+                        self._airco_id, command
+                    )
                 except AirconRegistrationError:
-                    # Our operator id fell out of the airco's small account
-                    # table - most likely evicted by the Smart M-Air app or
-                    # another client registering around the same time (#294).
-                    # getAirconStat's own eviction already self-heals via
-                    # update()'s add_account() retry; do the same here instead
-                    # of losing the command outright. One retry only - if the
-                    # table is genuinely full rather than just evicted,
-                    # add_account() has already raised the repair issue for it.
+                    # Our operator id is not in the airco's account table.
+                    # Re-register and try once more rather than losing the
+                    # command outright. If the table is full instead,
+                    # add_account() has already raised the repair issue.
                     await self.add_account()
                     response = await self._api.send_airco_command(
                         self._airco_id, command
                     )
+                # Only a successful write moves the module's `expires`, so
+                # only a successful write may claim the next rise in it.
+                self._wrote_since_last_poll = True
                 new_airco = self._parser.translate_bytes(response)
                 self._carry_forward_home_leave_mode(new_airco)
                 self._carry_forward_service_data(new_airco)

--- a/custom_components/mitsubishi_wf_rac/entity.py
+++ b/custom_components/mitsubishi_wf_rac/entity.py
@@ -15,7 +15,7 @@ from .const import (
     CONF_TARGET_OFFSET_HEAT,
     HVAC_TRANSLATION,
 )
-from .wfrac.device import Device
+from .coordinator import Device
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues",
   "requirements": [],
-  "version": "2026.9.5",
+  "version": "2026.9.6-beta1",
   "zeroconf": [
     "_beaver._tcp.local."
   ]

--- a/custom_components/mitsubishi_wf_rac/number.py
+++ b/custom_components/mitsubishi_wf_rac/number.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MitsubishiWfRacConfigEntry
 from .entity import WfRacEntity
-from .wfrac.device import Device
+from .coordinator import Device
 from .wfrac.models.aircon import HomeLeaveModeSetting
 from .const import DOMAIN
 

--- a/custom_components/mitsubishi_wf_rac/quality_scale.yaml
+++ b/custom_components/mitsubishi_wf_rac/quality_scale.yaml
@@ -1,0 +1,93 @@
+rules:
+  # Bronze
+  action-setup: done
+  appropriate-polling: done
+  brands:
+    status: todo
+    comment: >-
+      Needs an entry in home-assistant/brands moved from custom_integrations/
+      to core_integrations/ - relevant only for a Home Assistant Core
+      submission.
+  common-modules: done
+  config-flow: done
+  config-flow-test-coverage: done
+  dependency-transparency: done
+  docs-actions:
+    status: todo
+    comment: >-
+      Three of five entity services (request_home_leave_mode_status,
+      set_home_leave_mode, set_energy_total) are documented with what they do
+      and linked from the README; set_horizontal_swing_mode and
+      set_vertical_swing_mode are only named in a migration note, not
+      described.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters:
+    status: todo
+    comment: >-
+      The Installation section doesn't describe what the initial config-flow
+      form (host, port, name) asks for.
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: >-
+      No credentials to renew - the operatorId registration is a device-side
+      account slot, not a login.
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery: done
+  discovery-update-info: done
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
+  dynamic-devices:
+    status: exempt
+    comment: One device per config entry; no dynamically appearing sub-devices.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow: done
+  repair-issues: done
+  stale-devices:
+    status: exempt
+    comment: One device per config entry; nothing goes stale independently of it.
+
+  # Platinum
+  async-dependency:
+    status: exempt
+    comment: >-
+      No third-party library yet - repository.py talks to aiohttp directly.
+      Becomes applicable once the protocol code moves into its own library.
+  inject-websession:
+    status: exempt
+    comment: >-
+      Not applicable for the same reason as async-dependency, but already done
+      right in practice: async_get_clientsession(hass) is used rather than an
+      owned session. Moves to done once pywfrac exists.
+  strict-typing: done

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import WfRacEntity
 from .wfrac.models.aircon import AirconCommands, HomeLeaveModeSetting
-from .wfrac.device import Device
+from .coordinator import Device
 from .const import (
     DOMAIN,
     SWING_HORIZONTAL_MODE_TRANSLATION,

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -34,7 +34,7 @@ from homeassistant.const import (
 from homeassistant.helpers import entity_registry as er
 
 from .entity import WfRacEntity
-from .wfrac.device import Device
+from .coordinator import Device
 from .wfrac.rac_parser import SERVICE_DATA_CODE_BY_FIELD
 from .const import (
     ATTR_TARGET_TEMPERATURE,

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -322,6 +322,9 @@
       },
       "compressor": {
         "name": "Compressor Demand"
+      },
+      "external_control": {
+        "name": "External Control"
       }
     },
     "button": {

--- a/custom_components/mitsubishi_wf_rac/switch.py
+++ b/custom_components/mitsubishi_wf_rac/switch.py
@@ -10,7 +10,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MitsubishiWfRacConfigEntry
-from .wfrac.device import Device
+from .coordinator import Device
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -317,6 +317,9 @@
       },
       "compressor": {
         "name": "Kompressoranforderung"
+      },
+      "external_control": {
+        "name": "Externe Steuerung"
       }
     },
     "update": {

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -317,6 +317,9 @@
       },
       "compressor": {
         "name": "Compressor Demand"
+      },
+      "external_control": {
+        "name": "External Control"
       }
     },
     "switch": {},

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -317,6 +317,9 @@
       },
       "compressor": {
         "name": "圧縮機要求"
+      },
+      "external_control": {
+        "name": "外部からの操作"
       }
     },
     "update": {

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -317,6 +317,9 @@
       },
       "compressor": {
         "name": "Kompresoriaus poreikis"
+      },
+      "external_control": {
+        "name": "Išorinis valdymas"
       }
     },
     "update": {

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -317,6 +317,9 @@
       },
       "compressor": {
         "name": "Compressorvraag"
+      },
+      "external_control": {
+        "name": "Externe bediening"
       }
     },
     "update": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -317,6 +317,9 @@
       },
       "compressor": {
         "name": "压缩机需求"
+      },
+      "external_control": {
+        "name": "外部控制"
       }
     },
     "update": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -317,6 +317,9 @@
       },
       "compressor": {
         "name": "壓縮機需求"
+      },
+      "external_control": {
+        "name": "外部控制"
       }
     },
     "update": {

--- a/custom_components/mitsubishi_wf_rac/update.py
+++ b/custom_components/mitsubishi_wf_rac/update.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MitsubishiWfRacConfigEntry
 from .entity import WfRacEntity
-from .wfrac.device import Device
+from .coordinator import Device
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/mitsubishi_wf_rac/wfrac/device.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/device.py
@@ -22,6 +22,7 @@ from .repository import (
     AirconApiError,
     AirconCommandError,
     AirconConnectionError,
+    AirconRegistrationError,
     Repository,
 )
 
@@ -589,7 +590,23 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
 
             try:
                 command = self._parser.to_base64(airco_stat)
-                response = await self._api.send_airco_command(self._airco_id, command)
+                try:
+                    response = await self._api.send_airco_command(
+                        self._airco_id, command
+                    )
+                except AirconRegistrationError:
+                    # Our operator id fell out of the airco's small account
+                    # table - most likely evicted by the Smart M-Air app or
+                    # another client registering around the same time (#294).
+                    # getAirconStat's own eviction already self-heals via
+                    # update()'s add_account() retry; do the same here instead
+                    # of losing the command outright. One retry only - if the
+                    # table is genuinely full rather than just evicted,
+                    # add_account() has already raised the repair issue for it.
+                    await self.add_account()
+                    response = await self._api.send_airco_command(
+                        self._airco_id, command
+                    )
                 new_airco = self._parser.translate_bytes(response)
                 self._carry_forward_home_leave_mode(new_airco)
                 self._carry_forward_service_data(new_airco)

--- a/custom_components/mitsubishi_wf_rac/wfrac/repository.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/repository.py
@@ -91,6 +91,19 @@ class AirconCommandError(AirconApiError):
     """
 
 
+class AirconRegistrationError(AirconCommandError):
+    """Raised when setAirconStat is refused because our operator id isn't (or
+    no longer is) registered in the airco's account table (result 1/2).
+
+    A distinct subtype so callers can tell this apart from an ordinary
+    refusal and re-register before giving up: the account table has only
+    four slots, and opening the Smart M-Air app or adding a phone can evict
+    an existing registration from it (#294). getAirconStat's own eviction
+    already self-heals via Device.update()'s add_account() retry; this gives
+    the write path the same recovery instead of silently losing the command.
+    """
+
+
 class AirconConnectionError(AirconApiError):
     """Raised when the unit could not be reached at all.
 
@@ -381,4 +394,13 @@ class Repository:
         """send command to the Airco"""
         contents = {"airconId": airco_id, "airconStat": command}
         result = await self._post("setAirconStat", contents)
+        try:
+            code = int(result.get("result", 0))
+        except (TypeError, ValueError):
+            code = 0
+        if code in (1, 2):
+            raise AirconRegistrationError(
+                f"Aircon refused setAirconStat with result {code} "
+                f"({RESULT_CODES.get(code, 'meaning unknown')})"
+            )
         return cast(str, result["contents"]["airconStat"])

--- a/custom_components/mitsubishi_wf_rac/wfrac/repository.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/repository.py
@@ -36,25 +36,33 @@ REQUEST_TIMEOUT = timedelta(seconds=25)
 
 _REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT.total_seconds())
 
-# The `result` field every response carries, as the official app reads it.
-# Anything not listed is reported by number alone.
+# The `result` field every response carries. Anything not listed is reported by
+# number alone.
 #
-# The app reads these on updateAccountInfo, and that is where their wording
-# comes from; the meanings need not be as narrow elsewhere. Code 2 is the one
-# seen so far on setAirconStat, three seconds before the account's own
-# `expires` ran out - the same refusal, but an expired registration rather
-# than a full table, so the message names both.
+# The wording the official app uses for these comes from updateAccountInfo,
+# where the codes really are about the account. On setAirconStat they are not,
+# and taking the app's labels at face value sent us chasing the wrong cause for
+# a while: there, 1/11/12 all mean "the unit declined to apply this", either
+# because another client holds the 60s write lock or because the indoor unit's
+# MCU answered with an error nibble - the two are indistinguishable from
+# outside. Only 2 is still about the account, and it doubles as the module's
+# catch-all for a request its handler rejected for any other reason.
 RESULT_CODES: dict[int, str] = {
     0: "ok",
-    1: "operator id not registered with the unit",
-    2: "the unit refused the account - its table is full, or the registration expired",
+    1: "refused - another client holds the write lock, or the indoor unit declined",
+    2: "refused - operator id not registered with the unit, or the request was rejected",
     10: "internal error in the air conditioner",
-    11: "internal error in the air conditioner",
-    12: "operation prohibited",
+    11: "refused - another client holds the write lock, or the indoor unit declined",
+    12: "refused - another client holds the write lock, or the indoor unit declined",
     20: "firmware update required",
     99: "the unit did not confirm the command within 30s",
     429: "too many requests",
 }
+
+# setAirconStat codes that mean "declined, try again shortly" rather than
+# "your account is not known here". See RESULT_CODES above and
+# AirconWriteRefusedError.
+WRITE_REFUSED_CODES = frozenset({1, 11, 12})
 
 
 def _create_permissive_ssl_context() -> ssl.SSLContext:
@@ -92,15 +100,27 @@ class AirconCommandError(AirconApiError):
 
 
 class AirconRegistrationError(AirconCommandError):
-    """Raised when setAirconStat is refused because our operator id isn't (or
-    no longer is) registered in the airco's account table (result 1/2).
+    """Raised when setAirconStat answers result 2.
 
-    A distinct subtype so callers can tell this apart from an ordinary
-    refusal and re-register before giving up: the account table has only
-    four slots, and opening the Smart M-Air app or adding a phone can evict
-    an existing registration from it (#294). getAirconStat's own eviction
-    already self-heals via Device.update()'s add_account() retry; this gives
-    the write path the same recovery instead of silently losing the command.
+    The account table has four slots and the module never evicts from it, so
+    an operator id that was accepted once stays accepted; this is mostly seen
+    when a slot was never taken, or when the module rejected the request for
+    an unrelated reason (result 2 is also its catch-all - see RESULT_CODES).
+    Re-registering is cheap and fixes the first case, so callers do that once
+    before giving up.
+    """
+
+
+class AirconWriteRefusedError(AirconCommandError):
+    """Raised when setAirconStat answers result 1, 11 or 12.
+
+    The unit accepted the request and declined to carry it out. The usual
+    cause is the module's 60-second write lock: every successful
+    setAirconStat grants the sending deviceId exclusive write access for 60s
+    and refuses everyone else until it lapses, which is what happens when a
+    command is sent moments after someone used the Smart M-Air app (#294).
+    Re-registering cannot help here - the registration is fine, the lock just
+    belongs to someone else - so callers wait and retry instead.
     """
 
 
@@ -398,7 +418,12 @@ class Repository:
             code = int(result.get("result", 0))
         except (TypeError, ValueError):
             code = 0
-        if code in (1, 2):
+        if code in WRITE_REFUSED_CODES:
+            raise AirconWriteRefusedError(
+                f"Aircon refused setAirconStat with result {code} "
+                f"({RESULT_CODES.get(code, 'meaning unknown')})"
+            )
+        if code == 2:
             raise AirconRegistrationError(
                 f"Aircon refused setAirconStat with result {code} "
                 f"({RESULT_CODES.get(code, 'meaning unknown')})"

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -25,7 +25,7 @@ from custom_components.mitsubishi_wf_rac.const import (
     DOMAIN,
     HVAC_TRANSLATION,
 )
-from custom_components.mitsubishi_wf_rac.wfrac.device import Device
+from custom_components.mitsubishi_wf_rac.coordinator import Device
 from custom_components.mitsubishi_wf_rac.wfrac.models.aircon import AirconCommands
 
 

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -20,6 +20,7 @@ from custom_components.mitsubishi_wf_rac.const import DOMAIN
 from custom_components.mitsubishi_wf_rac import coordinator as coordinator_module
 from custom_components.mitsubishi_wf_rac.coordinator import (
     AVAILABILITY_FAILURE_LIMIT_MIN,
+    SERVICE_DATA_MAX_AGE,
     Device,
 )
 from custom_components.mitsubishi_wf_rac.wfrac.models.aircon import (
@@ -45,6 +46,7 @@ from custom_components.mitsubishi_wf_rac.wfrac.repository import (
     AirconCommandError,
     AirconConnectionError,
     AirconRegistrationError,
+    AirconWriteRefusedError,
 )
 
 from ..unit.live_captures import LIVE_CAPTURES
@@ -308,10 +310,9 @@ async def test_set_airco_raises_and_logs_on_send_failure(device):
 
 
 async def test_set_airco_reregisters_and_retries_once_on_registration_error(device):
-    """A write refused because our account fell out of the airco's table
-    (#294 - most likely evicted by the Smart M-Air app registering around the
-    same time) should self-heal like the read path already does, instead of
-    losing the command outright.
+    """A write refused with result 2 - our operator id is not in the airco's
+    account table - should self-heal like the read path already does, instead
+    of losing the command outright.
     """
     device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
     await device.update()
@@ -322,7 +323,7 @@ async def test_set_airco_reregisters_and_retries_once_on_registration_error(devi
     async def _fail_once_then_echo(airco_id, command):
         calls["n"] += 1
         if calls["n"] == 1:
-            raise AirconRegistrationError("result 1")
+            raise AirconRegistrationError("result 2")
         return await _echo_send_airco_command(airco_id, command)
 
     device._api.send_airco_command = AsyncMock(side_effect=_fail_once_then_echo)
@@ -789,6 +790,186 @@ async def test_raw_service_data_sensor_requests_its_segment_code(device, monkeyp
     set_airco.assert_awaited_once_with(
         {AirconCommands.ServiceDataStatusRequest: (code,)}, log_failure=False
     )
+
+
+def _stats_response_with_expires(payload: str, expires: int) -> dict:
+    return _stats_response(payload) | {"expires": expires}
+
+
+async def test_rising_expires_without_our_own_write_is_foreign_activity(device):
+    """The module's `expires` only moves when a setAirconStat succeeds, so a
+    rise we did not cause means another client wrote (#294).
+    """
+    device._api.get_aircon_stats.return_value = _stats_response_with_expires(
+        OFF_PAYLOAD, 1_000
+    )
+    await device.update()
+    assert device.foreign_activity is False
+
+    device._api.get_aircon_stats.return_value = _stats_response_with_expires(
+        OFF_PAYLOAD, 1_060
+    )
+    await device.update()
+
+    assert device.foreign_activity is True
+
+
+async def test_rising_expires_after_our_own_write_is_not_foreign_activity(device):
+    """Our own writes move `expires` too - attributing those to a stranger
+    would pause operation data permanently.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response_with_expires(
+        OFF_PAYLOAD, 1_000
+    )
+    await device.update()
+    device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
+
+    await device.set_airco({AirconCommands.Operation: True})
+
+    device._api.get_aircon_stats.return_value = _stats_response_with_expires(
+        OFF_PAYLOAD, 1_060
+    )
+    await device.update()
+
+    assert device.foreign_activity is False
+
+
+async def test_unchanged_expires_is_not_foreign_activity(device):
+    device._api.get_aircon_stats.return_value = _stats_response_with_expires(
+        OFF_PAYLOAD, 1_000
+    )
+    await device.update()
+    await device.update()
+
+    assert device.foreign_activity is False
+
+
+async def test_missing_expires_field_is_not_foreign_activity(device):
+    """Older firmware may not report it at all; absence must not be read as
+    a stranger writing every single poll.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    await device.update()
+
+    assert device.foreign_activity is False
+
+
+async def test_no_service_data_request_while_another_client_is_active(device, monkeypatch):
+    """The operation-data request is a setAirconStat and renews the 60s write
+    lock for another minute. While someone else is using the unit, that lock
+    is exactly what must not be taken (#294).
+    """
+    _shorten_service_data_timing(monkeypatch)
+    _activate_service_data_contexts(device, monkeypatch)
+    device.set_airco = set_airco = AsyncMock()
+    device._foreign_activity_until = datetime.now() + timedelta(minutes=3)
+
+    device._maybe_request_service_data()
+    await asyncio.sleep(0.05)
+
+    set_airco.assert_not_awaited()
+    assert device._last_service_data_request is None
+
+
+async def test_operation_data_survives_the_pause_instead_of_expiring(device):
+    """A pause we chose is not the same as a unit that stopped answering:
+    SERVICE_DATA_MAX_AGE must not run while we are deliberately not asking,
+    and the readings must not expire the moment it ends either.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    device._airco.CompressorFrequency = 42
+    device._last_service_data_response = datetime.now()
+
+    # Well past MAX_AGE, but the whole time was spent standing down - the
+    # state _detect_foreign_activity() leaves behind when it trips.
+    device._foreign_activity_since = datetime.now() - 2 * SERVICE_DATA_MAX_AGE
+    device._foreign_activity_until = datetime.now() + timedelta(minutes=3)
+    device._last_service_data_response = datetime.now() - 2 * SERVICE_DATA_MAX_AGE
+    await device.update()
+    assert device.airco.CompressorFrequency == 42
+    assert device._service_data_expired is False
+
+    # ...and once it lapses, the age restarts from the resume rather than
+    # expiring the readings on the very next poll.
+    device._foreign_activity_until = datetime.now() - timedelta(seconds=1)
+    await device.update()
+    assert device.airco.CompressorFrequency == 42
+    assert device._service_data_expired is False
+
+
+async def test_operation_data_still_expires_when_the_unit_goes_quiet(device):
+    """The pause exemption must not disarm the guard it is carved out of."""
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    device._airco.CompressorFrequency = 42
+    device._last_service_data_response = datetime.now() - 2 * SERVICE_DATA_MAX_AGE
+
+    await device.update()
+
+    assert device.airco.CompressorFrequency is None
+    assert device._service_data_expired is True
+
+
+async def test_service_data_resumes_once_the_backoff_lapses(device, monkeypatch):
+    _shorten_service_data_timing(monkeypatch)
+    _activate_service_data_contexts(device, monkeypatch)
+    device.set_airco = set_airco = AsyncMock()
+    device._foreign_activity_until = datetime.now() - timedelta(seconds=1)
+
+    device._maybe_request_service_data()
+    await asyncio.sleep(0.05)
+
+    set_airco.assert_awaited_once()
+
+
+async def test_service_data_request_gives_up_immediately_when_refused_as_a_write(
+    device, monkeypatch
+):
+    """A declined write is not worth contesting for an optional sensor read -
+    winning the retry would only mean holding the lock ourselves.
+    """
+    _shorten_service_data_timing(monkeypatch)
+    _activate_service_data_contexts(device, monkeypatch)
+    device.set_airco = set_airco = AsyncMock(
+        side_effect=AirconWriteRefusedError("result 1")
+    )
+
+    device._maybe_request_service_data()
+    await asyncio.sleep(0.05)
+
+    set_airco.assert_awaited_once()
+
+
+async def test_set_airco_waits_and_retries_once_when_the_write_lock_is_held(
+    device, monkeypatch
+):
+    """A user command refused because someone else holds the lock should wait
+    it out and retry - re-registering cannot help, the registration is fine.
+    """
+    monkeypatch.setattr(
+        coordinator_module, "WRITE_LOCK_RETRY_DELAY", timedelta(milliseconds=5)
+    )
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    device._api.update_account_info = AsyncMock(return_value={"result": 0})
+
+    calls = {"n": 0}
+
+    async def _fail_once_then_echo(airco_id, command):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise AirconWriteRefusedError("result 1")
+        return await _echo_send_airco_command(airco_id, command)
+
+    device._api.send_airco_command = AsyncMock(side_effect=_fail_once_then_echo)
+
+    await device.set_airco({AirconCommands.Operation: True})
+
+    device._api.update_account_info.assert_not_awaited()
+    assert device._api.send_airco_command.await_count == 2
+    assert device.airco.Operation is True
 
 
 async def test_service_data_request_does_not_overlap_an_active_request(device, monkeypatch):

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -17,8 +17,8 @@ from homeassistant.helpers import issue_registry as ir
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.mitsubishi_wf_rac.const import DOMAIN
-from custom_components.mitsubishi_wf_rac.wfrac import device as device_module
-from custom_components.mitsubishi_wf_rac.wfrac.device import (
+from custom_components.mitsubishi_wf_rac import coordinator as coordinator_module
+from custom_components.mitsubishi_wf_rac.coordinator import (
     AVAILABILITY_FAILURE_LIMIT_MIN,
     Device,
 )
@@ -90,13 +90,13 @@ def _shorten_service_data_timing(monkeypatch, offset_ms: int = 5) -> None:
     test can wait out.
     """
     monkeypatch.setattr(
-        device_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5)
+        coordinator_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5)
     )
     monkeypatch.setattr(
-        device_module, "SERVICE_DATA_REQUEST_OFFSET", timedelta(milliseconds=offset_ms)
+        coordinator_module, "SERVICE_DATA_REQUEST_OFFSET", timedelta(milliseconds=offset_ms)
     )
     monkeypatch.setattr(
-        device_module, "SERVICE_DATA_RETRY_DELAY", timedelta(milliseconds=5)
+        coordinator_module, "SERVICE_DATA_RETRY_DELAY", timedelta(milliseconds=5)
     )
 
 
@@ -150,7 +150,7 @@ async def test_update_transient_unreachable_is_debug_only(device, caplog):
     bare connection failure there is nothing to re-register against, and the
     hourly WiFi restart these modules do would make it a recurring no-op.
     """
-    caplog.set_level("DEBUG", logger=device_module.__name__)
+    caplog.set_level("DEBUG", logger=coordinator_module.__name__)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
     caplog.clear()
@@ -161,7 +161,7 @@ async def test_update_transient_unreachable_is_debug_only(device, caplog):
 
     assert device.available is True
     device._api.update_account_info.assert_not_awaited()
-    records = [r for r in caplog.records if r.name == device_module.__name__]
+    records = [r for r in caplog.records if r.name == coordinator_module.__name__]
     assert not [r for r in records if r.levelname == "WARNING"]
     assert len(records) == 1
     assert records[0].levelname == "DEBUG"
@@ -174,7 +174,7 @@ async def test_update_transient_unreachable_is_debug_only(device, caplog):
 
 
 async def test_update_sustained_unreachable_logs_one_transition(device, caplog):
-    caplog.set_level("DEBUG", logger=device_module.__name__)
+    caplog.set_level("DEBUG", logger=coordinator_module.__name__)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
     caplog.clear()
@@ -190,7 +190,7 @@ async def test_update_sustained_unreachable_logs_one_transition(device, caplog):
     warnings = [
         r
         for r in caplog.records
-        if r.name == device_module.__name__ and r.levelname == "WARNING"
+        if r.name == coordinator_module.__name__ and r.levelname == "WARNING"
     ]
     assert len(warnings) == 1
     assert "is unavailable after 3 failed polls" in warnings[0].message
@@ -198,7 +198,7 @@ async def test_update_sustained_unreachable_logs_one_transition(device, caplog):
     assert sum(
         r.exc_info is not None
         for r in caplog.records
-        if r.name == device_module.__name__ and r.levelname == "DEBUG"
+        if r.name == coordinator_module.__name__ and r.levelname == "DEBUG"
     ) == 1
 
 
@@ -214,14 +214,14 @@ async def test_update_initially_unreachable_logs_threshold_once(device, caplog):
     warnings = [
         r
         for r in caplog.records
-        if r.name == device_module.__name__ and r.levelname == "WARNING"
+        if r.name == coordinator_module.__name__ and r.levelname == "WARNING"
     ]
     assert len(warnings) == 1
     assert "is unavailable after 3 failed polls" in warnings[0].message
 
 
 async def test_update_recovery_is_logged_once(device, caplog):
-    caplog.set_level("INFO", logger=device_module.__name__)
+    caplog.set_level("INFO", logger=coordinator_module.__name__)
     device._api.get_aircon_stats.side_effect = AirconConnectionError("no route")
     for _ in range(3):
         await device.update()
@@ -235,7 +235,7 @@ async def test_update_recovery_is_logged_once(device, caplog):
     recoveries = [
         r
         for r in caplog.records
-        if r.name == device_module.__name__
+        if r.name == coordinator_module.__name__
         and r.levelname == "INFO"
         and "is available again" in r.message
     ]
@@ -418,7 +418,7 @@ async def test_set_airco_lock_prevents_stale_snapshot_race(device):
 
 
 async def test_async_queue_command_coalesces_into_one_send(device, monkeypatch):
-    monkeypatch.setattr(device_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
+    monkeypatch.setattr(coordinator_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
     device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
     await device.update()
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
@@ -434,7 +434,7 @@ async def test_async_queue_command_coalesces_into_one_send(device, monkeypatch):
 
 
 async def test_async_queue_command_notifies_listeners(device, monkeypatch):
-    monkeypatch.setattr(device_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
+    monkeypatch.setattr(coordinator_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
     device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
     await device.update()
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
@@ -456,7 +456,7 @@ async def test_async_queue_command_notifies_listeners(device, monkeypatch):
 
 
 async def test_async_queue_command_notifies_listeners_even_on_failure(device, monkeypatch):
-    monkeypatch.setattr(device_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
+    monkeypatch.setattr(coordinator_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
     device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
     await device.update()
     device._api.send_airco_command = AsyncMock(
@@ -484,7 +484,7 @@ async def test_home_leave_mode_status_request_does_not_swallow_a_queued_command(
     change) went out unset and was silently ignored by the unit. Sending the
     status request directly through set_airco() keeps it out of that merge.
     """
-    monkeypatch.setattr(device_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
+    monkeypatch.setattr(coordinator_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
     device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
     await device.update()
     sent = []
@@ -632,7 +632,7 @@ async def test_update_does_not_check_firmware_when_disabled_by_default(device, m
     # firmware_update_check option (see const.py's CONF_FIRMWARE_UPDATE_CHECK).
     assert device.firmware_update_check_enabled is False
     fetch = AsyncMock(return_value={"wireless": "026", "mcu": "200"})
-    monkeypatch.setattr(device_module, "fetch_latest_firmware", fetch)
+    monkeypatch.setattr(coordinator_module, "fetch_latest_firmware", fetch)
     device._api.get_aircon_stats.return_value = _stats_response_with_firmware(
         ON_COOL_PAYLOAD, "WF-RAC-HTTPS", "025"
     )
@@ -648,7 +648,7 @@ async def test_update_does_not_check_firmware_when_disabled_by_default(device, m
 async def test_update_detects_available_firmware_update(device, monkeypatch):
     device._firmware_update_check_enabled = True
     fetch = AsyncMock(return_value={"wireless": "026", "mcu": "200"})
-    monkeypatch.setattr(device_module, "fetch_latest_firmware", fetch)
+    monkeypatch.setattr(coordinator_module, "fetch_latest_firmware", fetch)
     device._api.get_aircon_stats.return_value = _stats_response_with_firmware(
         ON_COOL_PAYLOAD, "WF-RAC-HTTPS", "025"
     )
@@ -668,7 +668,7 @@ async def test_update_does_not_flag_downgrade_or_equal_version_as_update(device,
     # reported as an available update.
     device._firmware_update_check_enabled = True
     fetch = AsyncMock(return_value={"wireless": "025", "mcu": "200"})
-    monkeypatch.setattr(device_module, "fetch_latest_firmware", fetch)
+    monkeypatch.setattr(coordinator_module, "fetch_latest_firmware", fetch)
     device._api.get_aircon_stats.return_value = _stats_response_with_firmware(
         ON_COOL_PAYLOAD, "WF-RAC-HTTPS", "025"
     )
@@ -682,7 +682,7 @@ async def test_update_does_not_flag_downgrade_or_equal_version_as_update(device,
 async def test_update_firmware_check_is_rate_limited(device, monkeypatch):
     device._firmware_update_check_enabled = True
     fetch = AsyncMock(return_value={"wireless": "026", "mcu": "200"})
-    monkeypatch.setattr(device_module, "fetch_latest_firmware", fetch)
+    monkeypatch.setattr(coordinator_module, "fetch_latest_firmware", fetch)
     device._api.get_aircon_stats.return_value = _stats_response_with_firmware(
         ON_COOL_PAYLOAD, "WF-RAC-HTTPS", "025"
     )
@@ -698,7 +698,7 @@ async def test_update_firmware_check_is_rate_limited(device, monkeypatch):
 async def test_update_firmware_check_failure_leaves_state_unknown(device, monkeypatch):
     device._firmware_update_check_enabled = True
     fetch = AsyncMock(return_value=None)
-    monkeypatch.setattr(device_module, "fetch_latest_firmware", fetch)
+    monkeypatch.setattr(coordinator_module, "fetch_latest_firmware", fetch)
     device._api.get_aircon_stats.return_value = _stats_response_with_firmware(
         ON_COOL_PAYLOAD, "WF-RAC-HTTPS", "025"
     )
@@ -714,7 +714,7 @@ async def test_update_firmware_check_failure_leaves_state_unknown(device, monkey
 
 
 async def test_update_does_not_request_service_data_without_active_entities(device, monkeypatch):
-    monkeypatch.setattr(device_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
+    monkeypatch.setattr(coordinator_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
 
@@ -812,7 +812,7 @@ async def test_add_account_returns_none_on_api_error(device):
 
 def _issue(device):
     return ir.async_get(device._hass).async_get_issue(
-        DOMAIN, device_module.registration_full_issue_id(device.config_entry.entry_id)
+        DOMAIN, coordinator_module.registration_full_issue_id(device.config_entry.entry_id)
     )
 
 
@@ -1013,7 +1013,7 @@ async def test_service_data_survives_a_poll_that_answered_early(device, monkeypa
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
     device._last_service_data_request = datetime.now() - (
-        device_module.SERVICE_DATA_REQUEST_INTERVAL - timedelta(milliseconds=100)
+        coordinator_module.SERVICE_DATA_REQUEST_INTERVAL - timedelta(milliseconds=100)
     )
 
     await device.update()
@@ -1036,7 +1036,7 @@ async def test_async_update_data_wraps_exception_in_update_failed(device):
 async def test_coordinator_tracks_transient_failure_without_regular_log_noise(
     device, caplog
 ):
-    caplog.set_level("DEBUG", logger=device_module.__name__)
+    caplog.set_level("DEBUG", logger=coordinator_module.__name__)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.async_refresh()
     caplog.clear()
@@ -1087,7 +1087,7 @@ async def test_coordinator_notifies_when_device_reaches_unavailable_threshold(de
 
 
 async def test_coordinator_still_logs_unexpected_failures(device, caplog):
-    caplog.set_level("DEBUG", logger=device_module.__name__)
+    caplog.set_level("DEBUG", logger=coordinator_module.__name__)
 
     async def _boom():
         raise RuntimeError("unexpected")
@@ -1102,8 +1102,8 @@ async def test_coordinator_still_logs_unexpected_failures(device, caplog):
 async def test_async_update_data_counts_timeouts_as_connection_failures(
     device, monkeypatch, caplog
 ):
-    monkeypatch.setattr(device_module, "POLL_TIMEOUT", timedelta(milliseconds=10))
-    caplog.set_level("DEBUG", logger=device_module.__name__)
+    monkeypatch.setattr(coordinator_module, "POLL_TIMEOUT", timedelta(milliseconds=10))
+    caplog.set_level("DEBUG", logger=coordinator_module.__name__)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.async_refresh()
     original_update = device.update
@@ -1124,7 +1124,7 @@ async def test_async_update_data_counts_timeouts_as_connection_failures(
     warnings = [
         record
         for record in caplog.records
-        if record.name == device_module.__name__ and record.levelname == "WARNING"
+        if record.name == coordinator_module.__name__ and record.levelname == "WARNING"
     ]
     assert len(warnings) == 1
     assert "is unavailable after 3 failed polls" in warnings[0].message
@@ -1221,7 +1221,7 @@ async def test_service_data_expires_when_nothing_fresh_arrives(device):
     """
     device._airco.CompressorFrequency = 40.0
     device._last_service_data_response = datetime.now() - (
-        device_module.SERVICE_DATA_MAX_AGE + timedelta(seconds=1)
+        coordinator_module.SERVICE_DATA_MAX_AGE + timedelta(seconds=1)
     )
     new_airco = Aircon()
 
@@ -1234,7 +1234,7 @@ async def test_fresh_service_data_restarts_the_clock(device):
     device._airco.CompressorFrequency = 40.0
     device._airco.HotGasTemp = 50.0
     device._last_service_data_response = datetime.now() - (
-        device_module.SERVICE_DATA_MAX_AGE + timedelta(seconds=1)
+        coordinator_module.SERVICE_DATA_MAX_AGE + timedelta(seconds=1)
     )
     new_airco = Aircon()
     new_airco.CompressorFrequency = 45.0  # this poll carried the segments
@@ -1250,10 +1250,10 @@ async def test_expiring_service_data_warns_once_and_reports_the_recovery(
     device, caplog
 ):
     """The refusals themselves are routine; running out of values is not."""
-    caplog.set_level("DEBUG", logger=device_module.__name__)
+    caplog.set_level("DEBUG", logger=coordinator_module.__name__)
     device._airco.CompressorFrequency = 40.0
     device._last_service_data_response = datetime.now() - (
-        device_module.SERVICE_DATA_MAX_AGE + timedelta(seconds=1)
+        coordinator_module.SERVICE_DATA_MAX_AGE + timedelta(seconds=1)
     )
 
     for _ in range(3):
@@ -1278,7 +1278,7 @@ async def test_service_data_that_never_arrived_stays_quiet_until_it_is_due(
     device, caplog
 ):
     """A unit asked for the first time has nothing to lose yet."""
-    caplog.set_level("DEBUG", logger=device_module.__name__)
+    caplog.set_level("DEBUG", logger=coordinator_module.__name__)
     device._last_service_data_request = datetime.now()
 
     device._carry_forward_service_data(Aircon())

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -44,6 +44,7 @@ from custom_components.mitsubishi_wf_rac.wfrac.repository import (
     AirconApiError,
     AirconCommandError,
     AirconConnectionError,
+    AirconRegistrationError,
 )
 
 from ..unit.live_captures import LIVE_CAPTURES
@@ -304,6 +305,53 @@ async def test_set_airco_raises_and_logs_on_send_failure(device):
 
     with pytest.raises(AirconApiError):
         await device.set_airco({AirconCommands.Operation: True})
+
+
+async def test_set_airco_reregisters_and_retries_once_on_registration_error(device):
+    """A write refused because our account fell out of the airco's table
+    (#294 - most likely evicted by the Smart M-Air app registering around the
+    same time) should self-heal like the read path already does, instead of
+    losing the command outright.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    device._api.update_account_info = AsyncMock(return_value={"result": 0})
+
+    calls = {"n": 0}
+
+    async def _fail_once_then_echo(airco_id, command):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise AirconRegistrationError("result 1")
+        return await _echo_send_airco_command(airco_id, command)
+
+    device._api.send_airco_command = AsyncMock(side_effect=_fail_once_then_echo)
+
+    await device.set_airco({AirconCommands.Operation: True})
+
+    device._api.update_account_info.assert_awaited_once()
+    assert device._api.send_airco_command.await_count == 2
+    assert device.airco.Operation is True
+
+
+async def test_set_airco_gives_up_after_one_retry_if_still_refused(device):
+    """The table can be genuinely full rather than just evicted - retrying
+    forever would just hammer the unit. add_account() already raises the
+    repair issue for that case (#287); this should still fail (and log) like
+    any other refused write, not loop.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    device._api.update_account_info = AsyncMock(return_value={"result": 2})
+    device._api.send_airco_command = AsyncMock(
+        side_effect=AirconRegistrationError("result 2")
+    )
+
+    with pytest.raises(AirconRegistrationError):
+        await device.set_airco({AirconCommands.Operation: True})
+
+    device._api.update_account_info.assert_awaited_once()
+    assert device._api.send_airco_command.await_count == 2
 
 
 async def test_set_airco_fetches_state_first_if_unset(device):

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -13,7 +13,7 @@ from custom_components.mitsubishi_wf_rac.diagnostics import (
     async_get_config_entry_diagnostics,
 )
 from custom_components.mitsubishi_wf_rac.wfrac.capabilities import ModelCapabilities
-from custom_components.mitsubishi_wf_rac.wfrac.device import Device
+from custom_components.mitsubishi_wf_rac.coordinator import Device
 from custom_components.mitsubishi_wf_rac.wfrac.models.aircon import (
     Aircon,
     HomeLeaveModeSetting,

--- a/tests/integration/test_entity.py
+++ b/tests/integration/test_entity.py
@@ -15,7 +15,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.mitsubishi_wf_rac.button import EnergyTotalResetButton
 from custom_components.mitsubishi_wf_rac.const import DOMAIN
 from custom_components.mitsubishi_wf_rac.entity import WfRacEntity
-from custom_components.mitsubishi_wf_rac.wfrac.device import Device
+from custom_components.mitsubishi_wf_rac.coordinator import Device
 
 
 @pytest.fixture

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -1,6 +1,7 @@
 """Current entity-platform behaviour pinned to parsed live device state."""
 
 from dataclasses import replace
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -96,6 +97,7 @@ async def test_platform_entity_composition_and_metadata(hass, platform_device, m
     assert details[f"{DOMAIN}-airco-id-problem"] == (True, EntityCategory.DIAGNOSTIC)
     assert details[f"{DOMAIN}-airco-id-compressor"] == (True, None)
     assert details[f"{DOMAIN}-airco-id-occupancy"] == (True, None)
+    assert details[f"{DOMAIN}-airco-id-external-control"] == (True, EntityCategory.DIAGNOSTIC)
     assert details[f"{DOMAIN}-airco-id-home-leave-cooling-temp_rule-number"] == (False, None)
     assert details[f"{DOMAIN}-airco-id-home-leave-heating-air-flow-select"] == (False, None)
     operation_data_sensors = [entity for entity in entities if isinstance(entity, sensor.ServiceDataSensor)]
@@ -163,6 +165,22 @@ async def test_registry_cleanup_removes_only_named_entities(hass, platform_devic
     helper(hass, platform_device)
     assert all(registry.async_get(entity_id) is None for entity_id in expected)
     assert registry.async_get(survivor) is not None
+
+
+async def test_external_control_sensor_follows_the_backoff(platform_device):
+    """The only thing a user would otherwise see while we hold back is the
+    operation-data sensors going unknown, with no stated reason (#294).
+    """
+    entity = binary_sensor.ExternalControlBinarySensor(platform_device)
+    assert entity.is_on is False
+
+    platform_device._foreign_activity_until = datetime.now() + timedelta(minutes=3)
+    entity._update_state()
+    assert entity.is_on is True
+
+    platform_device._foreign_activity_until = datetime.now() - timedelta(seconds=1)
+    entity._update_state()
+    assert entity.is_on is False
 
 
 @pytest.mark.parametrize("capture, mode, action", [

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -29,7 +29,7 @@ from custom_components.mitsubishi_wf_rac.const import (
     SWING_HORIZONTAL_MODE_TRANSLATION,
     SWING_MODE_TRANSLATION,
 )
-from custom_components.mitsubishi_wf_rac.wfrac.device import Device
+from custom_components.mitsubishi_wf_rac.coordinator import Device
 from custom_components.mitsubishi_wf_rac.wfrac.models.aircon import AirconCommands, HomeLeaveModeSetting
 
 from ..unit.live_captures import LIVE_CAPTURES

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -22,7 +22,7 @@ from custom_components.mitsubishi_wf_rac.const import (
     CONF_AVAILABILITY_RETRY_LIMIT,
     DOMAIN,
 )
-from custom_components.mitsubishi_wf_rac.wfrac.device import registration_full_issue_id
+from custom_components.mitsubishi_wf_rac.coordinator import registration_full_issue_id
 
 _DATA = {
     "name": "Living Room AC",
@@ -138,7 +138,7 @@ async def test_remove_entry_clears_the_registration_full_repair_issue(hass: Home
     )
 
     with patch(
-        "custom_components.mitsubishi_wf_rac.wfrac.device.Repository",
+        "custom_components.mitsubishi_wf_rac.coordinator.Repository",
         return_value=AsyncMock(),
     ):
         await async_remove_entry(hass, entry)

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -20,6 +20,7 @@ from custom_components.mitsubishi_wf_rac.wfrac.repository import (
     REQUEST_TIMEOUT,
     AirconCommandError,
     AirconConnectionError,
+    AirconRegistrationError,
     Repository,
 )
 
@@ -232,6 +233,33 @@ async def test_refusal_in_the_result_field_is_reported_once(repository, caplog):
     await repo.get_aircon_stats("airco-id")
 
     assert len([r for r in caplog.records if r.levelname == "WARNING"]) == 2
+
+
+@pytest.mark.parametrize("code", [1, 2])
+async def test_send_airco_command_raises_on_registration_result_codes(
+    repository, code
+):
+    """Unlike getAirconStat (asserted above), setAirconStat refusing because
+    our account isn't registered (result 1/2) must be visible to the caller
+    rather than swallowed - Device.set_airco() relies on this to re-register
+    and retry instead of losing the command (#294).
+    """
+    refused = json.dumps({"result": code, "contents": {"airconStat": "AAA="}})
+    repo, _ = repository([_FakeResponse(200, refused)])
+
+    with pytest.raises(AirconRegistrationError):
+        await repo.send_airco_command("airco-id", "cmd")
+
+
+async def test_send_airco_command_does_not_raise_on_unrelated_result_code(repository):
+    """Result 12 ("operation prohibited") isn't a registration problem, so it
+    must not trigger the re-register-and-retry path - just the existing
+    logged-but-not-acted-on refusal.
+    """
+    refused = json.dumps({"result": 12, "contents": {"airconStat": "AAA="}})
+    repo, _ = repository([_FakeResponse(200, refused)])
+
+    assert await repo.send_airco_command("airco-id", "cmd") == "AAA="
 
 
 async def test_unknown_result_code_is_still_reported(repository, caplog):

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -21,6 +21,7 @@ from custom_components.mitsubishi_wf_rac.wfrac.repository import (
     AirconCommandError,
     AirconConnectionError,
     AirconRegistrationError,
+    AirconWriteRefusedError,
     Repository,
 )
 
@@ -226,7 +227,7 @@ async def test_refusal_in_the_result_field_is_reported_once(repository, caplog):
 
     warnings = [r for r in caplog.records if r.levelname == "WARNING"]
     assert len(warnings) == 1
-    assert "result 12 (operation prohibited)" in warnings[0].message
+    assert "result 12 (refused - another client holds the write lock" in warnings[0].message
 
     # A success clears it, so a later refusal is worth saying again.
     await repo.get_aircon_stats("airco-id")
@@ -235,28 +236,43 @@ async def test_refusal_in_the_result_field_is_reported_once(repository, caplog):
     assert len([r for r in caplog.records if r.levelname == "WARNING"]) == 2
 
 
-@pytest.mark.parametrize("code", [1, 2])
-async def test_send_airco_command_raises_on_registration_result_codes(
-    repository, code
-):
-    """Unlike getAirconStat (asserted above), setAirconStat refusing because
-    our account isn't registered (result 1/2) must be visible to the caller
-    rather than swallowed - Device.set_airco() relies on this to re-register
-    and retry instead of losing the command (#294).
+async def test_send_airco_command_raises_on_registration_result_code(repository):
+    """Unlike getAirconStat (asserted above), setAirconStat refusing with
+    result 2 must be visible to the caller rather than swallowed -
+    Device.set_airco() relies on this to re-register and retry instead of
+    losing the command (#294).
     """
-    refused = json.dumps({"result": code, "contents": {"airconStat": "AAA="}})
+    refused = json.dumps({"result": 2, "contents": {"airconStat": "AAA="}})
     repo, _ = repository([_FakeResponse(200, refused)])
 
     with pytest.raises(AirconRegistrationError):
         await repo.send_airco_command("airco-id", "cmd")
 
 
-async def test_send_airco_command_does_not_raise_on_unrelated_result_code(repository):
-    """Result 12 ("operation prohibited") isn't a registration problem, so it
-    must not trigger the re-register-and-retry path - just the existing
-    logged-but-not-acted-on refusal.
+@pytest.mark.parametrize("code", [1, 11, 12])
+async def test_send_airco_command_raises_on_write_refusal_codes(repository, code):
+    """1/11/12 mean the unit declined to carry the write out - usually
+    another client's 60s write lock (#294). They must reach the caller as
+    their own error type: waiting and retrying helps, re-registering does
+    not.
     """
-    refused = json.dumps({"result": 12, "contents": {"airconStat": "AAA="}})
+    refused = json.dumps({"result": code, "contents": {"airconStat": "AAA="}})
+    repo, _ = repository([_FakeResponse(200, refused)])
+
+    with pytest.raises(AirconWriteRefusedError):
+        await repo.send_airco_command("airco-id", "cmd")
+
+    # ...and not as the registration error, which would send set_airco() down
+    # the pointless re-register path.
+    assert not issubclass(AirconWriteRefusedError, AirconRegistrationError)
+
+
+async def test_send_airco_command_does_not_raise_on_unrelated_result_code(repository):
+    """Result 10 is an internal error in the unit, not something either
+    recovery path can act on - just the existing logged-but-not-acted-on
+    refusal.
+    """
+    refused = json.dumps({"result": 10, "contents": {"airconStat": "AAA="}})
     repo, _ = repository([_FakeResponse(200, refused)])
 
     assert await repo.send_airco_command("airco-id", "cmd") == "AAA="

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -14,7 +14,7 @@ import pytest
 from aiohttp import ClientConnectionError
 
 from custom_components.mitsubishi_wf_rac.const import MIN_TIME_BETWEEN_UPDATES
-from custom_components.mitsubishi_wf_rac.wfrac.device import POLL_TIMEOUT
+from custom_components.mitsubishi_wf_rac.coordinator import POLL_TIMEOUT
 from custom_components.mitsubishi_wf_rac.wfrac.repository import (
     MIN_TIME_BETWEEN_REQUESTS,
     REQUEST_TIMEOUT,


### PR DESCRIPTION
Collects everything queued for `2026.9.6-beta1`.

**The main fix (#294).** Every successful `setAirconStat` grants the sending device 60 seconds of exclusive write access and refuses everyone else until it lapses. The operation-data request is itself a `setAirconStat` — it changes no setting but takes the lock all the same — so at one request per 60s poll against a 60s lock, an enabled diagnostic entity held the lock permanently and left the Smart M-Air app unable to control the unit.

The integration now detects a foreign write from a rise in the reported `expires` timestamp that none of its own writes account for, and pauses operation-data requests for three minutes. The readings hold their last values across the pause instead of expiring, and a new diagnostic `External Control` binary sensor shows when it is happening.

This also corrects what the previous release said about the account table: registrations are never evicted, and a full table refuses the *new* client rather than displacing an existing one. Only result `2` is about the account at all; `1`, `11` and `12` mean "declined, wait and retry", so they now get their own error type and no longer trigger a pointless re-registration.

**Also included**
- The commit from #295, with its message corrected — it described the eviction mechanism that turns out not to exist.
- `wfrac/device.py` → `coordinator.py`, where Home Assistant core expects it. Purely structural, but it moves a lot of code, hence a beta first.
- `quality_scale.yaml`, and a README section on removing the integration.

294 tests pass, mypy clean.