### PR TITLE
Correct the cooling overshoot through the room temperature, not the setpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ device before saving it.
 | Retry limit | 3 or higher, default 3 | Consecutive failed polls before the device is marked unavailable. At the 60 s poll interval, `3` is about 3 minutes - enough to ride through the module's hourly WiFi reassociation. Raise it on a weak link; it cannot be set lower. |
 | Indoor Temp. Sensor Offset | -15..15 °C | Added to the unit's own indoor-sensor reading before it's shown as `current_temperature` / the Indoor Temperature sensor - display-only, doesn't change what the unit does. Suspended while an external temperature override is in effect: the unit is reporting the value it was given rather than measuring, so there is nothing to calibrate. |
 | Outdoor Temp. Sensor Offset | -15..15 °C | Same, for the Outdoor Temperature sensor. |
-| Target Temp. Offset | -5..5 °C, whole degrees | Calibrates the *setpoint sent to the unit* - see "Target Temp. Offset sign convention" below. Applies to every `hvac_mode` unless overridden by the two options below. |
-| Target Temp. Offset (Cooling) | -5..5 °C, whole degrees, unset by default | Overrides Target Temp. Offset for `cool` and `dry` mode. Leave unset to keep using Target Temp. Offset for those modes too. |
-| Target Temp. Offset (Heating) | -5..5 °C, whole degrees, unset by default | Overrides Target Temp. Offset for `heat` mode. Leave unset to keep using Target Temp. Offset for `heat` too. |
+| Target Temp. Offset | -5..5 °C | Calibrates the *setpoint sent to the unit* - see "Target Temp. Offset sign convention" below. Applies to every `hvac_mode` unless overridden by the two options below. |
+| Target Temp. Offset (Cooling) | -5..5 °C, unset by default | Overrides Target Temp. Offset for `cool` and `dry` mode. Leave unset to keep using Target Temp. Offset for those modes too. |
+| Target Temp. Offset (Heating) | -5..5 °C, unset by default | Overrides Target Temp. Offset for `heat` mode. Leave unset to keep using Target Temp. Offset for `heat` too. |
 | Cooling overshoot | 0..3 °C | How far past your setting the room actually goes before the unit stops. Set 22 °C, room settles at 21 °C: enter 1. Only has an effect while an external room temperature is in use. |
 | Heating overshoot | 0..3 °C | The same for heating: how far above your setting the room ends up. Positive in both cases. |
 | Check for firmware updates | on/off, off by default | Creates the Firmware Update entity (see Update above) and periodically checks the manufacturer's `getFirmware` endpoint. The only outbound internet call this integration makes - leave off to stay fully local. |
@@ -321,7 +321,7 @@ With an external room temperature in use, most units cool the room further than 
 
 Set **Cooling overshoot** to how far it goes: aim for 22 °C, watch where the room settles, and enter the difference as a positive number. The integration then hands the unit a room temperature that much lower, so the unit reaches its own stopping point exactly when your room is on target. Your setpoint and everything shown in Home Assistant stay the number you asked for.
 
-Why here and not in Target Temp. Offset: the unit only accepts whole-degree setpoints and rounds half a degree up, while the room temperature it is fed has 0.25 °C steps. Correcting through the room temperature is simply the finer of the two, and it leaves the setpoint matching what the official app shows.
+Why here and not in Target Temp. Offset: on the units measured so far, a half-degree setpoint is rounded up to the next whole one, so that field is too coarse for a correction of less than a degree (owners of ZT and ZTL units report their models do take half degrees). The room temperature the unit is fed has 0.25 °C steps on every model, so correcting there is the finer of the two - and it leaves the setpoint matching what the official app shows.
 
 While a correction is active, the climate entity's `current_temperature` shows your room temperature, and the Indoor Temperature sensor keeps showing what the unit reports - which is the lowered value, on purpose. That is the one situation where the two differ.
 

--- a/README.md
+++ b/README.md
@@ -267,9 +267,11 @@ device before saving it.
 | Retry limit | 3 or higher, default 3 | Consecutive failed polls before the device is marked unavailable. At the 60 s poll interval, `3` is about 3 minutes - enough to ride through the module's hourly WiFi reassociation. Raise it on a weak link; it cannot be set lower. |
 | Indoor Temp. Sensor Offset | -15..15 °C | Added to the unit's own indoor-sensor reading before it's shown as `current_temperature` / the Indoor Temperature sensor - display-only, doesn't change what the unit does. Suspended while an external temperature override is in effect: the unit is reporting the value it was given rather than measuring, so there is nothing to calibrate. |
 | Outdoor Temp. Sensor Offset | -15..15 °C | Same, for the Outdoor Temperature sensor. |
