### PR TITLE
Safeguard self clean against external sensor write

### DIFF
--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -470,17 +470,12 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
         target_offset = self._resolve_target_offset(mode_from_operation)
 
         self._attr_target_temperature = airco.PresetTemp + target_offset
-        # Report the override only once the unit demonstrably holds it and is
-        # in a mode that regulates on it. An override that is merely armed -
-        # just restored, or waiting out an off/fan_only spell - is not what the
-        # unit is working with, and the unit never reports the injected value
-        # back (it keeps reporting its own return-air reading in a separate
-        # segment), so this is the only place that can tell the two apart.
-        # Deliberately diverges from the Indoor Temperature sensor, which
-        # always shows the unit's own reading.
+        # Show the override whenever it is armed and the unit is in a mode that
+        # actually regulates on a room temperature. Off and fan_only are handled
+        # by the third condition. Deliberately diverges from the Indoor
+        # Temperature sensor, which always shows the unit's own reading.
         if (
             self._external_temperature_override is not None
-            and self._device.external_temperature_applied
             and is_external_temperature_mode(airco.Operation, airco.OperationMode)
         ):
             self._attr_current_temperature = self._external_temperature_override

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -751,6 +751,9 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 )
                 if attempt > 1:
                     _LOGGER.debug("Service data request succeeded on retry")
+                # Push updated state (including external_temperature_applied) to
+                # entities without waiting for the next poll.
+                self.async_set_updated_data(self._airco)
                 return
             except AirconWriteRefusedError as ex:
                 # Someone else may hold the write lock. Unlike a user command

--- a/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
@@ -362,14 +362,15 @@ class RacParser:
         stat_byte = _empty_stat_bytes()
         if not aircon_stat.CoolHotJudge:
             stat_byte[8] |= 8
-        # Status requests preserve any active override regardless of the
-        # current operating mode: the unit stores byte 5 as live state, and
-        # a plain poll while off or in fan_only would otherwise revert it.
-        raw_temperature = self.encode_external_temperature(
-            aircon_stat.ExternalTemperature
-        )
-        if raw_temperature is not None:
-            stat_byte[5] = raw_temperature
+        # External temperature override: only inject in temperature-controlling modes.
+        # Off and fan_only do not regulate temperature, so leaving byte 5 at 0xFF
+        # (internal sensor) is correct for those modes.
+        if self._should_encode_external_temperature(aircon_stat):
+            raw_temperature = self.encode_external_temperature(
+                aircon_stat.ExternalTemperature
+            )
+            if raw_temperature is not None:
+                stat_byte[5] = raw_temperature
         return stat_byte
 
     def command_to_byte(self, aircon_stat: AirconStat) -> bytearray:


### PR DESCRIPTION
Just tested, the self-clean is working with the write guard.

Moreover, I noticed a small bug. Due to some polling timings the indoor temperature of the model card was flickering between the external temperature value and the temperature value that has been read back from the status poll (encoded external temperature + internall applied correction factor by the AC).

