### PR TITLE
Allow a negative overshoot correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ device before saving it.
 | Target Temp. Offset | -5..5 °C | Calibrates the *setpoint sent to the unit* - see "Target Temp. Offset sign convention" below. Applies to every `hvac_mode` unless overridden by the two options below. |
 | Target Temp. Offset (Cooling) | -5..5 °C, unset by default | Overrides Target Temp. Offset for `cool` and `dry` mode. Leave unset to keep using Target Temp. Offset for those modes too. |
 | Target Temp. Offset (Heating) | -5..5 °C, unset by default | Overrides Target Temp. Offset for `heat` mode. Leave unset to keep using Target Temp. Offset for `heat` too. |
-| Cooling overshoot | 0..3 °C | How far past your setting the room actually goes before the unit stops. Set 22 °C, room settles at 21 °C: enter 1. Only has an effect while an external room temperature is in use. |
-| Heating overshoot | 0..3 °C | The same for heating: how far above your setting the room ends up. Positive in both cases. |
+| Cooling overshoot | -3..3 °C | How far past your setting the room actually goes before the unit stops. Set 22 °C, room settles at 21 °C: enter 1. Only has an effect while an external room temperature is in use. |
+| Heating overshoot | -3..3 °C | The same for heating: how far above your setting the room ends up. Positive in both cases. |
 | Check for firmware updates | on/off, off by default | Creates the Firmware Update entity (see Update above) and periodically checks the manufacturer's `getFirmware` endpoint. The only outbound internet call this integration makes - leave off to stay fully local. |
 
 ### Target Temp. Offset sign convention
@@ -323,11 +323,11 @@ An action-driven override survives a restart and a reload. It is re-armed, not r
 
 With an external room temperature in use, most units cool the room further than asked before stopping - measured between 0.6 and 2 K across four different models, and the same figure repeats every cycle. Heating has so far looked correct.
 
-Set **Cooling overshoot** to how far it goes: aim for 22 °C, watch where the room settles, and enter the difference as a positive number. The integration then hands the unit a room temperature that much lower, so the unit reaches its own stopping point exactly when your room is on target. Your setpoint and everything shown in Home Assistant stay the number you asked for.
+Set **Cooling overshoot** to how far it goes: aim for 22 °C, watch where the room settles, and enter the difference as a positive number. If your unit stops short instead and never quite gets there, a negative number corrects that the other way. The integration then hands the unit a room temperature that much lower, so the unit reaches its own stopping point exactly when your room is on target. Your setpoint and everything shown in Home Assistant stay the number you asked for.
 
 Why here and not in Target Temp. Offset: on the units measured so far, a half-degree setpoint is rounded up to the next whole one, so that field is too coarse for a correction of less than a degree (owners of ZT and ZTL units report their models do take half degrees). The room temperature the unit is fed has 0.25 °C steps on every model, so correcting there is the finer of the two - and it leaves the setpoint matching what the official app shows.
 
-While a correction is active, the climate entity's `current_temperature` shows your room temperature, and the Indoor Temperature sensor keeps showing what the unit reports - which is the lowered value, on purpose. That is the one situation where the two differ.
+While a correction is active, the climate entity's `current_temperature` shows your room temperature, and the Indoor Temperature sensor keeps showing what the unit reports - the value it was handed, on purpose. The two therefore differ by the correction, minus the half kelvin the unit adds on the way back: at exactly 0.5 the two cancel out and both read the same, which is not a sign that the correction is doing nothing.
 
 # Known limitations
 

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -444,8 +444,12 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=data)
 
         offset_range_validator = vol.All(vol.Coerce(float), vol.Range(min=-5.0, max=5.0))