-| Target Temp. Offset | -5..5 °C | Calibrates the *setpoint sent to the unit* - see "Target Temp. Offset sign convention" below. Applies to every `hvac_mode` unless overridden by the two options below. |
-| Target Temp. Offset (Cooling) | -5..5 °C, unset by default | Overrides Target Temp. Offset for `cool` and `dry` mode. Leave unset to keep using Target Temp. Offset for those modes too. |
-| Target Temp. Offset (Heating) | -5..5 °C, unset by default | Overrides Target Temp. Offset for `heat` mode. Leave unset to keep using Target Temp. Offset for `heat` too. |
+| Target Temp. Offset | -5..5 °C, whole degrees | Calibrates the *setpoint sent to the unit* - see "Target Temp. Offset sign convention" below. Applies to every `hvac_mode` unless overridden by the two options below. |
+| Target Temp. Offset (Cooling) | -5..5 °C, whole degrees, unset by default | Overrides Target Temp. Offset for `cool` and `dry` mode. Leave unset to keep using Target Temp. Offset for those modes too. |
+| Target Temp. Offset (Heating) | -5..5 °C, whole degrees, unset by default | Overrides Target Temp. Offset for `heat` mode. Leave unset to keep using Target Temp. Offset for `heat` too. |
+| Cooling overshoot | 0..3 °C | How far past your setting the room actually goes before the unit stops. Set 22 °C, room settles at 21 °C: enter 1. Only has an effect while an external room temperature is in use. |
+| Heating overshoot | 0..3 °C | The same for heating: how far above your setting the room ends up. Positive in both cases. |
 | Check for firmware updates | on/off, off by default | Creates the Firmware Update entity (see Update above) and periodically checks the manufacturer's `getFirmware` endpoint. The only outbound internet call this integration makes - leave off to stay fully local. |
 
 ### Target Temp. Offset sign convention
@@ -312,6 +314,16 @@ Feeding the value from an automation on every sensor update is fine and costs no
 **While an override is in effect, the unit stops reporting its own sensor.** Measured on hardware: the value you inject comes back on the next cycle as the unit's reported room temperature, half a kelvin above what you sent - the two protocol fields it travels in differ by that much with or without an override. So the Indoor Temperature sensor follows your override as well and is no longer a measurement of the room; keep your own sensor for that. Clearing the override brings the real reading back within a cycle.
 
 The override survives a restart and a reload. It is re-armed, not re-sent: the unit stays on whatever it last received until the next frame goes out. Both `current_temperature` and the Indoor Temperature sensor show what the unit reports throughout, so they agree with each other and with the official app at every point.
+
+### When the room ends up past your setting
+
+With an external room temperature in use, most units cool the room further than asked before stopping - measured between 0.6 and 2 K across four different models, and the same figure repeats every cycle. Heating has so far looked correct.
+
+Set **Cooling overshoot** to how far it goes: aim for 22 °C, watch where the room settles, and enter the difference as a positive number. The integration then hands the unit a room temperature that much lower, so the unit reaches its own stopping point exactly when your room is on target. Your setpoint and everything shown in Home Assistant stay the number you asked for.
+
+Why here and not in Target Temp. Offset: the unit only accepts whole-degree setpoints and rounds half a degree up, while the room temperature it is fed has 0.25 °C steps. Correcting through the room temperature is simply the finer of the two, and it leaves the setpoint matching what the official app shows.
+
+While a correction is active, the climate entity's `current_temperature` shows your room temperature, and the Indoor Temperature sensor keeps showing what the unit reports - which is the lowered value, on purpose. That is the one situation where the two differ.
 
 # Known limitations
 

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -478,9 +478,18 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
         # return-air sensor, which is out of the loop while the unit is
         # regulating on a value the user supplied. Applying it there would
         # correct a reading that needs no correcting.
