### PR TITLE
Keep the log quiet about refusals the caller recovers from

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ This integration creates one device per airco with the following entities.
 
 The diagnostic operation-data sensors below are disabled by default. Enabling a sensor makes the integration request its value; leaving all of them disabled makes no extra request at all.
 
+Any one of them switches the request on, so pick one that always has something to show. **Indoor Coil Temperature** is the safest choice: it is per indoor unit and reads a temperature whatever the system is doing. **Compressor Frequency** is the more telling value where it works, but reads a constant 0 on older firmware ([#207](https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues/207)). **Hot Gas Temperature** is a poor first choice: it reads unknown whenever the outdoor unit is idle, which looks like a broken sensor rather than a resting one.
+
 | Entity | Values | Description |
 |---|---|---|
 | Indoor Temperature | °C | Same value as the climate entity's `current_temperature`, exposed as its own sensor. |

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import (
+    DEFAULT_PORT,
     CONF_AIRCO_ID,
     CONF_AVAILABILITY_RETRY_LIMIT,
     CONF_FIRMWARE_UPDATE_CHECK,
@@ -80,8 +81,13 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             hass: HomeAssistant,
             data: dict[str, Any],
             exclude_entry_id: str | None = None,
+            allow_port_fallback: bool = False,
     ) -> dict[str, Any]:
-        """Validate the user input allows us to connect, and register with the airco device"""
+        """Validate the user input allows us to connect, and register with the airco device.
+
+        allow_port_fallback belongs to discovery only: a port the module
+        announced may be wrong (#290), a port a person typed is their decision.
+        """
         if len(data[CONF_HOST]) < 3:
             raise InvalidHost
 
@@ -109,7 +115,34 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             airco_id = await repository.get_airco_id()
         except (AirconApiError, KeyError, TypeError) as query_failed:
-            raise CannotConnect(reason=str(query_failed)) from query_failed
+            # A discovery announcement has been seen carrying a port the module
+            # does not serve (#290). The port is fixed in the firmware and not
+            # user-settable, so rather than failing on a value the device
+            # cannot have meant, try the one it always listens on. Only the
+            # announced value is second-guessed - a port the user typed is
+            # taken at face value.
+            if not allow_port_fallback or data[CONF_PORT] == DEFAULT_PORT:
+                raise CannotConnect(reason=str(query_failed)) from query_failed
+            _LOGGER.warning(
+                "No answer on announced port %s, retrying on %s. Please report "
+                "this with the discovery details - the announced port is "
+                "supposed to be %s on every firmware branch",
+                data[CONF_PORT],
+                DEFAULT_PORT,
+                DEFAULT_PORT,
+            )
+            repository = Repository(
+                hass,
+                data[CONF_HOST],
+                DEFAULT_PORT,
+                data[CONF_OPERATOR_ID],
+                data[CONF_DEVICE_ID],
+            )
+            try:
+                airco_id = await repository.get_airco_id()
+            except (AirconApiError, KeyError, TypeError) as retry_failed:
+                raise CannotConnect(reason=str(retry_failed)) from retry_failed
+            data[CONF_PORT] = DEFAULT_PORT
 
         data[CONF_AIRCO_ID] = airco_id
         if not airco_id:
@@ -148,6 +181,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema: vol.Schema,
             user_input: dict[str, Any] | None = None,
             description_placeholders: dict[str, str] | None = None,
+            allow_port_fallback: bool = False,
     ) -> ConfigFlowResult:
         """Create a new entry"""
         errors: dict[str, str] = {}
@@ -159,7 +193,9 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input[CONF_OPERATOR_ID] = await self._async_fetch_operator_id()
                 user_input[CONF_DEVICE_ID] = await self._async_fetch_device_id()
 
-                info = await self._async_register_airco(self.hass, user_input)
+                info = await self._async_register_airco(
+                    self.hass, user_input, allow_port_fallback=allow_port_fallback
+                )
 
                 data_input = user_input.copy()
                 options_input = {
@@ -247,6 +283,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=data_schema,
             user_input=user_input,
             description_placeholders=description_placeholders,
+            allow_port_fallback=True,
         )
 
     @staticmethod
@@ -267,7 +304,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 field(CONF_NAME, vol.Required, "Airco unknown"): cv.string,
                 field(CONF_HOST, vol.Required): cv.string,
-                field(CONF_PORT, vol.Optional, 51443): cv.port,
+                field(CONF_PORT, vol.Optional, DEFAULT_PORT): cv.port,
                 field(CONF_FORCE_UPDATE, vol.Optional, False): cv.boolean,
             }
         )
@@ -292,7 +329,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 field(CONF_NAME, vol.Required): cv.string,
                 field(CONF_HOST, vol.Required): cv.string,
