### PR TITLE
Echo the reported model constant in byte 0

### DIFF
--- a/custom_components/mitsubishi_wf_rac/wfrac/models/aircon.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/models/aircon.py
@@ -125,6 +125,11 @@ class Aircon(AirconBase):
 class AirconStat(AirconBase):
     """Aircon (command) class extends AirconBase class"""
 
+    # The receive half of an outgoing frame echoes the model byte verbatim, so
+    # it needs the value the unit actually reported rather than the coarse
+    # ModelNr grouping. None marks a stat built by hand instead of from a
+    # received state - see receive_to_bytes() for what it falls back to.
+    ModelNrRaw: int | None = None
     IsSelfCleanOperation: bool = False
     IsSelfCleanReset: bool = False
     # See AirconCommands - only ever set explicitly via
@@ -149,6 +154,7 @@ class AirconStat(AirconBase):
             PresetTemp=aircon.PresetTemp,
             Entrust=aircon.Entrust,
             ModelNr=aircon.ModelNr,
+            ModelNrRaw=aircon.ModelNrRaw,
             Vacant=aircon.Vacant,
             CoolHotJudge=aircon.CoolHotJudge,
             IsSelfCleanOperation=aircon.IsSelfCleanOperation,

--- a/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
@@ -467,8 +467,15 @@ class RacParser:
         if not aircon_stat.CoolHotJudge:
             stat_byte[8] |= 8
 
-        if aircon_stat.ModelNr in (1, 2):
-            stat_byte[0] |= aircon_stat.ModelNr
+        # The app echoes the true model constant here, including the ones our
+        # ModelNr grouping folds away (3 = ZT, 64 = FDT) - a mismatch in this
+        # byte is what other clients saw rejected with result 12.
+        model_nr_raw = aircon_stat.ModelNrRaw
+        if not isinstance(model_nr_raw, int) or not 0 <= model_nr_raw <= 127:
+            # A stat built by hand carries no reported byte to echo; the coarse
+            # ModelNr stands in, clamped to the protocol's seven-bit field.
+            model_nr_raw = aircon_stat.ModelNr if 0 <= aircon_stat.ModelNr <= 127 else 0
+        stat_byte[0] |= model_nr_raw
 
         if aircon_stat.ModelNr == 1:
             stat_byte[10] |= 1 if aircon_stat.Vacant else 0

--- a/tests/unit/test_rac_parser.py
+++ b/tests/unit/test_rac_parser.py
@@ -497,6 +497,34 @@ def test_receive_to_bytes_entrust_round_trips(parser):
     assert ac.Entrust is True
 
 
+# --- receive_to_bytes(): byte 0 carries the reported model constant -----
+#
+# ModelNr folds ZT (raw 3) onto 2 and leaves anything unrecognised at -1, so
+# echoing it would send a ZT unit a 2 and an FDT unit nothing. The app echoes
+# the reported byte instead, and a mismatch here is what other clients saw
+# answered with result 12.
+
+
+@pytest.mark.parametrize(
+    ("model_nr", "model_nr_raw"),
+    [(1, 1), (2, 2), (2, 3), (-1, 64)],
+)
+def test_receive_to_bytes_preserves_raw_model_byte(parser, model_nr, model_nr_raw):
+    stat = _base_stat(ModelNr=model_nr, ModelNrRaw=model_nr_raw)
+    assert parser.receive_to_bytes(stat)[0] == model_nr_raw
+
+
+@pytest.mark.parametrize(
+    ("model_nr", "expected"),
+    [(1, 1), (2, 2), (0, 0), (-1, 0)],
+)
+def test_receive_to_bytes_falls_back_to_model_nr_without_raw(parser, model_nr, expected):
+    # Only hand-built stats get here - from_aircon() always carries the raw
+    # byte along - and the byte has to stay inside the seven-bit model field.
+    stat = _base_stat(ModelNr=model_nr)
+    assert parser.receive_to_bytes(stat)[0] == expected
+
+
 # --- command_to_byte(): command-direction self-clean encoding -----------
 #
 # IsSelfCleanOperation is *not* part of the round-trip tests above: the


### PR DESCRIPTION
The receive half writes a folded model number into byte 0: ZT-2025 reports raw `3` but goes out as `2`, and FDT-2023 (`64`) goes out as `0`. The official app writes the real constant back (`AirconStatCoder.receiveToByte`), and LabyDev/KazeMBridge reports that exactly this kind of mismatch produced `result: 12` and refused swing commands on a Global 2022 unit.

`AirconStat` carries `ModelNrRaw` for this; the remaining `ModelNr` branches in the encoder stay on the folded value, since those are layout groupings rather than identity. Feature gates hang off `Capabilities` either way, so nothing else changes behaviour.

No symptom has been confirmed on a ZT unit here — this aligns us with the app rather than fixing a reported bug, and it goes in now because it cannot make anything worse and a dev release is the right place to find out.