### PR TITLE
Run the HACS repository checks upstream only

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,12 @@ jobs:
   hacs:
     name: HACS
     runs-on: "ubuntu-latest"
+    # Upstream only. Two of this action's checks are about repository
+    # properties rather than the code - topics set, issues enabled - and a
+    # fork has neither by default and cannot be expected to fix that. Running
+    # it there fails every push and every nightly schedule inherited with the
+    # fork, and mails the failures to whoever pushed.
+    if: github.repository == 'blues-sechseck/Mitsubishi-WF-RAC-Integration'
     steps:
       - name: HACS validation
         uses: "hacs/action@main"


### PR DESCRIPTION
Two of the HACS action's nine checks are about repository properties rather than the code: the repository must have topics set and issues enabled. A fork has neither by default, and a contributor cannot reasonably be asked to change that on their own copy — so the job fails on every push to a fork, plus on the nightly schedule the fork inherits, and mails each failure to whoever pushed.

The code-side jobs (Hassfest, Pytest, Mypy) keep running everywhere; only the HACS job is now upstream-only. It still runs on `pull_request` here, where the repository being validated is this one.