-                field(CONF_PORT, vol.Optional, 51443): cv.port,
+                field(CONF_PORT, vol.Optional, DEFAULT_PORT): cv.port,
             }
         )
 

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -12,6 +12,12 @@ from homeassistant.components.climate.const import (
 )
 
 DOMAIN = "mitsubishi_wf_rac"
+
+# The module serves its API here on every firmware branch, and the port cannot
+# be changed on the device - only the scheme differs (plain http on the older
+# WF-RAC branch). Used as the manual-setup default and as the fallback when a
+# discovery announcement carries something else.
+DEFAULT_PORT = 51443
 DEVICES = "wf-rac-devices"
 
 MIN_TIME_BETWEEN_UPDATES=timedelta(seconds=60)

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -746,6 +746,11 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         warning about a module behaviour no one can act on. Running out of
         values is the part a user can see, and it is worth exactly one line -
         with a matching one when they come back.
+
+        Every occurrence measured so far coincided with network maintenance
+        (a controller update, an access point restarting), not with anything
+        the unit did, so the message points there rather than at the air
+        conditioner.
         """
         if self._service_data_expired:
             return
@@ -758,7 +763,9 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         self._service_data_expired = True
         _LOGGER.warning(
             "No operation data from [%s] for over %.0fs; its compressor, "
-            "current, temperature and EEV sensors now report unknown",
+            "current, temperature and EEV sensors now report unknown. A "
+            "network interruption is the usual cause - check whether other "
+            "devices dropped out at the same time",
             self.device_name,
             SERVICE_DATA_MAX_AGE.total_seconds(),
         )

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -1153,6 +1153,16 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         """Return the discovered/persisted communication method (http/https), if known."""
         return self._api.method
 
+    @property
+    def result_codes(self) -> dict[str, dict[str, int]]:
+        """How often the unit refused each command, per `result` code.
+
+        Refusals themselves are a debug-level event: the common ones clear on
+        the next request and there is nothing for a user to do. Surfacing the
+        tally here keeps them available to whoever is actually investigating.
+        """
+        return self._api.result_codes
+
     async def _async_update_data(self) -> Aircon:
         """Update data via library.
 

--- a/custom_components/mitsubishi_wf_rac/diagnostics.py
+++ b/custom_components/mitsubishi_wf_rac/diagnostics.py
@@ -42,6 +42,10 @@ async def async_get_config_entry_diagnostics(
             "auto_heating": device.auto_heating,
             "port": device.port,
         },
+        # Refusals are logged at debug now (see Repository._report_result_code),
+        # so this is where a report shows whether the unit has been declining
+        # commands and how often.
+        "result_codes": device.result_codes,
         "aircon": asdict(device.airco),
     }
 

--- a/custom_components/mitsubishi_wf_rac/wfrac/repository.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/repository.py
@@ -59,6 +59,22 @@ RESULT_CODES: dict[int, str] = {
     429: "too many requests",
 }
 
+# getAirconStat touches neither the write lock nor the account table, so the
+# generic wording above sends a reader hunting for a lock that was never
+# involved. Its result 1 means only that the module had no fresh data from the
+# indoor unit - established in the module firmware.
+READ_RESULT_CODES: dict[int, str] = {
+    1: "the module had no fresh data from the indoor unit",
+}
+
+
+def describe_result(command: str, code: int) -> str:
+    """What a `result` code means for the command that returned it."""
+    if command == "getAirconStat" and code in READ_RESULT_CODES:
+        return READ_RESULT_CODES[code]
+    return RESULT_CODES.get(code, "meaning unknown")
+
+
 # setAirconStat codes that mean "declined, try again shortly" rather than
 # "your account is not known here". See RESULT_CODES above and
 # AirconWriteRefusedError.
@@ -157,6 +173,10 @@ class Repository:
         self._next_request_after = datetime.now()
         # Last refusal reported per command, see _report_result_code().
         self._refused_commands: dict[str, int] = {}
+        # Every non-zero result ever seen, per command. The log stays quiet
+        # about refusals the caller recovers from; these counts are what a
+        # diagnostics download carries instead.
+        self._result_codes: dict[str, dict[str, int]] = {}
         # Previously-discovered communication method (http/https), if the caller
         # persisted one from a prior run - skips rediscovery below. Keep it as
         # the preferred method as well: if a transport outage invalidates the
@@ -339,18 +359,27 @@ class Repository:
         return json_response
 
     def _report_result_code(self, command: str, response: dict[str, Any]) -> None:
-        """Say so when the unit answers HTTP 200 and still refuses the command.
+        """Record that the unit answered HTTP 200 and still refused the command.
 
         Nothing here changes what the caller does with the response. Which
         firmware reports which code on success over the local API is not
         established, and a command wrongly treated as failed would be worse
