### PR TITLE
Show what the unit reports under an external override, and read the applied state off the wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ device before saving it.
 | Option | Range | Description |
 |---|---|---|
 | Retry limit | 3 or higher, default 3 | Consecutive failed polls before the device is marked unavailable. At the 60 s poll interval, `3` is about 3 minutes - enough to ride through the module's hourly WiFi reassociation. Raise it on a weak link; it cannot be set lower. |
-| Indoor Temp. Sensor Offset | -15..15 °C | Added to the unit's own indoor-sensor reading before it's shown as `current_temperature` / the Indoor Temperature sensor - display-only, doesn't change what the unit does. |
+| Indoor Temp. Sensor Offset | -15..15 °C | Added to the unit's own indoor-sensor reading before it's shown as `current_temperature` / the Indoor Temperature sensor - display-only, doesn't change what the unit does. Suspended while an external temperature override is in effect: the unit is reporting the value it was given rather than measuring, so there is nothing to calibrate. |
 | Outdoor Temp. Sensor Offset | -15..15 °C | Same, for the Outdoor Temperature sensor. |
 | Target Temp. Offset | -5..5 °C | Calibrates the *setpoint sent to the unit* - see "Target Temp. Offset sign convention" below. Applies to every `hvac_mode` unless overridden by the two options below. |
 | Target Temp. Offset (Cooling) | -5..5 °C, unset by default | Overrides Target Temp. Offset for `cool` and `dry` mode. Leave unset to keep using Target Temp. Offset for those modes too. |
@@ -311,7 +311,7 @@ Feeding the value from an automation on every sensor update is fine and costs no
 
 **While an override is in effect, the unit stops reporting its own sensor.** Measured on hardware: the value you inject comes back on the next cycle as the unit's reported room temperature, half a kelvin above what you sent - the two protocol fields it travels in differ by that much with or without an override. So the Indoor Temperature sensor follows your override as well and is no longer a measurement of the room; keep your own sensor for that. Clearing the override brings the real reading back within a cycle.
 
-The override survives a restart and a reload. It is re-armed, not re-sent: the unit stays on whatever it last received until the next frame goes out, which is why the climate entity's `current_temperature` keeps showing the unit's reported reading until then, and the injected value afterwards.
+The override survives a restart and a reload. It is re-armed, not re-sent: the unit stays on whatever it last received until the next frame goes out. Both `current_temperature` and the Indoor Temperature sensor show what the unit reports throughout, so they agree with each other and with the official app at every point.
 
 # Known limitations
 

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -470,24 +470,17 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
         target_offset = self._resolve_target_offset(mode_from_operation)
 
         self._attr_target_temperature = airco.PresetTemp + target_offset
