### PR TITLE
Hold an off unit's setpoint to what the unit accepts anywhere

### DIFF
--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -64,6 +64,10 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 1
 
+# The modes whose setpoint the unit actually regulates on. Off and fan-only
+# have no setpoint of their own - see _setpoint_range_for_mode.
+REGULATING_HVAC_MODES = (HVACMode.AUTO, HVACMode.COOL, HVACMode.HEAT, HVACMode.DRY)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -359,13 +363,32 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
             return 33
         return 30
 
+    def _setpoint_range_for_mode(self, hvac_mode: HVACMode) -> tuple[float, float]:
+        """The range a setpoint is held to, for display and before sending.
+
+        A regulating mode is held to its own range. Off and fan-only have none:
+        the value applies to whichever regulating mode is turned on next, often
+        in the very next step of the same automation. Holding it to the default
+        18C floor there rejects a cooling setpoint the unit takes happily once
+        it is cooling, which is what it did until #317.
+        """
+        if hvac_mode in REGULATING_HVAC_MODES:
+            return (
+                self._min_temp_for_mode(hvac_mode),
+                self._max_temp_for_mode(hvac_mode),
+            )
+        return (
+            min(self._min_temp_for_mode(mode) for mode in REGULATING_HVAC_MODES),
+            max(self._max_temp_for_mode(mode) for mode in REGULATING_HVAC_MODES),
+        )
+
     @property
     def min_temp(self) -> float:
-        return self._min_temp_for_mode(self._attr_hvac_mode)
+        return self._setpoint_range_for_mode(self._attr_hvac_mode)[0]
 
     @property
     def max_temp(self) -> float:
-        return self._max_temp_for_mode(self._attr_hvac_mode)
+        return self._setpoint_range_for_mode(self._attr_hvac_mode)[1]
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
@@ -381,8 +404,7 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
         # being switched to, not the (still stale until the next poll) current one.
         target_hvac_mode = kwargs.get("hvac_mode", self._attr_hvac_mode)
         target_hvac_mode = HVACMode.OFF if target_hvac_mode is None else target_hvac_mode
-        min_temp = self._min_temp_for_mode(target_hvac_mode)
-        max_temp = self._max_temp_for_mode(target_hvac_mode)
+        min_temp, max_temp = self._setpoint_range_for_mode(target_hvac_mode)
 
         if set_temp < min_temp:
             raise ServiceValidationError(

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -261,6 +261,21 @@ async def test_climate_commands_and_state_branches(platform_device):
     with pytest.raises(ServiceValidationError, match="above maximum"):
         await entity.async_set_temperature(temperature=34, hvac_mode=HVACMode.COOL)
 
+    # A setpoint set while the unit is off belongs to the mode that comes
+    # next, so it is held to what the unit accepts anywhere rather than to the
+    # 18C floor of a mode nobody asked for (#317).
+    entity._attr_hvac_mode = HVACMode.OFF
+    assert (entity.min_temp, entity.max_temp) == (16, 30)
+    await entity.async_set_temperature(temperature=16)
+    assert platform_device.async_queue_command.await_args.args[0][AirconCommands.PresetTemp] == 16
+    entity._attr_hvac_mode = HVACMode.FAN_ONLY
+    assert entity.min_temp == 16
+    entity._attr_hvac_mode = HVACMode.HEAT
+    assert entity.min_temp == 18
+    with pytest.raises(ServiceValidationError, match="below minimum"):
+        await entity.async_set_temperature(temperature=16)
+    entity._attr_hvac_mode = HVACMode.COOL
+
     platform_device.airco.Operation = True
     platform_device.airco.CompressorRunning = True
     for mode, expected in ((0, HVACAction.COOLING), (1, HVACAction.COOLING), (2, HVACAction.HEATING), (3, HVACAction.FAN), (4, HVACAction.DRYING)):


### PR DESCRIPTION
`climate.set_temperature` validated against the mode the unit is in *right now*. Only `cool` has the 16 °C floor; everything else, including `off`, gets 18 °C. So an automation that sets 16 °C and then switches the unit to cooling was rejected with `temp_out_of_range`, while the same 16 °C typed into the card went through — by the time anyone looks at the card, the unit is already cooling.

Off and fan-only have no setpoint of their own: the value belongs to whichever regulating mode is turned on next. Both are now held to what the unit accepts anywhere — 16–30 normally, 10–33 on `PresetTempRange2` models — while a regulating mode keeps its own range. `min_temp`/`max_temp` use the same resolution, so the reported attribute and the validation agree.

Fixes #317