-        self._attr_current_temperature = airco.IndoorTemp + (
-            0.0 if self._device.external_temperature_applied else indoor_offset
-        )
+        # One exception to reporting the unit verbatim: with an overshoot
+        # correction configured, the value the unit reports is the bent one it
+        # was handed on purpose. The room is what the user supplied, so that is
+        # what the card shows - the Indoor Temperature sensor still mirrors the
+        # unit, which is what makes the two disagree exactly then and only then.
+        room = self._device.external_temperature_room_value
+        if room is not None:
+            self._attr_current_temperature = room
+        else:
+            self._attr_current_temperature = airco.IndoorTemp + (
+                0.0 if self._device.external_temperature_applied else indoor_offset
+            )
         self._attr_fan_mode = list(FAN_MODE_TRANSLATION.keys())[airco.AirFlow]
         self._attr_swing_mode = (
             SWING_3D_AUTO

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Callable
 from functools import partial
 from typing import Any
@@ -21,10 +22,14 @@ from homeassistant.const import (
     CONF_PORT,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import selector
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import (
     DEFAULT_PORT,
+    CONF_OVERSHOOT_COOL,
+    CONF_OVERSHOOT_HEAT,
+    OVERSHOOT_MAX,
     CONF_AIRCO_ID,
     CONF_AVAILABILITY_RETRY_LIMIT,
     CONF_FIRMWARE_UPDATE_CHECK,
@@ -413,6 +418,17 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return name if isinstance(name, str) else None
 
 
+def _to_whole_degrees(value: Any) -> Any:
+    """Round a target offset to what the unit can actually hold.
+
+    Away from zero, so a correction a user entered never comes out smaller
+    than they asked for.
+    """
+    if value is None or isinstance(value, bool) or not isinstance(value, (int, float)):
+        return value
+    return math.copysign(math.ceil(abs(value)), value)
+
+
 class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
     """Base class for options handling."""
 
@@ -428,7 +444,25 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
             data = {**user_input, CONF_HOST: self.config_entry.options[CONF_HOST]}
             return self.async_create_entry(title="", data=data)
 
-        offset_range_validator = vol.All(vol.Coerce(float), vol.Range(min=-5.0, max=5.0))
+        # Whole degrees, because that is all the unit has: a half degree sent
+        # to it is rounded up, so a 0.5 step here promises a fineness that
+        # silently becomes 1.0 (measured on hardware, see issue #218). A value
+        # stored from an earlier version still applies as it always did; the
+        # form just rounds it when next opened rather than offering steps that
+        # do not exist.
+        offset_range_validator = vol.All(
+            vol.Coerce(float), vol.Range(min=-5.0, max=5.0), _to_whole_degrees
+        )
+        overshoot_validator = vol.All(
+            vol.Coerce(float), vol.Range(min=0.0, max=OVERSHOOT_MAX)
+        )
+        overshoot_fields: dict[Any, Any] = {
+            vol.Optional(
+                key,
+                default=self.config_entry.options.get(key, 0.0),
+            ): overshoot_validator
+            for key in (CONF_OVERSHOOT_COOL, CONF_OVERSHOOT_HEAT)
+        }
         # target_offset_cool/heat are optional per-mode overrides that must
         # stay "unset" (None) unless the user explicitly fills them in - a
         # default= here would coerce a blank field to 0.0 and defeat the
@@ -438,7 +472,11 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
         per_mode_offset_fields: dict[Any, Any] = {
             vol.Optional(
                 key,
-                description={"suggested_value": self.config_entry.options.get(key)},
+                description={
+                    "suggested_value": _to_whole_degrees(
+                        self.config_entry.options.get(key)
+                    )
+                },
             ): vol.Any(None, offset_range_validator)
             for key in (CONF_TARGET_OFFSET_COOL, CONF_TARGET_OFFSET_HEAT)
         }
@@ -470,9 +508,14 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
                     ): vol.All(vol.Coerce(float), vol.Range(min=-15.0, max=15.0)),
                     vol.Optional(
                         CONF_TARGET_OFFSET,
-                        default=self.config_entry.options.get(CONF_TARGET_OFFSET, 0.0),
+                        description={
+                            "suggested_value": _to_whole_degrees(
+                                self.config_entry.options.get(CONF_TARGET_OFFSET, 0.0)
+                            )
+                        },
                     ): offset_range_validator,
                     **per_mode_offset_fields,
+                    **overshoot_fields,
                 },
             ),
         )

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import math
 from collections.abc import Callable
 from functools import partial
 from typing import Any
@@ -418,17 +417,6 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return name if isinstance(name, str) else None
 
 
-def _to_whole_degrees(value: Any) -> Any:
-    """Round a target offset to what the unit can actually hold.
-
-    Away from zero, so a correction a user entered never comes out smaller
-    than they asked for.
-    """
-    if value is None or isinstance(value, bool) or not isinstance(value, (int, float)):
-        return value
-    return math.copysign(math.ceil(abs(value)), value)
-
-
 class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
     """Base class for options handling."""
 