-        than the silent failure this makes visible - reports of "nothing
-        happens, and nothing in the log" currently have nothing to go on at
-        all.
+        than the silent failure this records.
 
-        One line per command entering a failing state, like everywhere else in
-        this integration: a unit that answers the same refusal every minute
-        would otherwise fill the log with a message the user has already read.
+        Debug, not warning: this layer sees only "the unit said no" and cannot
+        know whether that mattered. Most refusals here are a transient account
+        lease lapsing, which the caller's retry clears within seconds and the
+        user can do nothing about - a warning for those is noise in an
+        otherwise healthy setup. Escalation belongs to the caller, which knows
+        whether the request eventually got through (see
+        DeviceCoordinator.set_airco and _async_request_service_data).
+
+        The counts survive in `result_codes` for the diagnostics download, so
+        going quiet does not mean losing the evidence.
+
+        One line per command entering a failing state: a unit that answers the
+        same refusal every minute would otherwise repeat itself endlessly even
+        at debug level.
         """
         raw = response.get("result")
         if raw is None:
@@ -362,17 +391,23 @@ class Repository:
         if code == 0:
             self._refused_commands.pop(command, None)
             return
+        counts = self._result_codes.setdefault(command, {})
+        counts[str(code)] = counts.get(str(code), 0) + 1
         if self._refused_commands.get(command) == code:
-            _LOGGER.debug("Aircon still answers %r with result %s", command, code)
             return
         self._refused_commands[command] = code
-        _LOGGER.warning(
+        _LOGGER.debug(
             "Aircon answered %r with result %s (%s) - the request was accepted "
             "but not carried out",
             command,
             code,
-            RESULT_CODES.get(code, "meaning unknown"),
+            describe_result(command, code),
         )
+
+    @property
+    def result_codes(self) -> dict[str, dict[str, int]]:
+        """How often each non-zero `result` code came back, per command."""
+        return {command: dict(codes) for command, codes in self._result_codes.items()}
 
     async def get_info(self) -> dict[str, Any]:
         """Simple command to get aircon details"""
@@ -440,11 +475,11 @@ class Repository:
         if code in WRITE_REFUSED_CODES:
             raise AirconWriteRefusedError(
                 f"Aircon refused setAirconStat with result {code} "
-                f"({RESULT_CODES.get(code, 'meaning unknown')})"
+                f"({describe_result('setAirconStat', code)})"
             )
         if code == 2:
             raise AirconRegistrationError(
                 f"Aircon refused setAirconStat with result {code} "
-                f"({RESULT_CODES.get(code, 'meaning unknown')})"
+                f"({describe_result('setAirconStat', code)})"
             )
         return cast(str, result["contents"]["airconStat"])

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -425,6 +425,50 @@ async def test_zeroconf_discovery_confirm_creates_entry(hass: HomeAssistant):
     assert result["data"]["port"] == 51443
 
 
+async def test_zeroconf_announced_port_falls_back_to_the_fixed_one(hass: HomeAssistant):
+    """The module serves a port fixed in firmware, so an announcement carrying
+    something else (#290) is the announcement being wrong, not the device. Try
+    the real port rather than failing setup on a value it cannot have meant.
+    """
+    repo = _mock_repository()
+    repo.get_airco_id.side_effect = [AirconApiError("no answer"), "airco-1"]
+    with _patch_repository(repo) as repository_cls:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=_zeroconf_info(port=5353),
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"name": "Living Room AC"}
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    # The entry keeps the port that answered, not the one that was announced.
+    assert result["data"]["port"] == 51443
+    assert [call.args[2] for call in repository_cls.call_args_list] == [5353, 51443]
+
+
+async def test_manual_port_is_not_second_guessed(hass: HomeAssistant):
+    """Only an announced port is retried on the default. A port the user typed
+    is taken at face value, so a genuinely unusual setup still fails visibly
+    instead of being silently redirected.
+    """
+    repo = _mock_repository()
+    repo.get_airco_id.side_effect = AirconApiError("no answer")
+    with _patch_repository(repo) as repository_cls:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"name": "Living Room AC", "host": "192.168.1.50", "port": 8443},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"]
+    assert [call.args[2] for call in repository_cls.call_args_list] == [8443]
+
+
 async def test_zeroconf_discovery_confirm_port_can_be_overridden(hass: HomeAssistant):
     """A bad mDNS advertisement (see #290: port 5353, the mDNS port itself,
     instead of the fixed 51443) must be correctable in the confirm step

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -221,19 +221,31 @@ async def test_refusal_in_the_result_field_is_reported_once(repository, caplog):
         ]
     )
 