-        # Report the override once the unit demonstrably holds one and is in a
-        # mode that regulates on it. The unit never echoes the injected value
-        # back - it keeps reporting its own return-air reading in a separate
-        # segment - so this is the only place that can tell an override the
-        # unit has from one that is merely armed and waiting for a frame, as
-        # after a restart. A newer value replacing a live override does not
-        # reset that (see Device.set_external_temperature_override), so this
-        # does not flicker while a sensor feeds it.
-        # Deliberately diverges from the Indoor Temperature sensor, which
-        # always shows the unit's own reading.
-        if (
-            self._external_temperature_override is not None
-            and self._device.external_temperature_applied
-            and is_external_temperature_mode(airco.Operation, airco.OperationMode)
-        ):
-            self._attr_current_temperature = self._external_temperature_override
-        else:
-            self._attr_current_temperature = airco.IndoorTemp + indoor_offset
+        # Always what the unit reports, including while an external override
+        # is in effect - it echoes the injected value back, so the reading
+        # follows the override on its own and the climate entity agrees with
+        # the Indoor Temperature sensor either way.
+        # The calibration offset is what changes: it corrects the unit's own
+        # return-air sensor, which is out of the loop while the unit is
+        # regulating on a value the user supplied. Applying it there would
+        # correct a reading that needs no correcting.
+        self._attr_current_temperature = airco.IndoorTemp + (
+            0.0 if self._device.external_temperature_applied else indoor_offset
+        )
         self._attr_fan_mode = list(FAN_MODE_TRANSLATION.keys())[airco.AirFlow]
         self._attr_swing_mode = (
             SWING_3D_AUTO

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from collections import deque
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from collections.abc import Callable
@@ -275,7 +276,13 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         self._foreign_activity_since: datetime | None = None
         self._service_data_task: asyncio.Task[None] | None = None
         self._external_temperature_override: float | None = None
-        self._external_temperature_applied = False
+        # The byte-5 values recent frames actually carried. Two, not one: a
+        # frame carrying a new value goes out before the unit reports it back,
+        # so during that one cycle the previous value is still the one the
+        # unit is regulating on. Comparing against only the newest would make
+        # external_temperature_applied - and with it the indoor offset - flip
+        # off and on again on every value a source sensor feeds in.
+        self._external_temperature_written: deque[int] = deque(maxlen=2)
         self._external_temperature_carrier: Callable[[], None] | None = None
         self._consecutive_failures = 0
         # Clamped rather than validated: an entry can carry a lower value from
@@ -338,14 +345,11 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         it: a restored value says what we intend to send, not what the unit
         currently regulates on.
 
-        Replacing one override with another leaves that standing, though. The
-        unit is holding an override either way, and the new reading reaches it
-        on the next frame; resetting the flag for every value a source sensor
-        reports would make anything keyed to it flip back and forth at the
-        rate of the automation feeding it.
+        Nothing here says the unit has been told - see
+        external_temperature_applied, which reads that off the wire.
         """
-        if (value is None) != (self._external_temperature_override is None):
-            self._external_temperature_applied = False
+        if value is None:
+            self._external_temperature_written.clear()
         self._external_temperature_override = value
         self._sync_external_temperature_carrier()
 
@@ -386,15 +390,25 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
 
     @property
     def external_temperature_applied(self) -> bool:
-        """Whether a frame carrying the override has actually reached the unit
-        since it was armed.
+        """Whether the unit is currently regulating on a value we supplied.
 
-        False after a restart or reload until the next command or operation-data
-        request goes out, and again whenever a frame writes 0xFF instead (any
-        command sent while off or in fan_only does). Best effort: a command from
-        another controller can revert byte 5 without us seeing it.
+        Read off the wire rather than remembered: the unit echoes an injected
+        value back in byte 5 unchanged, so the byte it reports matching one a
+        recent frame carried is exactly the question - false after a restart
+        until a frame has gone out, false while the unit is off or in fan_only
+        (nothing writes the byte there), and false once another controller
+        takes the unit off the override without telling us.
+
+        One blind spot, and it is harmless: if the room happens to sit within
+        a quarter kelvin of the armed value, the unit's own reading encodes to
+        the same byte and this reads true early. Both branches show the same
+        temperature then, and the calibration offset it suppresses is at most
+        that far from being right anyway.
         """
-        return self._external_temperature_applied
+        if self._external_temperature_override is None or self._airco is None:
+            return False
+        raw = self._airco.ControllerRoomTempRaw
+        return raw is not None and raw in self._external_temperature_written
 
     def _subscribed_service_data_codes(self) -> tuple[int, ...]:
         """Operation-data codes currently subscribed, sorted: one per enabled
@@ -1015,12 +1029,14 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 self._carry_forward_home_leave_mode(new_airco)
                 self._carry_forward_service_data(new_airco)
                 self._airco = new_airco
-                # After the write, not before: until the unit has answered,
-                # nothing says it holds the value (see
-                # external_temperature_applied).
-                self._external_temperature_applied = (
-                    self._parser.carries_external_temperature(airco_stat)
-                )
+                # After the write, and only for what the frame really carried:
+                # a command sent while the unit is off writes the sentinel, not
+                # the override.
+                written = self._parser.external_temperature_raw_in_frame(airco_stat)
+                if written is None:
+                    self._external_temperature_written.clear()
+                else:
+                    self._external_temperature_written.append(written)
             except (AirconApiError, KeyError, TypeError, ValueError) as ex:
                 if log_failure:
                     _LOGGER.warning("Could not send airco data: %s", str(ex))

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -284,7 +284,13 @@ class TemperatureSensor(WfRacEntity, SensorEntity):
     def _update_state(self) -> None:
         if self._custom_type == ATTR_INSIDE_TEMPERATURE:
             indoor_offset = self._device.options.get(CONF_INDOOR_OFFSET, 0.0)
-            self._attr_native_value = self._device.airco.IndoorTemp + indoor_offset
+            # Same rule as the climate entity: the offset calibrates the unit's
+            # own return-air sensor, so it is suspended while the unit is
+            # regulating on an injected value instead (the unit reports that
+            # value back here, see Device.external_temperature_applied).
+            self._attr_native_value = self._device.airco.IndoorTemp + (
+                0.0 if self._device.external_temperature_applied else indoor_offset
+            )
         elif self._custom_type == ATTR_OUTSIDE_TEMPERATURE:
             outdoor_offset = self._device.options.get(CONF_OUTDOOR_OFFSET, 0.0)
             self._attr_native_value = self._device.airco.OutdoorTemp + outdoor_offset

--- a/custom_components/mitsubishi_wf_rac/wfrac/models/aircon.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/models/aircon.py
@@ -74,6 +74,10 @@ class Aircon(AirconBase):
     """Aircon (receive) class extends AirconBase class"""
 
     IndoorTemp: float = 0.0
+    # Raw byte 5 of the receive half: the room temperature the controller is
+    # working with, in 0.25 K steps (raw = round(T * 4) + 61). Compared as a
+    # byte, never displayed - see rac_parser._parse_basic_settings().
+    ControllerRoomTempRaw: int | None = None
     OutdoorTemp: float = 0.0
     Electric: float | None = None
     ErrorCode: str = ""

--- a/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
@@ -225,20 +225,23 @@ class RacParser:
         return is_external_temperature_mode(aircon_stat.Operation, aircon_stat.OperationMode)
 
     @classmethod
-    def carries_external_temperature(cls, aircon_stat: AirconStat) -> bool:
-        """Whether the frame built from this state writes the override into
-        byte 5 - i.e. whether the unit ends up holding it.
+    def external_temperature_raw_in_frame(cls, aircon_stat: AirconStat) -> int | None:
+        """The byte 5 an outgoing frame built from this state actually carries,
+        or None when it carries the 0xFF "use your own sensor" sentinel.
 
-        Status requests carry it unconditionally (they exist to keep it
-        alive); ordinary commands only in a temperature-controlling mode.
-        The coordinator uses this to tell an armed override from one the unit
-        has actually been told about.
+        Status requests carry the override unconditionally (they exist to keep
+        it alive); ordinary commands only in a temperature-controlling mode.
+        The coordinator keeps what went out, because what the unit reports
+        back is only meaningful against the byte it was sent.
         """
         if aircon_stat.ExternalTemperature is None:
-            return False
-        return cls._is_status_request(aircon_stat) or cls._should_encode_external_temperature(
-            aircon_stat
-        )
+            return None
+        if not (
+            cls._is_status_request(aircon_stat)
+            or cls._should_encode_external_temperature(aircon_stat)
+        ):
+            return None
+        return cls.encode_external_temperature(aircon_stat.ExternalTemperature)
 
     def to_base64(self, aircon_stat: AirconStat) -> str:
         """Convert AirconStat to Base64 string."""
@@ -553,13 +556,16 @@ class RacParser:
                 )
         ac_device.Vacant = (content[10] & 1) != 0
         ac_device.CompressorRunning = (content[9] & COMPRESSOR_RUNNING_MASK) != 0