@@ -444,15 +432,7 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
             data = {**user_input, CONF_HOST: self.config_entry.options[CONF_HOST]}
             return self.async_create_entry(title="", data=data)
 
-        # Whole degrees, because that is all the unit has: a half degree sent
-        # to it is rounded up, so a 0.5 step here promises a fineness that
-        # silently becomes 1.0 (measured on hardware, see issue #218). A value
-        # stored from an earlier version still applies as it always did; the
-        # form just rounds it when next opened rather than offering steps that
-        # do not exist.
-        offset_range_validator = vol.All(
-            vol.Coerce(float), vol.Range(min=-5.0, max=5.0), _to_whole_degrees
-        )
+        offset_range_validator = vol.All(vol.Coerce(float), vol.Range(min=-5.0, max=5.0))
         overshoot_validator = vol.All(
             vol.Coerce(float), vol.Range(min=0.0, max=OVERSHOOT_MAX)
         )
@@ -472,11 +452,7 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
         per_mode_offset_fields: dict[Any, Any] = {
             vol.Optional(
                 key,
-                description={
-                    "suggested_value": _to_whole_degrees(
-                        self.config_entry.options.get(key)
-                    )
-                },
+                description={"suggested_value": self.config_entry.options.get(key)},
             ): vol.Any(None, offset_range_validator)
             for key in (CONF_TARGET_OFFSET_COOL, CONF_TARGET_OFFSET_HEAT)
         }
@@ -508,11 +484,7 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
                     ): vol.All(vol.Coerce(float), vol.Range(min=-15.0, max=15.0)),
                     vol.Optional(
                         CONF_TARGET_OFFSET,
-                        description={
-                            "suggested_value": _to_whole_degrees(
-                                self.config_entry.options.get(CONF_TARGET_OFFSET, 0.0)
-                            )
-                        },
+                        default=self.config_entry.options.get(CONF_TARGET_OFFSET, 0.0),
                     ): offset_range_validator,
                     **per_mode_offset_fields,
                     **overshoot_fields,

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -75,6 +75,16 @@ CONF_OUTDOOR_OFFSET = "outdoor_offset"
 CONF_TARGET_OFFSET = "target_offset"
 CONF_TARGET_OFFSET_COOL = "target_offset_cool"
 CONF_TARGET_OFFSET_HEAT = "target_offset_heat"
+# How far past the setting the room actually goes before the unit stops. Not a
+# display correction like the offsets above: it shifts the room temperature fed
+# to the unit, which is the only lever fine enough to correct this (0.25 K, vs
+# whole degrees for the setpoint - the unit rounds half degrees up).
+# Protocol mode numbers, mirroring HVAC_TRANSLATION below.
+OPERATION_MODE_COOL = 1
+OPERATION_MODE_HEAT = 2
+CONF_OVERSHOOT_COOL = "overshoot_cool"
+CONF_OVERSHOOT_HEAT = "overshoot_heat"
+OVERSHOOT_MAX = 3.0
 
 SENSOR_TYPE_TEMPERATURE = "temperature"
 

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -14,7 +14,14 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, MIN_TIME_BETWEEN_UPDATES
+from .const import (
+    CONF_OVERSHOOT_COOL,
+    CONF_OVERSHOOT_HEAT,
+    DOMAIN,
+    MIN_TIME_BETWEEN_UPDATES,
+    OPERATION_MODE_COOL,
+    OPERATION_MODE_HEAT,
+)
 from .wfrac.firmware_check import fetch_latest_firmware
 from .wfrac.models.aircon import Aircon, AirconCommands, AirconStat, HomeLeaveModeSetting
 from .wfrac.rac_parser import (
@@ -387,6 +394,60 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 )
             return
         self._release_external_temperature_carrier()