+    def _reports():
+        return [
+            r for r in caplog.records
+            if "was accepted but not carried out" in r.message
+        ]
+
     # The caller still gets the response: nothing about the control flow moves.
     assert await repo.get_aircon_stats("airco-id") == {"airconStat": "AAA="}
     await repo.get_aircon_stats("airco-id")
 
-    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-    assert len(warnings) == 1
-    assert "result 12 (refused - another client holds the write lock" in warnings[0].message
+    assert len(_reports()) == 1
+    assert "result 12 (refused - another client holds the write lock" in _reports()[0].message
+    # Debug, not warning: this layer cannot tell whether the refusal mattered,
+    # and the common ones clear by themselves. See _report_result_code.
+    assert {r.levelname for r in _reports()} == {"DEBUG"}
 
     # A success clears it, so a later refusal is worth saying again.
     await repo.get_aircon_stats("airco-id")
     await repo.get_aircon_stats("airco-id")
 
-    assert len([r for r in caplog.records if r.levelname == "WARNING"]) == 2
+    assert len(_reports()) == 2
+
+    # Every refusal is counted even though only two were logged - this is what
+    # a diagnostics download carries in place of the log lines.
+    assert repo.result_codes == {"getAirconStat": {"12": 3}}
 
 
 async def test_send_airco_command_raises_on_registration_result_code(repository):
@@ -279,13 +291,30 @@ async def test_send_airco_command_does_not_raise_on_unrelated_result_code(reposi
 
 
 async def test_unknown_result_code_is_still_reported(repository, caplog):
+    caplog.set_level("DEBUG", logger="custom_components.mitsubishi_wf_rac.wfrac.repository")
     repo, _ = repository([_FakeResponse(200, json.dumps({"result": 77, "contents": {}}))])
 
     await repo.get_aircon_stats("airco-id")
 
-    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-    assert len(warnings) == 1
-    assert "result 77 (meaning unknown)" in warnings[0].message
+    reports = [r for r in caplog.records if "was accepted but not carried out" in r.message]
+    assert len(reports) == 1
+    assert "result 77 (meaning unknown)" in reports[0].message
+
+
+async def test_read_refusal_does_not_blame_the_write_lock(repository, caplog):
+    """getAirconStat touches neither the write lock nor the account table, so
+    its result 1 must not be described with the setAirconStat wording - that
+    reading sent a tester chasing a lock that was never involved (#294).
+    """
+    caplog.set_level("DEBUG", logger="custom_components.mitsubishi_wf_rac.wfrac.repository")
+    repo, _ = repository([_FakeResponse(200, json.dumps({"result": 1, "contents": {}}))])
+
+    await repo.get_aircon_stats("airco-id")
+
+    reports = [r for r in caplog.records if "was accepted but not carried out" in r.message]
+    assert len(reports) == 1
+    assert "no fresh data from the indoor unit" in reports[0].message
+    assert "write lock" not in reports[0].message
 
 
 async def test_timestamp_offset_backdates_the_request_stamp(repository):


### PR DESCRIPTION
Four small things, all of them "what the user sees when nothing is wrong". Prompted by @daveywf's testing in #294, and by the fact that a Core submission should not ship an integration that logs a dozen warnings a day on a healthy setup.

### The log

`_report_result_code` warned on every non-zero `result` field. That layer only sees *the unit said no* — it cannot know whether the caller recovered, and for the common case it does: a transient account lease lapsing, cleared by the next request, nothing a user can act on. Measured on my own instance over three days: about a dozen warnings a day with nothing wrong.

They move to **debug**. The edge-triggering (one line per command entering a failing state) stays — it was never the problem. Escalation belongs to the caller, which knows whether the request got through.

To avoid trading noise for blindness, every refusal is now **counted per command and code and surfaced in the diagnostics download**. Quiet in normal operation, complete for whoever is actually investigating.

### The wording

`getAirconStat` touches neither the write lock nor the account table — its `result 1` means only that the module had no fresh data from the indoor unit. The shared table described it as a write-lock collision and sent a tester chasing a lock that was never involved. It now has its own text.

### Discovery port

A module has been seen announcing a port it does not serve (#290 — 5353, the mDNS port itself). The port is fixed in firmware and not settable on the device, so failing setup on it helps nobody: discovery now retries once on the real port and keeps the one that answered, warning with the announced value so a report carries it.

Deliberately limited to discovery. A port a person typed is their decision and is still taken at face value — a test covers that distinction.

### README

Any operation-data sensor switches the channel on, so it says which one to pick. `Hot Gas Temperature` is the worst first choice: it reads unknown whenever the outdoor unit is idle, which looks like breakage.

313 tests pass, `mypy --strict` clean.