-        # content[5] is deliberately NOT decoded here. On the read path that
-        # byte reports the temperature the controller is currently working
-        # with, whatever its source - the 0xFF "internal sensor" convention
-        # only applies to the write direction. Every unit always reports a
-        # value, so a decoded float cannot distinguish an active external-
-        # temperature override from an ordinary reading. Override state is
-        # tracked integration-side instead (Device._external_temperature_override).
+        # The temperature the controller is working with, whatever its source:
+        # every unit always reports one here, so the value alone says nothing
+        # about where it came from. Kept as the raw byte rather than a float
+        # because its one job is an exact comparison - an injected override
+        # comes back in this byte unchanged, so equality against the byte we
+        # wrote is what tells an override the unit has from one still waiting
+        # for a frame (see Device.external_temperature_applied and reference
+        # doc 5.6). The 0xFF "internal sensor" convention applies to the write
+        # direction only.
+        ac_device.ControllerRoomTempRaw = content[5] & 0xFF
         if ac_device.ModelNr in (1, 2):
             # Mirrors the self-clean bit written in receive_to_bytes() above.
             # No longer exposed as an entity: the real cycle can only be

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -260,10 +260,14 @@ def _service_entity(device) -> AircoClimate:
     return entity
 
 
-def _mark_reached_the_unit(device) -> None:
-    """Stand in for a frame that carried the override, without sending one.
-    The write path's own bookkeeping is covered in test_coordinator.py."""
-    device._external_temperature_applied = True
+def _mark_reached_the_unit(device, temperature: float) -> None:
+    """Put the device in the state that follows a frame carrying the override:
+    the frame recorded what it wrote, byte 5 echoes it back, and the 0.1 K
+    segment carries the same reading."""
+    raw = round(temperature * 4) + 61
+    device._external_temperature_written.append(raw)
+    device.airco.ControllerRoomTempRaw = raw
+    device.airco.IndoorTemp = temperature + 0.5
 
 
 async def test_set_external_temperature_arms_without_sending_anything(device):