+
+    def _corrected_external_temperature(
+        self, temperature: float | None, operation_mode: int
+    ) -> float | None:
+        """Bend the room temperature we hand the unit by its overshoot.
+
+        The unit's thermostat band sits below the setting in cooling (measured
+        across four units: it keeps calling for cooling until roughly 1-2 K
+        under it, see issue #218). Telling it the room is that much colder than
+        it is moves its stop point to where the room actually reaches the
+        setting - and unlike the setpoint, which the unit rounds to whole
+        degrees, this lever has the protocol's 0.25 K resolution.
+
+        Heating is the mirror image, and zero - the default - changes nothing.
+        """
+        if temperature is None:
+            return None
+        overshoot = self._resolve_overshoot(operation_mode)
+        if not overshoot:
+            return temperature
+        if operation_mode == OPERATION_MODE_COOL:
+            return temperature - overshoot
+        if operation_mode == OPERATION_MODE_HEAT:
+            return temperature + overshoot
+        return temperature
+
+    def _resolve_overshoot(self, operation_mode: int) -> float:
+        """The configured overshoot for the mode a frame is going out in."""
+        if operation_mode == OPERATION_MODE_COOL:
+            key = CONF_OVERSHOOT_COOL
+        elif operation_mode == OPERATION_MODE_HEAT:
+            key = CONF_OVERSHOOT_HEAT
+        else:
+            return 0.0
+        value = self.options.get(key, 0.0)
+        return float(value) if isinstance(value, (int, float)) else 0.0
+
+    @property
+    def external_temperature_room_value(self) -> float | None:
+        """The room temperature behind an override the unit is being lied to
+        about, or None when nothing is being bent.
+
+        With an overshoot configured, what the unit reports back is the value
+        it was handed, which is deliberately not the room. The number the user
+        supplied is - so that is what the climate entity shows, while the
+        Indoor Temperature sensor keeps reporting the unit verbatim.
+        """
+        if self._external_temperature_override is None or self._airco is None:
+            return None
+        if not self.external_temperature_applied:
+            return None
+        if not self._resolve_overshoot(self._airco.OperationMode):
+            return None
+        return self._external_temperature_override
 
     @property
     def external_temperature_applied(self) -> bool:
@@ -994,6 +1055,13 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
 
             for key, value in params.items():
                 setattr(airco_stat, key, value)
+
+            # After the parameters, not before: the correction depends on the
+            # mode this frame is putting the unit into, which a command in
+            # params may just have changed.
+            airco_stat.ExternalTemperature = self._corrected_external_temperature(
+                airco_stat.ExternalTemperature, airco_stat.OperationMode
+            )
 
             try:
                 command = self._parser.to_base64(airco_stat)

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -69,7 +69,7 @@
           "target_offset_heat": "Leave empty to use the general target temperature offset.",
           "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. Only has an effect while an external room temperature is in use, and 0 changes nothing.",
           "overshoot_heat": "The same for heating: how far above your setting the room ends up. Enter a positive number in both cases.",
-          "target_offset": "Whole degrees - the unit rounds half a degree up to the next one."
+          "target_offset": "Most units round a half degree up to the next whole one, so 0.5 here often acts as 1."
         }
       }
     }

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -59,12 +59,17 @@
           "outdoor_offset": "Outdoor Temp. Sensor Offset",
           "target_offset": "Target Temp. Offset",
           "target_offset_cool": "Target Temp. Offset (Cooling)",
-          "target_offset_heat": "Target Temp. Offset (Heating)"
+          "target_offset_heat": "Target Temp. Offset (Heating)",
+          "overshoot_cool": "Cooling overshoot",
+          "overshoot_heat": "Heating overshoot"
         },
         "title": "WF-RAC options",
         "data_description": {
           "target_offset_cool": "Leave empty to use the general target temperature offset.",
-          "target_offset_heat": "Leave empty to use the general target temperature offset."
+          "target_offset_heat": "Leave empty to use the general target temperature offset.",
+          "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. Only has an effect while an external room temperature is in use, and 0 changes nothing.",
+          "overshoot_heat": "The same for heating: how far above your setting the room ends up. Enter a positive number in both cases.",
+          "target_offset": "Whole degrees - the unit rounds half a degree up to the next one."
         }
       }
     }

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -92,7 +92,7 @@
           "target_offset_heat": "Leave empty to use the general target temperature offset.",
           "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. Only has an effect while an external room temperature is in use, and 0 changes nothing.",
           "overshoot_heat": "The same for heating: how far above your setting the room ends up. Enter a positive number in both cases.",
-          "target_offset": "Whole degrees - the unit rounds half a degree up to the next one."
+          "target_offset": "Most units round a half degree up to the next whole one, so 0.5 here often acts as 1."
         }
       }
     }

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -82,12 +82,17 @@
           "outdoor_offset": "Outdoor Temp. Sensor Offset",
           "target_offset": "Target Temp. Offset",
           "target_offset_cool": "Target Temp. Offset (Cooling)",
