### PR TITLE
Group the options, and name the source after the temperature it carries

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ This integration creates one device per airco with the following entities.
 
 ## Sensors
 
-The diagnostic operation-data sensors below are disabled by default. Enabling a sensor makes the integration request its value; leaving all of them disabled makes no extra request at all - unless an external temperature override is armed, which asks for one segment on its own behalf (see [External temperature override](#external-temperature-override)).
+The diagnostic operation-data sensors below are disabled by default. Enabling a sensor makes the integration request its value; leaving all of them disabled makes no extra request at all - unless an external temperature override is armed, which asks for one segment on its own behalf (see [External temperature override](#indoor-temperature-override)).
 
 Any one of them switches the request on, so pick one that always has something to show. **Indoor Coil Temperature** is the safest choice: it is per indoor unit and reads a temperature whatever the system is doing. **Compressor Frequency** is the more telling value where it works, but reads a constant 0 on older firmware ([#207](https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues/207)). **Hot Gas Temperature** is a poor first choice: it reads unknown whenever the outdoor unit is idle, which looks like a broken sensor rather than a resting one.
 
 | Entity | Values | Description |
 |---|---|---|
-| Indoor Temperature | °C | The room temperature the unit reports, exposed as its own sensor. Normally the same value as the climate entity's `current_temperature`; while an external temperature override is in effect it follows that override rather than the room (see [External temperature override](#external-temperature-override)). |
+| Indoor Temperature | °C | The room temperature the unit reports, exposed as its own sensor. Normally the same value as the climate entity's `current_temperature`; while an external temperature override is in effect it follows that override rather than the room (see [External temperature override](#indoor-temperature-override)). |
 | Outdoor Temperature *(shared on multi-split)* | °C | Outdoor unit temperature, corrected by the "Outdoor Temp. Sensor Offset" option if set. On multi-split systems this is an outdoor-unit-level value - reads identically on every indoor unit sharing one outdoor unit, since there's only one outdoor sensor. |
 | Target Temperature *(disabled by default)* | °C | Current setpoint, exposed as its own sensor. Off by default because the climate entity already carries the same value as its `target_temperature` attribute. |
 | Energy Usage (current run) | kWh, increasing | Energy consumption of the **current run**, as reported by the unit in **0.25 kWh steps**. The unit clears this counter to 0 every time it is switched on, and holds the last value while it is off — so a low or zero reading is normal, not a fault, and a run consuming less than 0.25 kWh reads 0 throughout. For a lifetime figure use Energy Usage Total below. Only created if the unit actually reports this value — not all models do. |
@@ -262,6 +262,12 @@ address itself isn't here - it's connection-critical, so changing it goes
 through "Reconfigure" instead, which re-validates the new address against the
 device before saving it.
 
+The dialog groups these into three sections: **Indoor temperature source**
+(the source sensor and its two overshoot corrections), **Setpoint offsets**
+(what gets sent to the unit) and **Sensor offsets** (what Home Assistant
+shows). The overshoot fields only appear once a source is picked and saved -
+without one there is no room temperature for them to correct.
+
 | Option | Range | Description |
 |---|---|---|
 | Retry limit | 3 or higher, default 3 | Consecutive failed polls before the device is marked unavailable. At the 60 s poll interval, `3` is about 3 minutes - enough to ride through the module's hourly WiFi reassociation. Raise it on a weak link; it cannot be set lower. |
@@ -270,7 +276,7 @@ device before saving it.
 | Target Temp. Offset | -5..5 °C | Calibrates the *setpoint sent to the unit* - see "Target Temp. Offset sign convention" below. Applies to every `hvac_mode` unless overridden by the two options below. |
 | Target Temp. Offset (Cooling) | -5..5 °C, unset by default | Overrides Target Temp. Offset for `cool` and `dry` mode. Leave unset to keep using Target Temp. Offset for those modes too. |
 | Target Temp. Offset (Heating) | -5..5 °C, unset by default | Overrides Target Temp. Offset for `heat` mode. Leave unset to keep using Target Temp. Offset for `heat` too. |
-| Cooling overshoot | -3..3 °C | How far past your setting the room actually goes before the unit stops. Set 22 °C, room settles at 21 °C: enter 1. Only has an effect while an external room temperature is in use. |
+| Cooling overshoot | -3..3 °C | How far past your setting the room actually goes before the unit stops. Set 22 °C, room settles at 21 °C: enter 1. Only shown, and only has an effect, while an Indoor temperature source is configured. |
 | Heating overshoot | -3..3 °C | The same for heating: how far above your setting the room ends up. Positive in both cases. |
 | Check for firmware updates | on/off, off by default | Creates the Firmware Update entity (see Update above) and periodically checks the manufacturer's `getFirmware` endpoint. The only outbound internet call this integration makes - leave off to stay fully local. |
 
@@ -297,9 +303,9 @@ The climate entity exposes the following entity services (use as `mitsubishi_wf_
 | `set_vertical_swing_mode` | `swing_mode` | Set the vertical (up/down) louver position. |
 | `request_home_leave_mode_status` | — | Ask the unit to report its Home Leave Mode thresholds/airflow (only on supporting models). |
 | `set_home_leave_mode` | `temp_rule_cooling`, `temp_setting_cooling`, `air_flow_cooling`, `temp_rule_heating`, `temp_setting_heating`, `air_flow_heating` | Write new Home Leave Mode thresholds/airflow (only on supporting models). |
-| `set_external_temperature` | `temperature` (optional) | Provide an external room temperature to the AC, overriding its own indoor sensor. Omit `temperature` or pass `null` to revert to the internal sensor. See below. |
+| `set_external_temperature` | `temperature` (optional) | Provide a room temperature to the AC, overriding the one its own indoor sensor reads. Omit `temperature` or pass `null` to revert to the internal sensor. See below. |
 
-## External temperature override
+## Indoor temperature override
 
 `set_external_temperature` hands the unit a room temperature measured somewhere you actually care about, and it regulates on that instead of its own return-air sensor.
 
@@ -309,9 +315,9 @@ The value is not a setting the unit stores under a flag of its own. It has no se
 - **Nothing is written just for the override.** A frame carrying it also re-asserts power, mode, fan speed, setpoint and both louver axes, and it takes the unit's 60-second write lock. Sending one per sensor reading would end any running self-clean cycle and keep the official app locked out for as long as the override is in use.
 - **While the unit is off or in `fan_only`, the override is not written.** Neither mode regulates on a room temperature, and a request carrying the value ends a self-clean cycle started from the remote - self-clean runs from the off state. The unit falls back to its own sensor there, and the first frame after it returns to a regulating mode writes the value again.
 
-The **External Temperature Active** sensor (diagnostic) says whether the unit is actually regulating on your value right now, so an override that is armed but not yet in effect - after a restart, or while the unit is off - is visible rather than something to deduce.
+The **Indoor temperature override** sensor (diagnostic) says whether the unit is actually regulating on your value right now, so an override that is armed but not yet in effect - after a restart, or while the unit is off - is visible rather than something to deduce.
 
-You can select an **External temperature source** in the integration options. The integration reads that temperature sensor immediately after setup and follows its state changes itself, converting its unit to °C and rounding to the protocol's 0.25 °C steps. If the source becomes `unavailable`, `unknown`, or disappears, it clears the override on the next frame so the unit returns to its internal sensor. When a source is configured, use of `set_external_temperature` with a value is refused to avoid two competing writers; calling it without `temperature` still clears the override, though only until the source reports again. The source cannot be one of this integration's own temperature sensors: while an override is armed those report the injected value back, so feeding one in would walk the override away from the room. Without a configured source, automations using the action remain supported as before. Clearing that option hands control back: the value it had armed is dropped rather than restored, and the unit is back on its own sensor.
+You can select a sensor under **Indoor temperature source** in the integration options. The integration reads that temperature sensor immediately after setup and follows its state changes itself, converting its unit to °C and rounding to the protocol's 0.25 °C steps. If the source becomes `unavailable`, `unknown`, or disappears, it clears the override on the next frame so the unit returns to its internal sensor. When a source is configured, use of `set_external_temperature` with a value is refused to avoid two competing writers; calling it without `temperature` still clears the override, though only until the source reports again. The source cannot be one of this integration's own temperature sensors: while an override is armed those report the injected value back, so feeding one in would walk the override away from the room. Without a configured source, automations using the action remain supported as before. Clearing that option hands control back: the value it had armed is dropped rather than restored, and the unit is back on its own sensor.
 
 What an armed override costs is one request per poll cycle, which holds the unit's write lock for part of the cycle exactly as an enabled operation-data sensor does.
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ The climate entity exposes the following entity services (use as `mitsubishi_wf_
 
 ## Indoor temperature override
 
-`set_external_temperature` hands the unit a room temperature measured somewhere you actually care about, and it regulates on that instead of its own return-air sensor.
+`set_external_temperature` hands the unit a room temperature measured out in the room, and it regulates on that instead of the one its own return-air sensor reads.
 
 The value is not a setting the unit stores under a flag of its own. It has no set-bit, which means it can only travel inside a frame sent for some other reason - and any frame that leaves it out sends the unit back to its internal sensor. Three things follow from that.
 

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     CONF_PORT,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import section
 from homeassistant.helpers import entity_registry as er, selector
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
@@ -45,6 +46,12 @@ from .coordinator import AVAILABILITY_FAILURE_LIMIT_MIN
 from .wfrac.repository import AirconApiError, Repository
 
 _LOGGER = logging.getLogger(__name__)
+
+# Form-only keys: sections group the fields in the dialog, they are not
+# options themselves and never reach entry.options - see async_step_init.
+SECTION_INDOOR_TEMPERATURE_SOURCE = "indoor_temperature_source"
+SECTION_SETPOINT_OFFSETS = "setpoint_offsets"
+SECTION_SENSOR_OFFSETS = "sensor_offsets"
 
 
 class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -431,18 +438,65 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
             )
         )
 
+    @property
+    def _source_configured(self) -> bool:
+        """Whether a temperature source entity is picked for this entry."""
+        return bool(self.config_entry.options.get(CONF_EXTERNAL_TEMPERATURE_SOURCE))
+
+    def _rendered_option_keys(self) -> set[str]:
+        """The option keys this form shows for the current configuration.
+
+        Deliberately derived from the saved options - the same input the
+        schema is built from - rather than recorded while building it: the
+        save path needs to know what the form could not have collected, and
+        answering that from state carried between the two halves is one
+        forgotten assignment away from silently dropping settings.
+        """
+        keys = {
+            CONF_AVAILABILITY_RETRY_LIMIT,
+            CONF_FIRMWARE_UPDATE_CHECK,
+            CONF_EXTERNAL_TEMPERATURE_SOURCE,
+            CONF_TARGET_OFFSET,
+            CONF_TARGET_OFFSET_COOL,
+            CONF_TARGET_OFFSET_HEAT,
+            CONF_INDOOR_OFFSET,
+            CONF_OUTDOOR_OFFSET,
+        }
+        if self._source_configured:
+            keys |= {CONF_OVERSHOOT_COOL, CONF_OVERSHOOT_HEAT}
+        return keys
+
     async def async_step_init(
             self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
+            # Sections hand their fields back nested under the section key,
+            # while everything that reads an option reads it flat off
+            # entry.options - so the shape is flattened straight back out and
+            # the stored options stay exactly what they have always been.
+            data: dict[str, Any] = {}
+            for key, value in user_input.items():
+                if isinstance(value, dict):
+                    data.update(value)
+                else:
+                    data[key] = value
+            # A field the form did not show cannot be collected from it, and
+            # async_create_entry replaces the options wholesale rather than
+            # merging - so an unrendered value has to be carried over by hand
+            # or it is dropped. That is how the overshoot figures survive
+            # removing the source that hides them. A field that was shown and
+            # left empty is meant to be empty and is not carried over.
+            for key, value in self.config_entry.options.items():
+                if key not in self._rendered_option_keys():
+                    data.setdefault(key, value)
             # Host moved to the reconfigure flow (validated against the
             # device) - keep the entry's existing value, since this form no
-            # longer collects it and async_create_entry replaces options
-            # wholesale rather than merging.
-            data = {**user_input, CONF_HOST: self.config_entry.options[CONF_HOST]}
+            # longer collects it.
+            data[CONF_HOST] = self.config_entry.options[CONF_HOST]
             return self.async_create_entry(title="", data=data)
 
+        options = self.config_entry.options
         offset_range_validator = vol.All(vol.Coerce(float), vol.Range(min=-5.0, max=5.0))
         # Negative allowed, though overshooting is what everyone has measured
         # so far: a unit that stops short of the setting instead needs the
@@ -451,12 +505,48 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
         overshoot_validator = vol.All(
             vol.Coerce(float), vol.Range(min=-OVERSHOOT_MAX, max=OVERSHOOT_MAX)
         )
-        overshoot_fields: dict[Any, Any] = {
+
+        source_fields: dict[Any, Any] = {
+            # Keep this optional without a default: an omitted source must
+            # stay omitted, rather than becoming a falsey value that
+            # unnecessarily changes the saved options shape.
             vol.Optional(
-                key,
-                default=self.config_entry.options.get(key, 0.0),
-            ): overshoot_validator
-            for key in (CONF_OVERSHOOT_COOL, CONF_OVERSHOOT_HEAT)
+                CONF_EXTERNAL_TEMPERATURE_SOURCE,
+                description={
+                    "suggested_value": options.get(CONF_EXTERNAL_TEMPERATURE_SOURCE)
+                },
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(
+                    domain="sensor",
+                    device_class="temperature",
+                    # This integration's own temperature sensors report the
+                    # injected value back while an override is armed, so
+                    # picking one would feed the override into itself and walk
+                    # it away from the room half a kelvin per poll.
+                    # EntitySelector rejects an excluded entity on submit, not
+                    # just in the picker, so this is the enforcement and not
+                    # only a convenience.
+                    exclude_entities=self._own_entity_ids(),
+                )
+            ),
+        }
+        # The overshoot corrections act on the room temperature handed to the
+        # unit, so without a source there is no value to bend and the fields
+        # do nothing at all. They appear once a source is picked and saved -
+        # a form cannot rebuild itself while it is open.
+        if self._source_configured:
+            source_fields.update(
+                {
+                    vol.Optional(key, default=options.get(key, 0.0)): overshoot_validator
+                    for key in (CONF_OVERSHOOT_COOL, CONF_OVERSHOOT_HEAT)
+                }
+            )
+
+        setpoint_fields: dict[Any, Any] = {
+            vol.Optional(
+                CONF_TARGET_OFFSET,
+                default=options.get(CONF_TARGET_OFFSET, 0.0),
+            ): offset_range_validator,
         }
         # target_offset_cool/heat are optional per-mode overrides that must
         # stay "unset" (None) unless the user explicitly fills them in - a
@@ -464,12 +554,22 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
         # fallback-to-target_offset resolution in climate.py. suggested_value
         # (not default=) pre-fills the displayed value without forcing one
         # when absent.
-        per_mode_offset_fields: dict[Any, Any] = {
+        setpoint_fields.update(
+            {
+                vol.Optional(
+                    key,
+                    description={"suggested_value": options.get(key)},
+                ): vol.Any(None, offset_range_validator)
+                for key in (CONF_TARGET_OFFSET_COOL, CONF_TARGET_OFFSET_HEAT)
+            }
+        )
+
+        sensor_fields: dict[Any, Any] = {
             vol.Optional(
                 key,
-                description={"suggested_value": self.config_entry.options.get(key)},
-            ): vol.Any(None, offset_range_validator)
-            for key in (CONF_TARGET_OFFSET_COOL, CONF_TARGET_OFFSET_HEAT)
+                default=options.get(key, 0.0),
+            ): vol.All(vol.Coerce(float), vol.Range(min=-15.0, max=15.0))
+            for key in (CONF_INDOOR_OFFSET, CONF_OUTDOOR_OFFSET)
         }
 
         return self.async_show_form(
@@ -481,53 +581,29 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
                     # migrations. Raising it stays available for weak links.
                     vol.Required(
                         CONF_AVAILABILITY_RETRY_LIMIT,
-                        default=self.config_entry.options.get(
+                        default=options.get(
                             CONF_AVAILABILITY_RETRY_LIMIT, AVAILABILITY_FAILURE_LIMIT_MIN
                         ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=AVAILABILITY_FAILURE_LIMIT_MIN)),
                     vol.Required(
                         CONF_FIRMWARE_UPDATE_CHECK,
-                        default=self.config_entry.options.get(CONF_FIRMWARE_UPDATE_CHECK, False),
+                        default=options.get(CONF_FIRMWARE_UPDATE_CHECK, False),
                     ): bool,
-                    vol.Optional(
-                        CONF_INDOOR_OFFSET,
-                        default=self.config_entry.options.get(CONF_INDOOR_OFFSET, 0.0),
-                    ): vol.All(vol.Coerce(float), vol.Range(min=-15.0, max=15.0)),
-                    # Keep this optional without a default: an omitted source
-                    # must stay omitted, rather than becoming a falsey value
-                    # that unnecessarily changes the saved options shape.
-                    vol.Optional(
-                        CONF_EXTERNAL_TEMPERATURE_SOURCE,
-                        description={
-                            "suggested_value": self.config_entry.options.get(
-                                CONF_EXTERNAL_TEMPERATURE_SOURCE
-                            )
-                        },
-                    ): selector.EntitySelector(
-                        selector.EntitySelectorConfig(
-                            domain="sensor",
-                            device_class="temperature",
-                            # This integration's own temperature sensors report
-                            # the injected value back while an override is
-                            # armed, so picking one would feed the override
-                            # into itself and walk it away from the room half a
-                            # kelvin per poll. EntitySelector rejects an
-                            # excluded entity on submit, not just in the
-                            # picker, so this is the enforcement and not only a
-                            # convenience.
-                            exclude_entities=self._own_entity_ids(),
-                        )
+                    vol.Required(SECTION_INDOOR_TEMPERATURE_SOURCE): section(
+                        vol.Schema(source_fields), {"collapsed": False}
                     ),
-                    vol.Optional(
-                        CONF_OUTDOOR_OFFSET,
-                        default=self.config_entry.options.get(CONF_OUTDOOR_OFFSET, 0.0),
-                    ): vol.All(vol.Coerce(float), vol.Range(min=-15.0, max=15.0)),
-                    vol.Optional(
-                        CONF_TARGET_OFFSET,
-                        default=self.config_entry.options.get(CONF_TARGET_OFFSET, 0.0),
-                    ): offset_range_validator,
-                    **per_mode_offset_fields,
-                    **overshoot_fields,
+                    # Collapsed once a source is in use: the overshoot above is
+                    # the right lever then, and these two stack with it if both
+                    # are set. Still shown, because they keep working - what
+                    # they correct is the unit's own sensor bias, which is out
+                    # of the loop while the unit regulates on a supplied value.
+                    vol.Required(SECTION_SETPOINT_OFFSETS): section(
+                        vol.Schema(setpoint_fields),
+                        {"collapsed": self._source_configured},
+                    ),
+                    vol.Required(SECTION_SENSOR_OFFSETS): section(
+                        vol.Schema(sensor_fields), {"collapsed": True}
+                    ),
                 },
             ),
         )

--- a/custom_components/mitsubishi_wf_rac/services.yaml
+++ b/custom_components/mitsubishi_wf_rac/services.yaml
@@ -198,7 +198,7 @@ set_external_temperature:
   fields:
     temperature:
       name: Temperature
-      description: Room temperature in °C, measured wherever you care about it. Leave blank to use the unit's own sensor.
+      description: Room temperature in °C. Leave blank to use the unit's own sensor.
       required: false
       selector:
         number:

--- a/custom_components/mitsubishi_wf_rac/services.yaml
+++ b/custom_components/mitsubishi_wf_rac/services.yaml
@@ -183,10 +183,10 @@ set_home_leave_mode:
               value: "4"
 # Service ID
 set_external_temperature:
-  name: Set external temperature override
+  name: Set indoor temperature override
   description: >-
-    Arms an external room temperature for the AC to regulate on instead of its
-    own indoor sensor. The value is not sent by this action; it rides along on
+    Arms a room temperature for the AC to regulate on instead of the one its
+    own indoor sensor reads. The value is not sent by this action; it rides along on
     the next frame that goes out anyway, so it takes effect within a minute.
     While an override is armed the integration asks the unit for one operation
     data segment per cycle, which is the frame that carries it. Omit the
@@ -198,7 +198,7 @@ set_external_temperature:
   fields:
     temperature:
       name: Temperature
-      description: External room temperature in °C. Leave blank to use the internal sensor.
+      description: Room temperature in °C, measured wherever you care about it. Leave blank to use the unit's own sensor.
       required: false
       selector:
         number:

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -54,24 +54,46 @@
         "description": "Below are the options you can change for this airco.",
         "data": {
           "availability_retry_limit": "Retry limit (minimum 3)",
-          "firmware_update_check": "Firmware Update Check (Online)",
-          "external_temperature_source": "External temperature source",
-          "indoor_offset": "Indoor Temp. Sensor Offset",
-          "outdoor_offset": "Outdoor Temp. Sensor Offset",
-          "target_offset": "Target Temp. Offset",
-          "target_offset_cool": "Target Temp. Offset (Cooling)",
-          "target_offset_heat": "Target Temp. Offset (Heating)",
-          "overshoot_cool": "Cooling overshoot",
-          "overshoot_heat": "Heating overshoot"
+          "firmware_update_check": "Firmware Update Check (Online)"
         },
         "title": "WF-RAC options",
-        "data_description": {
-          "target_offset_cool": "Leave empty to use the general target temperature offset.",
-          "target_offset_heat": "Leave empty to use the general target temperature offset.",
-          "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. If it stops short instead and never gets cold enough, enter a negative number. Only has an effect while an external room temperature is in use.",
-          "overshoot_heat": "The same for heating: positive if the room ends up above your setting, negative if it stops short of it.",
-          "target_offset": "Most units round a half degree up to the next whole one, so 0.5 here often acts as 1.",
-          "external_temperature_source": "The selected sensor controls the external temperature override. Unavailable or unknown states return the unit to its internal sensor."
+        "sections": {
+          "indoor_temperature_source": {
+            "name": "Indoor temperature source",
+            "description": "Hand the unit a room temperature measured where you care about it, instead of the one it reads at its own return air grille.",
+            "data": {
+              "external_temperature_source": "Sensor",
+              "overshoot_cool": "Cooling overshoot",
+              "overshoot_heat": "Heating overshoot"
+            },
+            "data_description": {
+              "external_temperature_source": "The unit regulates on this sensor. Leave it empty to put the unit back on its own sensor. Unavailable or unknown states do the same on the next frame.",
+              "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. If it stops short instead and never gets cold enough, enter a negative number.",
+              "overshoot_heat": "The same for heating: positive if the room ends up above your setting, negative if it stops short of it."
+            }
+          },
+          "setpoint_offsets": {
+            "name": "Setpoint offsets",
+            "description": "Change the setting sent to the unit while the card keeps showing yours. With a source in use the overshoot above is the better lever, and setting both applies both.",
+            "data": {
+              "target_offset": "Target Temp. Offset",
+              "target_offset_cool": "Target Temp. Offset (Cooling)",
+              "target_offset_heat": "Target Temp. Offset (Heating)"
+            },
+            "data_description": {
+              "target_offset": "Positive lowers the setting sent to the unit, negative raises it - the card keeps showing yours either way. Most units round a half degree up to the next whole one, so 0.5 here often acts as 1.",
+              "target_offset_cool": "Leave empty to use the general target temperature offset.",
+              "target_offset_heat": "Leave empty to use the general target temperature offset."
+            }
+          },
+          "sensor_offsets": {
+            "name": "Sensor offsets",
+            "description": "Correct the readings shown in Home Assistant. Display only - neither changes what the unit does.",
+            "data": {
+              "indoor_offset": "Indoor Temp. Sensor Offset",
+              "outdoor_offset": "Outdoor Temp. Sensor Offset"
+            }
+          }
         }
       }
     }
@@ -93,7 +115,7 @@
       "message": "This model does not report the Home Leave Mode capability."
     },
     "external_temperature_source_configured": {
-      "message": "External temperature is controlled by the configured source entity."
+      "message": "The indoor temperature is controlled by the configured source entity."
     },
     "home_leave_mode_status_unknown": {
       "message": "Home Leave Mode values are unknown yet. Call the climate entity's \"Request Home Leave Mode status\" action once first - the unit doesn't include them in a plain poll."
@@ -337,7 +359,7 @@
         "name": "External Control"
       },
       "external_temperature_active": {
-        "name": "External Temperature Active"
+        "name": "Indoor temperature override"
       }
     },
     "button": {

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -60,7 +60,7 @@
         "sections": {
           "indoor_temperature_source": {
             "name": "Indoor temperature source",
-            "description": "Hand the unit a room temperature measured where you care about it, instead of the one it reads at its own return air grille.",
+            "description": "Hand the unit a room temperature measured out in the room, instead of the one it reads at its own return air grille.",
             "data": {
               "external_temperature_source": "Sensor",
               "overshoot_cool": "Cooling overshoot",

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -77,17 +77,35 @@
         "description": "Nachfolgend finden Sie die Optionen, die Sie für diese Klimaanlage ändern können.",
         "data": {
           "availability_retry_limit": "max. Anzahl Wiederholungen (mind. 3)",
-          "firmware_update_check": "Firmware-Update-Prüfung (Online)",
-          "indoor_offset": "Innentemperatur Sensor-Offset",
-          "outdoor_offset": "Außentemperatur Sensor-Offset",
-          "target_offset": "Zieltemperatur-Offset",
-          "target_offset_cool": "Zieltemperatur-Offset (Kühlen)",
-          "target_offset_heat": "Zieltemperatur-Offset (Heizen)"
+          "firmware_update_check": "Firmware-Update-Prüfung (Online)"
         },
         "title": "WF-RAC Optionen",
-        "data_description": {
-          "target_offset_cool": "Leer lassen, um den allgemeinen Zieltemperatur-Offset zu verwenden.",
-          "target_offset_heat": "Leer lassen, um den allgemeinen Zieltemperatur-Offset zu verwenden."
+        "sections": {
+          "indoor_temperature_source": {
+            "name": "Quelle der Innentemperatur",
+            "description": "Gibt dem Gerät eine Raumtemperatur, die dort gemessen wird, wo es darauf ankommt, statt der am eigenen Ansauggitter."
+          },
+          "setpoint_offsets": {
+            "name": "Sollwert-Korrekturen",
+            "description": "Verschieben den Wert, der ans Gerät geht, während die Karte weiterhin Ihren zeigt. Bei genutzter Quelle ist der Überschwing-Wert oben der bessere Hebel; sind beide gesetzt, wirken auch beide.",
+            "data": {
+              "target_offset": "Zieltemperatur-Offset",
+              "target_offset_cool": "Zieltemperatur-Offset (Kühlen)",
+              "target_offset_heat": "Zieltemperatur-Offset (Heizen)"
+            },
+            "data_description": {
+              "target_offset_cool": "Leer lassen, um den allgemeinen Zieltemperatur-Offset zu verwenden.",
+              "target_offset_heat": "Leer lassen, um den allgemeinen Zieltemperatur-Offset zu verwenden."
+            }
+          },
+          "sensor_offsets": {
+            "name": "Sensor-Korrekturen",
+            "description": "Korrigieren nur die in Home Assistant angezeigten Messwerte, nicht das Verhalten des Geräts.",
+            "data": {
+              "indoor_offset": "Innentemperatur Sensor-Offset",
+              "outdoor_offset": "Außentemperatur Sensor-Offset"
+            }
+          }
         }
       }
     }

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -86,7 +86,7 @@
         "sections": {
           "indoor_temperature_source": {
             "name": "Indoor temperature source",
-            "description": "Hand the unit a room temperature measured where you care about it, instead of the one it reads at its own return air grille.",
+            "description": "Hand the unit a room temperature measured out in the room, instead of the one it reads at its own return air grille.",
             "data": {
               "external_temperature_source": "Sensor",
               "overshoot_cool": "Cooling overshoot",

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -56,7 +56,7 @@
       "message": "{temperature} °C is above the {max_temp} °C maximum for this mode."
     },
     "external_temperature_source_configured": {
-      "message": "External temperature is controlled by the configured source entity."
+      "message": "The indoor temperature is controlled by the configured source entity."
     },
     "home_leave_mode_not_supported": {
       "message": "This model does not report the Home Leave Mode capability."
@@ -80,24 +80,46 @@
         "description": "Below are the options you can change for this airco.",
         "data": {
           "availability_retry_limit": "Retry limit (minimum 3)",
-          "firmware_update_check": "Firmware Update Check (Online)",
-          "external_temperature_source": "External temperature source",
-          "indoor_offset": "Indoor Temp. Sensor Offset",
-          "outdoor_offset": "Outdoor Temp. Sensor Offset",
-          "target_offset": "Target Temp. Offset",
-          "target_offset_cool": "Target Temp. Offset (Cooling)",
-          "target_offset_heat": "Target Temp. Offset (Heating)",
-          "overshoot_cool": "Cooling overshoot",
-          "overshoot_heat": "Heating overshoot"
+          "firmware_update_check": "Firmware Update Check (Online)"
         },
         "title": "WF-RAC options",
-        "data_description": {
-          "target_offset_cool": "Leave empty to use the general target temperature offset.",
-          "target_offset_heat": "Leave empty to use the general target temperature offset.",
-          "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. If it stops short instead and never gets cold enough, enter a negative number. Only has an effect while an external room temperature is in use.",
-          "overshoot_heat": "The same for heating: positive if the room ends up above your setting, negative if it stops short of it.",
-          "target_offset": "Most units round a half degree up to the next whole one, so 0.5 here often acts as 1.",
-          "external_temperature_source": "The selected sensor controls the external temperature override. Unavailable or unknown states return the unit to its internal sensor."
+        "sections": {
+          "indoor_temperature_source": {
+            "name": "Indoor temperature source",
+            "description": "Hand the unit a room temperature measured where you care about it, instead of the one it reads at its own return air grille.",
+            "data": {
+              "external_temperature_source": "Sensor",
+              "overshoot_cool": "Cooling overshoot",
+              "overshoot_heat": "Heating overshoot"
+            },
+            "data_description": {
+              "external_temperature_source": "The unit regulates on this sensor. Leave it empty to put the unit back on its own sensor. Unavailable or unknown states do the same on the next frame.",
+              "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. If it stops short instead and never gets cold enough, enter a negative number.",
+              "overshoot_heat": "The same for heating: positive if the room ends up above your setting, negative if it stops short of it."
+            }
+          },
+          "setpoint_offsets": {
+            "name": "Setpoint offsets",
+            "description": "Change the setting sent to the unit while the card keeps showing yours. With a source in use the overshoot above is the better lever, and setting both applies both.",
+            "data": {
+              "target_offset": "Target Temp. Offset",
+              "target_offset_cool": "Target Temp. Offset (Cooling)",
+              "target_offset_heat": "Target Temp. Offset (Heating)"
+            },
+            "data_description": {
+              "target_offset": "Positive lowers the setting sent to the unit, negative raises it - the card keeps showing yours either way. Most units round a half degree up to the next whole one, so 0.5 here often acts as 1.",
+              "target_offset_cool": "Leave empty to use the general target temperature offset.",
+              "target_offset_heat": "Leave empty to use the general target temperature offset."
+            }
+          },
+          "sensor_offsets": {
+            "name": "Sensor offsets",
+            "description": "Correct the readings shown in Home Assistant. Display only - neither changes what the unit does.",
+            "data": {
+              "indoor_offset": "Indoor Temp. Sensor Offset",
+              "outdoor_offset": "Outdoor Temp. Sensor Offset"
+            }
+          }
         }
       }
     }
@@ -332,7 +354,7 @@
         "name": "External Control"
       },
       "external_temperature_active": {
-        "name": "External Temperature Active"
+        "name": "Indoor temperature override"
       }
     },
     "switch": {},

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -77,17 +77,35 @@
         "description": "以下は、このエアコンの変更可能なオプションです。",
         "data": {
           "availability_retry_limit": "リトライ回数の上限（最小 3）",
-          "firmware_update_check": "ファームウェア更新の確認 (オンライン)",
-          "indoor_offset": "室内オフセット",
-          "outdoor_offset": "室外オフセット",
-          "target_offset": "設定オフセット",
-          "target_offset_cool": "設定オフセット（冷房時）",
-          "target_offset_heat": "設定オフセット（暖房時）"
+          "firmware_update_check": "ファームウェア更新の確認 (オンライン)"
         },
         "title": "WF-RAC の設定",
-        "data_description": {
-          "target_offset_cool": "空欄の場合は、共通の設定オフセットが使用されます。",
-          "target_offset_heat": "空欄の場合は、共通の設定オフセットが使用されます。"
+        "sections": {
+          "indoor_temperature_source": {
+            "name": "室内温度の取得元",
+            "description": "エアコン自身の吸込口ではなく、実際に気になる場所で測った室温をエアコンに渡します。"
+          },
+          "setpoint_offsets": {
+            "name": "設定温度の補正",
+            "description": "カードには設定した値を表示したまま、エアコンに送る値をずらします。取得元を使っている場合は上のオーバーシュート補正のほうが適しています。両方設定すると両方効きます。",
+            "data": {
+              "target_offset": "設定オフセット",
+              "target_offset_cool": "設定オフセット（冷房時）",
+              "target_offset_heat": "設定オフセット（暖房時）"
+            },
+            "data_description": {
+              "target_offset_cool": "空欄の場合は、共通の設定オフセットが使用されます。",
+              "target_offset_heat": "空欄の場合は、共通の設定オフセットが使用されます。"
+            }
+          },
+          "sensor_offsets": {
+            "name": "センサー値の補正",
+            "description": "Home Assistant に表示される値だけを補正します。エアコンの動作は変わりません。",
+            "data": {
+              "indoor_offset": "室内オフセット",
+              "outdoor_offset": "室外オフセット"
+            }
+          }
         }
       }
     }

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -77,17 +77,35 @@
         "description": "Žemiau pateikiamos parinktys, kurias galite keisti šiam oro kondicionieriui.",
         "data": {
           "availability_retry_limit": "Pakartotinio bandymo limitas (min. 3)",
-          "firmware_update_check": "Programinės įrangos atnaujinimų tikrinimas (internetu)",
-          "indoor_offset": "Vidaus poslinkis",
-          "outdoor_offset": "Lauko poslinkis",
-          "target_offset": "Tikslinis poslinkis",
-          "target_offset_cool": "Tikslinis poslinkis (vėsinimas)",
-          "target_offset_heat": "Tikslinis poslinkis (šildymas)"
+          "firmware_update_check": "Programinės įrangos atnaujinimų tikrinimas (internetu)"
         },
         "title": "WF-RAC parinktys",
-        "data_description": {
-          "target_offset_cool": "Palikite tuščią, jei norite naudoti bendrą tikslinės temperatūros poslinkį.",
-          "target_offset_heat": "Palikite tuščią, jei norite naudoti bendrą tikslinės temperatūros poslinkį."
+        "sections": {
+          "indoor_temperature_source": {
+            "name": "Vidaus temperatūros šaltinis",
+            "description": "Kondicionieriui perduodama kambario temperatūra, išmatuota ten, kur jums svarbu, o ne prie jo paties oro įsiurbimo grotelių."
+          },
+          "setpoint_offsets": {
+            "name": "Nustatytos temperatūros pataisos",
+            "description": "Pakeičia kondicionieriui siunčiamą reikšmę, o kortelėje toliau rodoma jūsų nustatytoji. Naudojant šaltinį, geriau tinka viršuje esanti perviršio pataisa; nustačius abi, veikia abi.",
+            "data": {
+              "target_offset": "Tikslinis poslinkis",
+              "target_offset_cool": "Tikslinis poslinkis (vėsinimas)",
+              "target_offset_heat": "Tikslinis poslinkis (šildymas)"
+            },
+            "data_description": {
+              "target_offset_cool": "Palikite tuščią, jei norite naudoti bendrą tikslinės temperatūros poslinkį.",
+              "target_offset_heat": "Palikite tuščią, jei norite naudoti bendrą tikslinės temperatūros poslinkį."
+            }
+          },
+          "sensor_offsets": {
+            "name": "Jutiklių rodmenų pataisos",
+            "description": "Pataiso tik Home Assistant rodomus rodmenis, o ne paties kondicionieriaus veikimą.",
+            "data": {
+              "indoor_offset": "Vidaus poslinkis",
+              "outdoor_offset": "Lauko poslinkis"
+            }
+          }
         }
       }
     }

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -77,17 +77,35 @@
         "description": "Hieronder zijn instellingen die je kan aanpassen voor deze airco.",
         "data": {
           "availability_retry_limit": "Herhaal limiet (minimaal 3)",
-          "firmware_update_check": "Firmware-updatecontrole (online)",
-          "indoor_offset": "Binnen offset",
-          "outdoor_offset": "Buiten offset",
-          "target_offset": "Doel offset",
-          "target_offset_cool": "Doel offset (Koelen)",
-          "target_offset_heat": "Doel offset (Verwarmen)"
+          "firmware_update_check": "Firmware-updatecontrole (online)"
         },
         "title": "WF-RAC opties",
-        "data_description": {
-          "target_offset_cool": "Laat leeg om de algemene doeltemperatuur-offset te gebruiken.",
-          "target_offset_heat": "Laat leeg om de algemene doeltemperatuur-offset te gebruiken."
+        "sections": {
+          "indoor_temperature_source": {
+            "name": "Bron voor de binnentemperatuur",
+            "description": "Geeft de airco een kamertemperatuur die gemeten is waar het je om gaat, in plaats van die bij zijn eigen aanzuigrooster."
+          },
+          "setpoint_offsets": {
+            "name": "Correcties op het instelpunt",
+            "description": "Verschuiven de waarde die naar de airco gaat, terwijl de kaart die van jou blijft tonen. Met een bron in gebruik is de overshoot hierboven de betere knop; staan ze allebei ingesteld, dan werken ze allebei.",
+            "data": {
+              "target_offset": "Doel offset",
+              "target_offset_cool": "Doel offset (Koelen)",
+              "target_offset_heat": "Doel offset (Verwarmen)"
+            },
+            "data_description": {
+              "target_offset_cool": "Laat leeg om de algemene doeltemperatuur-offset te gebruiken.",
+              "target_offset_heat": "Laat leeg om de algemene doeltemperatuur-offset te gebruiken."
+            }
+          },
+          "sensor_offsets": {
+            "name": "Correcties op sensorwaarden",
+            "description": "Corrigeren alleen wat Home Assistant toont, niet wat de airco doet.",
+            "data": {
+              "indoor_offset": "Binnen offset",
+              "outdoor_offset": "Buiten offset"
+            }
+          }
         }
       }
     }

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -77,17 +77,35 @@
         "description": "以下是你可以为此空调更改的选项。",
         "data": {
           "availability_retry_limit": "重试次数上限（最少 3）",
-          "firmware_update_check": "固件更新检查（在线）",
-          "indoor_offset": "室内偏移",
-          "outdoor_offset": "室外偏移",
-          "target_offset": "目标偏移",
-          "target_offset_cool": "目标偏移（制冷）",
-          "target_offset_heat": "目标偏移（制热）"
+          "firmware_update_check": "固件更新检查（在线）"
         },
         "title": "WF-RAC 选项",
-        "data_description": {
-          "target_offset_cool": "留空以使用通用的目标温度偏移。",
-          "target_offset_heat": "留空以使用通用的目标温度偏移。"
+        "sections": {
+          "indoor_temperature_source": {
+            "name": "室内温度来源",
+            "description": "把你真正在意的位置测得的室温交给空调，取代它自己回风口处的读数。"
+          },
+          "setpoint_offsets": {
+            "name": "设定温度修正",
+            "description": "改变发送给空调的数值，卡片上仍显示你设定的值。使用来源时，上面的过冲修正更合适；两者都设置则两者都会生效。",
+            "data": {
+              "target_offset": "目标偏移",
+              "target_offset_cool": "目标偏移（制冷）",
+              "target_offset_heat": "目标偏移（制热）"
+            },
+            "data_description": {
+              "target_offset_cool": "留空以使用通用的目标温度偏移。",
+              "target_offset_heat": "留空以使用通用的目标温度偏移。"
+            }
+          },
+          "sensor_offsets": {
+            "name": "传感器读数修正",
+            "description": "只修正 Home Assistant 中显示的读数，不改变空调的行为。",
+            "data": {
+              "indoor_offset": "室内偏移",
+              "outdoor_offset": "室外偏移"
+            }
+          }
         }
       }
     }

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -77,17 +77,35 @@
         "description": "以下是你可以為此空調更改的選項。",
         "data": {
           "availability_retry_limit": "重試次數上限（最少 3）",
-          "firmware_update_check": "韌體更新檢查（線上）",
-          "indoor_offset": "室內偏移",
-          "outdoor_offset": "室外偏移",
-          "target_offset": "目標偏移",
-          "target_offset_cool": "目標偏移（製冷）",
-          "target_offset_heat": "目標偏移（製熱）"
+          "firmware_update_check": "韌體更新檢查（線上）"
         },
         "title": "WF-RAC 選項",
-        "data_description": {
-          "target_offset_cool": "留空以使用通用的目標溫度偏移。",
-          "target_offset_heat": "留空以使用通用的目標溫度偏移。"
+        "sections": {
+          "indoor_temperature_source": {
+            "name": "室內溫度來源",
+            "description": "把你真正在意的位置量到的室溫交給空調，取代它自己回風口處的讀數。"
+          },
+          "setpoint_offsets": {
+            "name": "設定溫度修正",
+            "description": "改變送往空調的數值，卡片上仍顯示你設定的值。使用來源時，上面的過衝修正更合適；兩者都設定則兩者都會生效。",
+            "data": {
+              "target_offset": "目標偏移",
+              "target_offset_cool": "目標偏移（製冷）",
+              "target_offset_heat": "目標偏移（製熱）"
+            },
+            "data_description": {
+              "target_offset_cool": "留空以使用通用的目標溫度偏移。",
+              "target_offset_heat": "留空以使用通用的目標溫度偏移。"
+            }
+          },
+          "sensor_offsets": {
+            "name": "感測器讀數修正",
+            "description": "只修正 Home Assistant 中顯示的讀數，不改變空調的行為。",
+            "data": {
+              "indoor_offset": "室內偏移",
+              "outdoor_offset": "室外偏移"
+            }
+          }
         }
       }
     }

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -10,7 +10,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.const import CONF_DEVICE_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType, InvalidData
+from homeassistant.data_entry_flow import FlowResultType, InvalidData, section
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -25,10 +25,16 @@ from custom_components.mitsubishi_wf_rac.const import (
     CONF_OPERATOR_ID,
     CONF_OUTDOOR_OFFSET,
     CONF_OVERSHOOT_COOL,
+    CONF_OVERSHOOT_HEAT,
     CONF_TARGET_OFFSET,
     CONF_TARGET_OFFSET_COOL,
     CONF_TARGET_OFFSET_HEAT,
     DOMAIN,
+)
+from custom_components.mitsubishi_wf_rac.config_flow import (
+    SECTION_INDOOR_TEMPERATURE_SOURCE,
+    SECTION_SENSOR_OFFSETS,
+    SECTION_SETPOINT_OFFSETS,
 )
 from custom_components.mitsubishi_wf_rac.wfrac.repository import AirconApiError
 
@@ -495,6 +501,38 @@ async def test_zeroconf_discovery_confirm_port_can_be_overridden(hass: HomeAssis
 # --- options flow --------------------------------------------------------
 
 
+_OPTION_SECTIONS = {
+    CONF_EXTERNAL_TEMPERATURE_SOURCE: SECTION_INDOOR_TEMPERATURE_SOURCE,
+    CONF_OVERSHOOT_COOL: SECTION_INDOOR_TEMPERATURE_SOURCE,
+    CONF_OVERSHOOT_HEAT: SECTION_INDOOR_TEMPERATURE_SOURCE,
+    CONF_TARGET_OFFSET: SECTION_SETPOINT_OFFSETS,
+    CONF_TARGET_OFFSET_COOL: SECTION_SETPOINT_OFFSETS,
+    CONF_TARGET_OFFSET_HEAT: SECTION_SETPOINT_OFFSETS,
+    CONF_INDOOR_OFFSET: SECTION_SENSOR_OFFSETS,
+    CONF_OUTDOOR_OFFSET: SECTION_SENSOR_OFFSETS,
+}
+
+
+def _form_input(values: dict | None = None) -> dict:
+    """Shape flat option values the way the sectioned form hands them back.
+
+    Every section is present even when empty: they are vol.Required, so a
+    submission that leaves one out is rejected before any field is looked at.
+    """
+    nested: dict = {
+        SECTION_INDOOR_TEMPERATURE_SOURCE: {},
+        SECTION_SETPOINT_OFFSETS: {},
+        SECTION_SENSOR_OFFSETS: {},
+    }
+    for key, value in (values or {}).items():
+        section = _OPTION_SECTIONS.get(key)
+        if section is None:
+            nested[key] = value
+        else:
+            nested[section][key] = value
+    return nested
+
+
 async def test_options_flow_shows_form_with_current_defaults(hass: HomeAssistant):
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -519,12 +557,14 @@ async def test_options_flow_saves_submitted_values(hass: HomeAssistant):
     result = await hass.config_entries.options.async_init(entry.entry_id)
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {
-            CONF_INDOOR_OFFSET: 1.0,
-            CONF_OUTDOOR_OFFSET: -1.0,
-            CONF_TARGET_OFFSET: 0.5,
-            CONF_EXTERNAL_TEMPERATURE_SOURCE: "sensor.living_room_temperature",
-        },
+        _form_input(
+            {
+                CONF_INDOOR_OFFSET: 1.0,
+                CONF_OUTDOOR_OFFSET: -1.0,
+                CONF_TARGET_OFFSET: 0.5,
+                CONF_EXTERNAL_TEMPERATURE_SOURCE: "sensor.living_room_temperature",
+            }
+        ),
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -561,7 +601,7 @@ async def test_options_flow_refuses_its_own_entity_as_source(hass: HomeAssistant
     with pytest.raises((vol.Invalid, InvalidData)):
         await hass.config_entries.options.async_configure(
             result["flow_id"],
-            {CONF_EXTERNAL_TEMPERATURE_SOURCE: own.entity_id},
+            _form_input({CONF_EXTERNAL_TEMPERATURE_SOURCE: own.entity_id}),
         )
 
     assert entry.options.get(CONF_EXTERNAL_TEMPERATURE_SOURCE) is None
@@ -581,7 +621,7 @@ async def test_options_flow_accepts_a_foreign_temperature_sensor(hass: HomeAssis
     result = await hass.config_entries.options.async_init(entry.entry_id)
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {CONF_EXTERNAL_TEMPERATURE_SOURCE: "sensor.hallway_temperature"},
+        _form_input({CONF_EXTERNAL_TEMPERATURE_SOURCE: "sensor.hallway_temperature"}),
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -616,7 +656,7 @@ async def test_options_flow_enforces_offset_range(hass: HomeAssistant, key, valu
     schema = result["data_schema"]
 
     with pytest.raises(vol.MultipleInvalid):
-        schema({key: value})
+        schema(_form_input({key: value}))
 
 
 async def test_options_flow_rejects_a_retry_limit_below_the_floor(hass: HomeAssistant):
@@ -635,9 +675,9 @@ async def test_options_flow_rejects_a_retry_limit_below_the_floor(hass: HomeAssi
     schema = result["data_schema"]
 
     with pytest.raises(vol.MultipleInvalid):
-        schema({CONF_AVAILABILITY_RETRY_LIMIT: 1})
+        schema(_form_input({CONF_AVAILABILITY_RETRY_LIMIT: 1}))
 
-    assert schema({CONF_AVAILABILITY_RETRY_LIMIT: 5})[
+    assert schema(_form_input({CONF_AVAILABILITY_RETRY_LIMIT: 5}))[
         CONF_AVAILABILITY_RETRY_LIMIT
     ] == 5
 
@@ -658,7 +698,7 @@ async def test_options_flow_defaults_firmware_update_check_to_off(hass: HomeAssi
     result = await hass.config_entries.options.async_init(entry.entry_id)
     schema = result["data_schema"]
 
-    validated = schema({})
+    validated = schema(_form_input())
     assert validated[CONF_FIRMWARE_UPDATE_CHECK] is False
 
 
@@ -673,9 +713,7 @@ async def test_options_flow_saves_submitted_firmware_update_check(hass: HomeAssi
     result = await hass.config_entries.options.async_init(entry.entry_id)
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {
-            CONF_FIRMWARE_UPDATE_CHECK: True,
-        },
+        _form_input({CONF_FIRMWARE_UPDATE_CHECK: True}),
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -693,11 +731,13 @@ async def test_options_flow_saves_submitted_per_mode_offsets(hass: HomeAssistant
     result = await hass.config_entries.options.async_init(entry.entry_id)
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {
-            CONF_TARGET_OFFSET: 0.5,
-            CONF_TARGET_OFFSET_COOL: 1.5,
-            CONF_TARGET_OFFSET_HEAT: -1.5,
-        },
+        _form_input(
+            {
+                CONF_TARGET_OFFSET: 0.5,
+                CONF_TARGET_OFFSET_COOL: 1.5,
+                CONF_TARGET_OFFSET_HEAT: -1.5,
+            }
+        ),
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -708,17 +748,22 @@ async def test_options_flow_saves_submitted_per_mode_offsets(hass: HomeAssistant
 @pytest.mark.parametrize("value", [1.25, -1.25, 0.0, 3.0, -3.0])
 async def test_options_flow_accepts_a_signed_overshoot(hass: HomeAssistant, value):
     # Overshooting is what everyone has measured, but a unit that stops short
-    # of the setting needs the correction the other way.
+    # of the setting needs the correction the other way. The fields only exist
+    # while a source is configured - there is no room temperature to bend
+    # without one.
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50"},
+        options={
+            "host": "192.168.1.50",
+            CONF_EXTERNAL_TEMPERATURE_SOURCE: "sensor.hallway_temperature",
+        },
     )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], {CONF_OVERSHOOT_COOL: value}
+        result["flow_id"], _form_input({CONF_OVERSHOOT_COOL: value})
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -741,9 +786,7 @@ async def test_options_flow_leaves_per_mode_offsets_unset_when_omitted(hass: Hom
     result = await hass.config_entries.options.async_init(entry.entry_id)
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {
-            CONF_TARGET_OFFSET: 0.5,
-        },
+        _form_input({CONF_TARGET_OFFSET: 0.5}),
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -751,6 +794,98 @@ async def test_options_flow_leaves_per_mode_offsets_unset_when_omitted(hass: Hom
     assert CONF_TARGET_OFFSET_HEAT not in result["data"]
     assert result["data"].get(CONF_TARGET_OFFSET_COOL) is None
     assert result["data"].get(CONF_TARGET_OFFSET_HEAT) is None
+
+
+async def test_options_flow_only_offers_the_overshoots_with_a_source(hass: HomeAssistant):
+    """They bend the room temperature handed to the unit, so without a source
+    there is nothing for them to act on and they would sit there doing
+    nothing.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room AC"},
+        options={"host": "192.168.1.50"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    source_section = next(
+        value
+        for key, value in result["data_schema"].schema.items()
+        if str(key.schema) == SECTION_INDOOR_TEMPERATURE_SOURCE
+    )
+    assert {str(key.schema) for key in source_section.schema.schema} == {
+        CONF_EXTERNAL_TEMPERATURE_SOURCE
+    }
+
+    hass.config_entries.async_update_entry(
+        entry,
+        options={
+            **entry.options,
+            CONF_EXTERNAL_TEMPERATURE_SOURCE: "sensor.hallway_temperature",
+        },
+    )
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    source_section = next(
+        value
+        for key, value in result["data_schema"].schema.items()
+        if str(key.schema) == SECTION_INDOOR_TEMPERATURE_SOURCE
+    )
+    assert {str(key.schema) for key in source_section.schema.schema} == {
+        CONF_EXTERNAL_TEMPERATURE_SOURCE,
+        CONF_OVERSHOOT_COOL,
+        CONF_OVERSHOOT_HEAT,
+    }
+
+
+async def test_options_flow_keeps_values_it_never_showed(hass: HomeAssistant):
+    """async_create_entry replaces the options wholesale, so a field the form
+    did not render is dropped unless it is carried over by hand. Without that,
+    saving anything at all after removing a source would also throw away the
+    overshoot figures the user measured.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room AC"},
+        options={
+            "host": "192.168.1.50",
+            CONF_OVERSHOOT_COOL: 1.0,
+            CONF_OVERSHOOT_HEAT: -0.5,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], _form_input({CONF_TARGET_OFFSET: 0.5})
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_OVERSHOOT_COOL] == 1.0
+    assert result["data"][CONF_OVERSHOOT_HEAT] == -0.5
+
+
+async def test_options_flow_clears_a_source_the_form_did_show(hass: HomeAssistant):
+    """The carry-over must not resurrect a field that was shown and left
+    empty - clearing the source is how a user turns the override off.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room AC"},
+        options={
+            "host": "192.168.1.50",
+            CONF_EXTERNAL_TEMPERATURE_SOURCE: "sensor.hallway_temperature",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], _form_input()
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert CONF_EXTERNAL_TEMPERATURE_SOURCE not in result["data"]
 
 
 async def test_options_form_fields_all_have_a_label(hass: HomeAssistant):
@@ -767,11 +902,24 @@ async def test_options_form_fields_all_have_a_label(hass: HomeAssistant):
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
-    fields = {str(key.schema) for key in result["data_schema"].schema}
+    schema = result["data_schema"].schema
+    fields = set()
+    for key, value in schema.items():
+        if isinstance(value, section):
+            fields |= {str(inner.schema) for inner in value.schema.schema}
+        else:
+            fields.add(str(key.schema))
 
     strings_file = Path(mitsubishi_wf_rac.__file__).parent / "strings.json"
     strings = json.loads(strings_file.read_text(encoding="utf-8"))
-    assert set(strings["options"]["step"]["init"]["data"]) == fields
+    init = strings["options"]["step"]["init"]
+    labelled = set(init["data"])
+    for group in init["sections"].values():
+        labelled |= set(group["data"])
+    # This entry has no source, so the overshoot fields are not rendered -
+    # they are still labelled, and must be.
+    assert fields <= labelled
+    assert labelled - fields == {CONF_OVERSHOOT_COOL, CONF_OVERSHOOT_HEAT}
 
 
 # --- WfRacConfigFlow.is_matching() / _name ------------------------------

--- a/tests/unit/test_translation_keys.py
+++ b/tests/unit/test_translation_keys.py
@@ -55,6 +55,47 @@ def test_step_data_keys_match_english_translation():
             assert actual == expected, f"{section}.{step}"
 
 
+def test_step_section_keys_match_english_translation():
+    """Fields moved into sections leave step.data empty, so the check above
+    would compare two empty sets and pass while saying nothing.
+    """
+    for section in ("config", "options"):
+        for step, body in ENGLISH[section]["step"].items():
+            sections = body.get("sections", {})
+            mirror = STRINGS[section]["step"].get(step, {}).get("sections", {})
+            assert set(mirror) == set(sections), f"{section}.{step}"
+            for name, group in sections.items():
+                assert set(mirror[name].get("data", {})) == set(group.get("data", {})), name
+
+
+def test_sections_cover_every_field_the_options_form_shows():
+    """A field the form renders but no section names shows up unlabelled."""
+    from custom_components.mitsubishi_wf_rac import config_flow
+
+    init = ENGLISH["options"]["step"]["init"]
+    labelled = set(init.get("data", {}))
+    for group in init.get("sections", {}).values():
+        labelled |= set(group.get("data", {}))
+
+    handler = config_flow.WfRacOptionsFlowHandler
+    rendered = config_flow.WfRacOptionsFlowHandler._rendered_option_keys
+    assert handler and rendered  # imported, not just referenced
+    # _rendered_option_keys() is the form's own answer to "what does this
+    # dialog collect", so the labels have to cover exactly that.
+    assert labelled == {
+        config_flow.CONF_AVAILABILITY_RETRY_LIMIT,
+        config_flow.CONF_FIRMWARE_UPDATE_CHECK,
+        config_flow.CONF_EXTERNAL_TEMPERATURE_SOURCE,
+        config_flow.CONF_OVERSHOOT_COOL,
+        config_flow.CONF_OVERSHOOT_HEAT,
+        config_flow.CONF_TARGET_OFFSET,
+        config_flow.CONF_TARGET_OFFSET_COOL,
+        config_flow.CONF_TARGET_OFFSET_HEAT,
+        config_flow.CONF_INDOOR_OFFSET,
+        config_flow.CONF_OUTDOOR_OFFSET,
+    }
+
+
 def test_setup_and_options_steps_have_distinct_titles():
     """The options form grew out of a copy of the setup step and kept its
     heading while the fields diverged - it now holds offsets and polling
@@ -70,12 +111,20 @@ def test_per_mode_offsets_explain_that_blank_means_the_general_offset():
     general target offset (see climate.py). Without a description the form
     gives the user no way to know that.
     """
-    described = STRINGS["options"]["step"]["init"]["data_description"]
+    described = _described_option_keys()
     assert "target_offset_cool" in described
     assert "target_offset_heat" in described
 
 
 def test_external_temperature_source_explains_its_failsafe():
-    described = STRINGS["options"]["step"]["init"]["data_description"]
-    assert "external_temperature_source" in described
+    assert "external_temperature_source" in _described_option_keys()
+
+
+def _described_option_keys() -> set[str]:
+    """Every option field carrying a description, wherever it now sits."""
+    init = STRINGS["options"]["step"]["init"]
+    described = set(init.get("data_description", {}))
+    for group in init.get("sections", {}).values():
+        described |= set(group.get("data_description", {}))
+    return described
 


### PR DESCRIPTION
Settles the naming discussion in #218 and the config-flow layout storytame asked for there.

**Naming.** "External" read as outdoor temperature to one tester, and it collided with the existing **External Control** sensor, which means something entirely different — another client is writing to the unit. So:

| | before | after |
|---|---|---|
| Option | External temperature source | **Indoor temperature source** (field: *Sensor*) |
| Binary sensor | External Temperature Active | **Indoor temperature override** |
| Action | Set external temperature override | **Set indoor temperature override** |

`mitsubishi_wf_rac.set_external_temperature` keeps its id — it is in people's automations. Entity ids do not change either, so existing installations keep `binary_sensor.<unit>_external_temperature_active` and only fresh ones get the new slug.

**Sections.** The ten fields sit in three groups instead of one flat list:

- *Indoor temperature source* — the source sensor and the two overshoot corrections
- *Setpoint offsets* — what gets sent to the unit
- *Sensor offsets* — what Home Assistant shows

The last split is the one worth having: one changes what the unit is asked to do, the other only changes what it reports, and that is the pair that has been misread in the issue thread. `Target Temp. Offset` now also states its direction, which it never did.

**Conditional fields.** The overshoot corrections only appear once a source is configured — without one there is no room temperature for them to bend. The setpoint offsets stay visible with a source in use, only collapsed, because they keep working; silently ignoring a value someone has set would be worse than showing it.

**Mechanics.** Sections hand their values back nested, so the submission is flattened straight back out and the stored options keep the exact shape they have always had — no migration. A field the form does not render cannot be collected from it, and `async_create_entry` replaces the options wholesale, so unrendered values are carried over by hand; without that, saving anything at all after removing a source would also throw away the overshoot figures. A field that *was* shown and left empty is still honoured as empty, which is how clearing the source works.

Six translations move their existing keys into the sections and get their own section headings; the source and overshoot labels stay English there, as they already were.

377 tests, mypy clean.