@@ -307,7 +311,10 @@ async def test_update_state_uses_indoor_temp_without_override(device):
     assert entity._attr_current_temperature == 23.5
 
 
-async def test_update_state_uses_override_once_the_unit_has_it(device):
+async def test_update_state_shows_what_the_unit_reports_under_an_override(device):
+    # The unit echoes the injected value back, so the reading follows it on its
+    # own. The calibration offset drops out: it corrects the unit's own sensor,
+    # which is not what the unit is regulating on any more.
     _set_options(device, {CONF_INDOOR_OFFSET: 1.5})
     device.airco.IndoorTemp = 22.0
     device.airco.Operation = True
@@ -315,10 +322,10 @@ async def test_update_state_uses_override_once_the_unit_has_it(device):
     entity = _service_entity(device)
 
     await entity.async_set_external_temperature(temperature=20.0)
-    _mark_reached_the_unit(device)
+    _mark_reached_the_unit(device, 20.0)
     entity._update_state()
 
-    assert entity._attr_current_temperature == 20.0
+    assert entity._attr_current_temperature == 20.5
 
 
 async def test_update_state_keeps_indoor_temp_until_the_override_is_sent(device):
@@ -336,25 +343,32 @@ async def test_update_state_keeps_indoor_temp_until_the_override_is_sent(device)
     assert entity._attr_current_temperature == 23.5
 
 
-async def test_update_state_keeps_showing_the_override_when_the_value_changes(device):
-    # A source sensor feeding the action reports a new value every cycle. That
-    # replaces a live override rather than starting a new one, so the display
-    # must not fall back to the unit's reading in between.
+async def test_update_state_reapplies_the_offset_while_a_new_value_is_in_flight(device):
+    # A source sensor feeding the action reports a new value every cycle. Until
+    # the unit confirms the new one, it is still regulating on the old - and
+    # the display follows the unit rather than what has merely been armed.
     _set_options(device, {CONF_INDOOR_OFFSET: 1.5})
-    device.airco.IndoorTemp = 22.0
     device.airco.Operation = True
     device.airco.OperationMode = HVAC_TRANSLATION[HVACMode.COOL]
     entity = _service_entity(device)
 
     await entity.async_set_external_temperature(temperature=20.0)
-    _mark_reached_the_unit(device)
+    _mark_reached_the_unit(device, 20.0)
     await entity.async_set_external_temperature(temperature=20.25)
     entity._update_state()
 
-    assert entity._attr_current_temperature == 20.25
+    assert entity._attr_current_temperature == 20.5
+
+    _mark_reached_the_unit(device, 20.25)
+    entity._update_state()
+
+    assert entity._attr_current_temperature == 20.75
 
 
-async def test_update_state_falls_back_to_indoor_when_off_or_fan_only(device):
+async def test_update_state_keeps_the_offset_while_the_unit_is_off_or_fan_only(device):
+    # Nothing writes byte 5 in those modes, so the unit is on its own sensor
+    # however the override is armed - and its own sensor is what the offset
+    # calibrates.
     _set_options(device, {CONF_INDOOR_OFFSET: 1.5})
     device.airco.IndoorTemp = 22.0
     device.airco.Operation = True
@@ -362,7 +376,6 @@ async def test_update_state_falls_back_to_indoor_when_off_or_fan_only(device):
     entity = _service_entity(device)
 
     await entity.async_set_external_temperature(temperature=20.0)