-          "target_offset_heat": "Target Temp. Offset (Heating)"
+          "target_offset_heat": "Target Temp. Offset (Heating)",
+          "overshoot_cool": "Cooling overshoot",
+          "overshoot_heat": "Heating overshoot"
         },
         "title": "WF-RAC options",
         "data_description": {
           "target_offset_cool": "Leave empty to use the general target temperature offset.",
-          "target_offset_heat": "Leave empty to use the general target temperature offset."
+          "target_offset_heat": "Leave empty to use the general target temperature offset.",
+          "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. Only has an effect while an external room temperature is in use, and 0 changes nothing.",
+          "overshoot_heat": "The same for heating: how far above your setting the room ends up. Enter a positive number in both cases.",
+          "target_offset": "Whole degrees - the unit rounds half a degree up to the next one."
         }
       }
     }

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -21,6 +21,7 @@ from custom_components.mitsubishi_wf_rac.sensor import TemperatureSensor
 from custom_components.mitsubishi_wf_rac.const import (
     ATTR_TARGET_TEMPERATURE,
     CONF_INDOOR_OFFSET,
+    CONF_OVERSHOOT_COOL,
     CONF_TARGET_OFFSET,
     CONF_TARGET_OFFSET_COOL,
     CONF_TARGET_OFFSET_HEAT,
@@ -415,6 +416,38 @@ async def test_set_external_temperature_arms_while_the_unit_is_off(device):
 
     assert entity._external_temperature_override == 20.0
     device.async_queue_command.assert_not_awaited()
+
+
+async def test_current_temperature_shows_the_room_not_the_bent_value(device):
+    # With an overshoot configured the unit is handed a value that is
+    # deliberately not the room, and it reports that value back. The card has
+    # to show the room the user supplied instead - otherwise the correction
+    # would look like the room got colder.
+    _set_options(device, {CONF_OVERSHOOT_COOL: 1.0})
+    device.airco.Operation = True
+    device.airco.OperationMode = HVAC_TRANSLATION[HVACMode.COOL]
+    entity = _service_entity(device)
+
+    await entity.async_set_external_temperature(temperature=22.0)
+    # What a frame carrying the bent value leaves behind.
+    _mark_reached_the_unit(device, 21.0)
+    entity._update_state()
+
+    assert entity._attr_current_temperature == 22.0
+
+
+async def test_current_temperature_follows_the_unit_without_an_overshoot(device):
+    # Nothing is being bent, so there is nothing to correct back: both the
+    # card and the Indoor Temperature sensor mirror the unit.
+    device.airco.Operation = True
+    device.airco.OperationMode = HVAC_TRANSLATION[HVACMode.COOL]
+    entity = _service_entity(device)
+
+    await entity.async_set_external_temperature(temperature=22.0)
+    _mark_reached_the_unit(device, 22.0)
+    entity._update_state()
+
+    assert entity._attr_current_temperature == 22.5
 
 
 def _restoring_entity(device, restored: dict[str, float | str | None]) -> AircoClimate:

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -519,12 +519,12 @@ async def test_options_flow_saves_submitted_values(hass: HomeAssistant):
         {
             CONF_INDOOR_OFFSET: 1.0,
             CONF_OUTDOOR_OFFSET: -1.0,
-            CONF_TARGET_OFFSET: 1.0,
+            CONF_TARGET_OFFSET: 0.5,
         },
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_TARGET_OFFSET] == 1.0
+    assert result["data"][CONF_TARGET_OFFSET] == 0.5
     # host isn't a form field anymore (moved to the reconfigure flow), but
     # the entry's existing value must survive an options save regardless.
     assert result["data"]["host"] == "192.168.1.50"