+        # Negative allowed, though overshooting is what everyone has measured
+        # so far: a unit that stops short of the setting instead needs the
+        # correction the other way, and there is no reason to make that
+        # impossible before anyone has looked.
         overshoot_validator = vol.All(
-            vol.Coerce(float), vol.Range(min=0.0, max=OVERSHOOT_MAX)
+            vol.Coerce(float), vol.Range(min=-OVERSHOOT_MAX, max=OVERSHOOT_MAX)
         )
         overshoot_fields: dict[Any, Any] = {
             vol.Optional(

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -79,7 +79,9 @@ CONF_TARGET_OFFSET_HEAT = "target_offset_heat"
 # How far past the setting the room actually goes before the unit stops. Not a
 # display correction like the offsets above: it shifts the room temperature fed
 # to the unit, which is the only lever fine enough to correct this (0.25 K, vs
-# whole degrees for the setpoint - the unit rounds half degrees up).
+# whole degrees for the setpoint - the unit rounds half degrees up). Signed:
+# positive for a room that goes past the setting, negative for one that stops
+# short of it.
 # Protocol mode numbers, mirroring HVAC_TRANSLATION below.
 OPERATION_MODE_COOL = 1
 OPERATION_MODE_HEAT = 2

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -68,8 +68,8 @@
         "data_description": {
           "target_offset_cool": "Leave empty to use the general target temperature offset.",
           "target_offset_heat": "Leave empty to use the general target temperature offset.",
-          "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. Only has an effect while an external room temperature is in use, and 0 changes nothing.",
-          "overshoot_heat": "The same for heating: how far above your setting the room ends up. Enter a positive number in both cases.",
+          "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. If it stops short instead and never gets cold enough, enter a negative number. Only has an effect while an external room temperature is in use.",
+          "overshoot_heat": "The same for heating: positive if the room ends up above your setting, negative if it stops short of it.",
           "target_offset": "Most units round a half degree up to the next whole one, so 0.5 here often acts as 1.",
           "external_temperature_source": "The selected sensor controls the external temperature override. Unavailable or unknown states return the unit to its internal sensor."
         }

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -94,8 +94,8 @@
         "data_description": {
           "target_offset_cool": "Leave empty to use the general target temperature offset.",
           "target_offset_heat": "Leave empty to use the general target temperature offset.",
-          "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. Only has an effect while an external room temperature is in use, and 0 changes nothing.",
-          "overshoot_heat": "The same for heating: how far above your setting the room ends up. Enter a positive number in both cases.",
+          "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. If it stops short instead and never gets cold enough, enter a negative number. Only has an effect while an external room temperature is in use.",
+          "overshoot_heat": "The same for heating: positive if the room ends up above your setting, negative if it stops short of it.",
           "target_offset": "Most units round a half degree up to the next whole one, so 0.5 here often acts as 1.",
           "external_temperature_source": "The selected sensor controls the external temperature override. Unavailable or unknown states return the unit to its internal sensor."
         }

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -24,6 +24,7 @@ from custom_components.mitsubishi_wf_rac.const import (
     CONF_INDOOR_OFFSET,
     CONF_OPERATOR_ID,
     CONF_OUTDOOR_OFFSET,
+    CONF_OVERSHOOT_COOL,
     CONF_TARGET_OFFSET,
     CONF_TARGET_OFFSET_COOL,
     CONF_TARGET_OFFSET_HEAT,
@@ -702,6 +703,26 @@ async def test_options_flow_saves_submitted_per_mode_offsets(hass: HomeAssistant
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_TARGET_OFFSET_COOL] == 1.5
     assert result["data"][CONF_TARGET_OFFSET_HEAT] == -1.5
+
+
+@pytest.mark.parametrize("value", [1.25, -1.25, 0.0, 3.0, -3.0])
+async def test_options_flow_accepts_a_signed_overshoot(hass: HomeAssistant, value):
+    # Overshooting is what everyone has measured, but a unit that stops short
+    # of the setting needs the correction the other way.
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room AC"},
+        options={"host": "192.168.1.50"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {CONF_OVERSHOOT_COOL: value}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_OVERSHOOT_COOL] == value
 
 
 async def test_options_flow_leaves_per_mode_offsets_unset_when_omitted(hass: HomeAssistant):

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -372,6 +372,30 @@ async def test_set_airco_bends_the_override_by_the_configured_overshoot(
     assert raw[5] == int(round(expected * 4)) + 61
 
 
+async def test_set_airco_bends_the_override_the_other_way_when_negative(device):
+    # A unit that stops short of the setting rather than past it needs the
+    # correction reversed: it is told the room is warmer, so it keeps cooling.
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    _set_options(device, {CONF_OVERSHOOT_COOL: -0.75})
+    device._external_temperature_override = 18.7
+
+    captured = {}
+
+    async def _capture_and_echo(airco_id, command, **_kwargs):
+        captured["command"] = command
+        return await _echo_send_airco_command(airco_id, command)
+
+    device._api.send_airco_command = AsyncMock(side_effect=_capture_and_echo)
+
+    await device.set_airco(
+        {AirconCommands.Operation: True, AirconCommands.OperationMode: 1}
+    )
+
+    raw = base64.b64decode(captured["command"])
+    assert raw[5] == int(round((18.7 + 0.75) * 4)) + 61
+
+
 async def test_set_airco_leaves_the_override_alone_in_other_modes(device):
     # Dry and auto have no measured overshoot of their own, and applying the
     # cooling figure there would be a guess dressed as a correction.


### PR DESCRIPTION
From @alexnikgr in #218: the setting is capped at 0 because overshooting is what all four reports show, but a unit that stops short of the setting instead cannot be corrected at all right now. No reason to rule that out before anyone has looked — the meaning stays the same, negative just means the room lands on the near side of your setting.

Also corrects a README claim while I was in there. The climate entity and the Indoor Temperature sensor differ by the correction *minus* the half kelvin the unit adds on the way back, so at exactly 0.5 they cancel out and read the same — which @mungojam reasonably took for the correction being ignored.

370 tests pass, mypy clean.