-    _mark_reached_the_unit(device)
 
     for operation, mode in (
         (False, HVAC_TRANSLATION[HVACMode.COOL]),

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -342,33 +342,55 @@ async def test_set_airco_explicitly_clears_external_temperature_override(device)
     assert raw[5] == 0xFF
 
 
-async def test_external_temperature_counts_as_applied_once_a_frame_carried_it(device):
+async def test_external_temperature_applied_reads_the_echoed_byte(device):
+    # The unit echoes an injected value back in byte 5 unchanged, so the byte
+    # it reports matching one a recent frame carried is the whole question.
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
-    device.set_external_temperature_override(18.7)
-    device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
 
-    # Arming alone says nothing about what the unit holds.
     assert device.external_temperature_applied is False
 
-    await device.set_airco({AirconCommands.PresetTemp: 22})
+    device.set_external_temperature_override(18.7)
+    raw = round(18.7 * 4) + 61
 
+    # Armed, but nothing has carried it yet - the unit is still on its own
+    # sensor even if that happens to read the same.
+    device.airco.ControllerRoomTempRaw = raw
+    assert device.external_temperature_applied is False
+
+    device._external_temperature_written.append(raw)
     assert device.external_temperature_applied is True
 
+    # 0xFF: the unit is back on its own sensor, whatever is still armed here.
+    device.airco.ControllerRoomTempRaw = 0xFF
+    assert device.external_temperature_applied is False
 
-async def test_external_temperature_stops_counting_as_applied_in_fan_only(device):
-    # fan_only sends 0xFF in byte 5, which puts the unit back on its own
-    # sensor - the override stays armed but is no longer in effect.
+    device.airco.ControllerRoomTempRaw = raw
+    device.set_external_temperature_override(None)
+    assert device.external_temperature_applied is False
+
+
+async def test_external_temperature_applied_survives_a_value_change(device):
+    # A source sensor feeding new values must not make the flag - and with it
+    # the indoor offset - flicker: the frame carrying a new value goes out a
+    # cycle before the unit reports it back, and until then the previous value
+    # is what the unit is regulating on.
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
     device.set_external_temperature_override(18.7)
-    device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
+    old_raw = round(18.7 * 4) + 61
+    device._external_temperature_written.append(old_raw)
+    device.airco.ControllerRoomTempRaw = old_raw
 
-    await device.set_airco({AirconCommands.PresetTemp: 22})
-    await device.set_airco({AirconCommands.OperationMode: 3})
+    device.set_external_temperature_override(19.0)
+    new_raw = round(19.0 * 4) + 61
+    device._external_temperature_written.append(new_raw)
 
-    assert device.external_temperature_applied is False
-    assert device.external_temperature_override == 18.7
+    # The frame is out, the unit still reports the previous value.
+    assert device.external_temperature_applied is True
+
+    device.airco.ControllerRoomTempRaw = new_raw
+    assert device.external_temperature_applied is True
 
 
 async def test_set_airco_raises_and_logs_on_send_failure(device):


### PR DESCRIPTION
Follows the hardware measurement in #218: the unit *does* echo an injected external temperature back, which §5.6 of the protocol reference used to deny. Two things follow from that.

## Both temperature readings show what the unit reports

Until now the climate entity showed the armed override while the Indoor Temperature sensor showed the unit's reading, and they were half a kelvin apart — the value travels in two protocol fields with different resolutions, and that gap sits between them with or without an override. Now both simply show what the unit reports, so they agree with each other and with the official app at every point.

## The indoor calibration offset is suspended under an override

Indoor Temp. Sensor Offset corrects the unit's own return-air sensor. While the unit is regulating on a value it was handed, that sensor is out of the loop and the reported value is the injected one — correcting it would correct a reading that needs no correcting.

## The applied flag is read off the wire

`Device.external_temperature_applied` no longer carries a remembered boolean; it compares the byte the unit reports against what recent frames actually carried. That also catches the case the old flag could not: another controller taking the unit off the override without telling us.

It compares against **recent frames**, plural, and that detail matters. A frame carrying a new value goes out a full cycle before the unit reports it back, so comparing against only the newest would drop the flag — and visibly, the suspended offset with it — once for every value a source sensor feeds in. Keeping the last two closes exactly that gap.

One acknowledged blind spot, in the property's docstring: if the room happens to sit within a quarter kelvin of the armed value, the unit's own reading encodes to the same byte and this reads true early. Both branches then show the same temperature, and the offset it suppresses is at most that far from being right.

## Testing

345 tests pass, mypy clean. New coverage for the flag surviving a value change, and the existing override tests now set up the state a frame leaves behind rather than a flag.

## Note on ordering

This touches `climate.py` alongside #310. Whichever goes in second will want a rebase; there is no conflict in behaviour, only in adjacent lines.