@@ -636,41 +636,15 @@ async def test_options_flow_saves_submitted_per_mode_offsets(hass: HomeAssistant
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {
-            CONF_TARGET_OFFSET: 1.0,
-            CONF_TARGET_OFFSET_COOL: 2.0,
-            CONF_TARGET_OFFSET_HEAT: -2.0,
+            CONF_TARGET_OFFSET: 0.5,
+            CONF_TARGET_OFFSET_COOL: 1.5,
+            CONF_TARGET_OFFSET_HEAT: -1.5,
         },
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_TARGET_OFFSET_COOL] == 2.0
-    assert result["data"][CONF_TARGET_OFFSET_HEAT] == -2.0
-
-
-@pytest.mark.parametrize(
-    "submitted,stored",
-    [(0.5, 1.0), (-0.5, -1.0), (1.25, 2.0), (-1.75, -2.0), (0.0, 0.0), (2.0, 2.0)],
-)
-async def test_options_flow_rounds_target_offsets_to_whole_degrees(
-    hass: HomeAssistant, submitted, stored
-):
-    # The unit only holds whole degrees and rounds a half up, so a fractional
-    # setting here silently became a bigger one (#218). Rounding away from zero
-    # keeps a correction from coming out smaller than the user asked for.
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50"},
-    )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"], {CONF_TARGET_OFFSET: submitted}
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_TARGET_OFFSET] == stored
+    assert result["data"][CONF_TARGET_OFFSET_COOL] == 1.5
+    assert result["data"][CONF_TARGET_OFFSET_HEAT] == -1.5
 
 
 async def test_options_flow_leaves_per_mode_offsets_unset_when_omitted(hass: HomeAssistant):

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -519,12 +519,12 @@ async def test_options_flow_saves_submitted_values(hass: HomeAssistant):
         {
             CONF_INDOOR_OFFSET: 1.0,
             CONF_OUTDOOR_OFFSET: -1.0,
-            CONF_TARGET_OFFSET: 0.5,
+            CONF_TARGET_OFFSET: 1.0,
         },
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_TARGET_OFFSET] == 0.5
+    assert result["data"][CONF_TARGET_OFFSET] == 1.0
     # host isn't a form field anymore (moved to the reconfigure flow), but
     # the entry's existing value must survive an options save regardless.
     assert result["data"]["host"] == "192.168.1.50"
@@ -636,15 +636,41 @@ async def test_options_flow_saves_submitted_per_mode_offsets(hass: HomeAssistant
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {
-            CONF_TARGET_OFFSET: 0.5,
-            CONF_TARGET_OFFSET_COOL: 1.5,
-            CONF_TARGET_OFFSET_HEAT: -1.5,
+            CONF_TARGET_OFFSET: 1.0,
+            CONF_TARGET_OFFSET_COOL: 2.0,
+            CONF_TARGET_OFFSET_HEAT: -2.0,
         },
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_TARGET_OFFSET_COOL] == 1.5
-    assert result["data"][CONF_TARGET_OFFSET_HEAT] == -1.5
+    assert result["data"][CONF_TARGET_OFFSET_COOL] == 2.0
+    assert result["data"][CONF_TARGET_OFFSET_HEAT] == -2.0
+
+
+@pytest.mark.parametrize(
+    "submitted,stored",
+    [(0.5, 1.0), (-0.5, -1.0), (1.25, 2.0), (-1.75, -2.0), (0.0, 0.0), (2.0, 2.0)],
+)
+async def test_options_flow_rounds_target_offsets_to_whole_degrees(
+    hass: HomeAssistant, submitted, stored
+):
+    # The unit only holds whole degrees and rounds a half up, so a fractional
+    # setting here silently became a bigger one (#218). Rounding away from zero
+    # keeps a correction from coming out smaller than the user asked for.
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room AC"},
+        options={"host": "192.168.1.50"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {CONF_TARGET_OFFSET: submitted}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_TARGET_OFFSET] == stored
 
 
 async def test_options_flow_leaves_per_mode_offsets_unset_when_omitted(hass: HomeAssistant):

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -16,7 +16,23 @@ import pytest
 from homeassistant.helpers import issue_registry as ir
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.mitsubishi_wf_rac.const import DOMAIN
+from custom_components.mitsubishi_wf_rac.const import (
+    CONF_OVERSHOOT_COOL,
+    CONF_OVERSHOOT_HEAT,
+    DOMAIN,
+)
+
+
+def _set_options(device, options: dict) -> None:
+    """ConfigEntry.options is a read-only mappingproxy - update it the way the
+    options flow does. The fixture's entry is not registered with hass, and
+    async_update_entry only works on one that is."""
+    entry = device.config_entry
+    if entry.entry_id not in device.hass.config_entries._entries:
+        entry.add_to_hass(device.hass)
+    device.hass.config_entries.async_update_entry(
+        entry, options={**entry.options, **options}
+    )
 from custom_components.mitsubishi_wf_rac import coordinator as coordinator_module
 from custom_components.mitsubishi_wf_rac.coordinator import (
     AVAILABILITY_FAILURE_LIMIT_MIN,
@@ -318,6 +334,65 @@ async def test_set_airco_includes_stored_external_temperature_override(device):
 
     raw = base64.b64decode(captured["command"])
 
+    assert raw[5] == int(round(18.7 * 4)) + 61
+
+
+@pytest.mark.parametrize(
+    "mode,overshoot_key,expected",
+    [
+        # Cooling stops below the setting, so the unit is told the room is
+        # that much colder than it is - it then reaches its stop point where
+        # the room is actually on target. Heating is the mirror image.
+        (AirconCommands.OperationMode, CONF_OVERSHOOT_COOL, 18.7 - 1.25),
+        (AirconCommands.OperationMode, CONF_OVERSHOOT_HEAT, 18.7 + 1.25),
+    ],
+)
+async def test_set_airco_bends_the_override_by_the_configured_overshoot(
+    device, mode, overshoot_key, expected
+):
+    operation_mode = 1 if overshoot_key == CONF_OVERSHOOT_COOL else 2
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    _set_options(device, {overshoot_key: 1.25})
+    device._external_temperature_override = 18.7
+
+    captured = {}
+
+    async def _capture_and_echo(airco_id, command, **_kwargs):
+        captured["command"] = command
+        return await _echo_send_airco_command(airco_id, command)
+
+    device._api.send_airco_command = AsyncMock(side_effect=_capture_and_echo)
+
+    await device.set_airco(
+        {AirconCommands.Operation: True, AirconCommands.OperationMode: operation_mode}
+    )
+
+    raw = base64.b64decode(captured["command"])
+    assert raw[5] == int(round(expected * 4)) + 61
+
+
+async def test_set_airco_leaves_the_override_alone_in_other_modes(device):
+    # Dry and auto have no measured overshoot of their own, and applying the
+    # cooling figure there would be a guess dressed as a correction.
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    _set_options(device, {CONF_OVERSHOOT_COOL: 1.25, CONF_OVERSHOOT_HEAT: 1.25})
+    device._external_temperature_override = 18.7
+
+    captured = {}
+
+    async def _capture_and_echo(airco_id, command, **_kwargs):
+        captured["command"] = command
+        return await _echo_send_airco_command(airco_id, command)
+
+    device._api.send_airco_command = AsyncMock(side_effect=_capture_and_echo)
+
+    await device.set_airco(
+        {AirconCommands.Operation: True, AirconCommands.OperationMode: 4}
+    )
+
+    raw = base64.b64decode(captured["command"])
     assert raw[5] == int(round(18.7 * 4)) + 61
 
 


### PR DESCRIPTION
Builds on #311 (same files) and addresses the control deviation measured in #218.

Four units now report the same thing: with an external room temperature in use, cooling runs past the setting before the unit stops — 0.6 K, ~1 K, 1.0–1.3 K and 1.5–2.0 K on four different models. It is not a display problem and not a shifted setpoint (the internally used setpoint was read off the unit and does not move under an override); the thermostat band simply sits below the setting.

## What the user does

Set **Cooling overshoot** to how far it goes: aim for 22 °C, see where the room settles, enter the difference as a positive number. Nothing else changes — the setpoint stays what was asked for, in Home Assistant and in the official app.

Positive in both directions on purpose: "how far past" needs no sign convention, which is the part of Target Temp. Offset that keeps needing explaining.

## Why the correction rides on the room temperature

The unit only accepts whole-degree setpoints and rounds half a degree **up** — measured: 22.5 sent comes back as an internal 23.0, 22.0 as 22.0. So the setpoint is too coarse a lever for a 0.6 K correction, and a `-0.5` entered there has always silently acted as `-1`. Byte 5 carries quarter degrees, which is fine enough, and correcting there leaves the setpoint equal to what the app shows.

For the same reason the target offsets are now rounded to whole degrees. Values already stored keep applying exactly as they did; the form rounds them when next opened, away from zero, so a correction never comes out smaller than asked for.

## One deliberate divergence

While a correction is active, the climate entity's `current_temperature` shows the room temperature the user supplied, while the Indoor Temperature sensor keeps mirroring the unit — which is reporting the lowered value on purpose. #311 had just brought those two together; this is the one case where they must differ, because the unit is being told something untrue by design.

Dry and auto are left alone: no overshoot has been measured there, and applying the cooling figure would be a guess dressed as a correction.

## Testing

356 tests pass, mypy clean. New coverage for the correction in both directions, other modes left untouched, the card showing the room rather than the bent value, and the whole-degree rounding of the target offsets.

## Not in this PR

Measuring the overshoot automatically. The signals are all there — setpoint, real room temperature, per-unit compressor demand — but that is a control loop on top of a control loop, and it wants its own change and its own off switch.
