### PR TITLE
Show the room the unit is being fed, whatever else is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Any one of them switches the request on, so pick one that always has something t
 
 | Entity | Values | Description |
 |---|---|---|
-| Indoor Temperature | °C | The room temperature the unit reports, exposed as its own sensor. Normally the same value as the climate entity's `current_temperature`; while an external temperature override is in effect it follows that override rather than the room (see [External temperature override](#indoor-temperature-override)). |
+| Indoor Temperature | °C | What the unit reports as the room temperature, exposed as its own sensor. Normally the same value as the climate entity's `current_temperature`; while an override is in effect the two part company, because this one keeps following the unit while the climate entity shows the temperature the unit was handed (see [Indoor temperature override](#indoor-temperature-override)). |
 | Outdoor Temperature *(shared on multi-split)* | °C | Outdoor unit temperature, corrected by the "Outdoor Temp. Sensor Offset" option if set. On multi-split systems this is an outdoor-unit-level value - reads identically on every indoor unit sharing one outdoor unit, since there's only one outdoor sensor. |
 | Target Temperature *(disabled by default)* | °C | Current setpoint, exposed as its own sensor. Off by default because the climate entity already carries the same value as its `target_temperature` attribute. |
 | Energy Usage (current run) | kWh, increasing | Energy consumption of the **current run**, as reported by the unit in **0.25 kWh steps**. The unit clears this counter to 0 every time it is switched on, and holds the last value while it is off — so a low or zero reading is normal, not a fault, and a run consuming less than 0.25 kWh reads 0 throughout. For a lifetime figure use Energy Usage Total below. Only created if the unit actually reports this value — not all models do. |
@@ -321,9 +321,9 @@ You can select a sensor under **Indoor temperature source** in the integration o
 
 What an armed override costs is one request per poll cycle, which holds the unit's write lock for part of the cycle exactly as an enabled operation-data sensor does.
 
-**While an override is in effect, the unit stops reporting its own sensor.** Measured on hardware: the value you inject comes back on the next cycle as the unit's reported room temperature, half a kelvin above what you sent - the two protocol fields it travels in differ by that much with or without an override. So the Indoor Temperature sensor follows your override as well and is no longer a measurement of the room; keep your own sensor for that. Clearing the override brings the real reading back within a cycle.
+**While an override is in effect, the unit stops reporting its own sensor.** Measured on hardware: the value you inject comes back on the next cycle as the unit's reported room temperature, half a kelvin above what you sent - the two protocol fields it travels in differ by that much with or without an override. So the Indoor Temperature sensor follows your override as well and is no longer a measurement of the room; the climate entity shows the value you supplied instead, and your own sensor remains the measurement. Clearing the override brings the real reading back within a cycle.
 
-An action-driven override survives a restart and a reload. It is re-armed, not re-sent: the unit stays on whatever it last received until the next frame goes out. With a configured source, its current state is used instead of a restored value. Both `current_temperature` and the Indoor Temperature sensor show what the unit reports throughout, so they agree with each other and with the official app - with the one exception described next.
+An action-driven override survives a restart and a reload. It is re-armed, not re-sent: the unit stays on whatever it last received until the next frame goes out. With a configured source, its current state is used instead of a restored value. The Indoor Temperature sensor shows what the unit reports throughout, so it keeps agreeing with the official app. `current_temperature` does not: while the unit is regulating on a value you supplied, the climate entity shows that value.
 
 ### When the room ends up past your setting
 
@@ -333,7 +333,7 @@ Set **Cooling overshoot** to how far it goes: aim for 22 °C, watch where the ro
 
 Why here and not in Target Temp. Offset: on the units measured so far, a half-degree setpoint is rounded up to the next whole one, so that field is too coarse for a correction of less than a degree (owners of ZT and ZTL units report their models do take half degrees). The room temperature the unit is fed has 0.25 °C steps on every model, so correcting there is the finer of the two - and it leaves the setpoint matching what the official app shows.
 
-While a correction is active, the climate entity's `current_temperature` shows your room temperature, and the Indoor Temperature sensor keeps showing what the unit reports - the value it was handed, on purpose. The two therefore differ by the correction, minus the half kelvin the unit adds on the way back: at exactly 0.5 the two cancel out and both read the same, which is not a sign that the correction is doing nothing.
+While an override is in effect, the climate entity's `current_temperature` shows the room temperature you supplied and the Indoor Temperature sensor keeps showing what the unit reports - which is the value it was handed, plus the half kelvin it adds on the way back, minus any correction. The two therefore differ, and how far apart they sit is not a measurement of anything: it is the correction and that half kelvin, which cancel out at exactly 0.5.
 
 # Known limitations
 

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -598,19 +598,16 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
         target_offset = self._resolve_target_offset(mode_from_operation)
 
         self._attr_target_temperature = airco.PresetTemp + target_offset
-        # Always what the unit reports, including while an external override
-        # is in effect - it echoes the injected value back, so the reading
-        # follows the override on its own and the climate entity agrees with
-        # the Indoor Temperature sensor either way.
-        # The calibration offset is what changes: it corrects the unit's own
-        # return-air sensor, which is out of the loop while the unit is
-        # regulating on a value the user supplied. Applying it there would
-        # correct a reading that needs no correcting.
-        # One exception to reporting the unit verbatim: with an overshoot
-        # correction configured, the value the unit reports is the bent one it
-        # was handed on purpose. The room is what the user supplied, so that is
-        # what the card shows - the Indoor Temperature sensor still mirrors the
-        # unit, which is what makes the two disagree exactly then and only then.
+        # While the unit is regulating on a temperature someone supplied, that
+        # value is the room and the card shows it - see
+        # Device.external_temperature_room_value. What the unit reports back
+        # is its own rendering of what it was handed, which is why the Indoor
+        # Temperature sensor (still verbatim) and the card disagree exactly
+        # then and only then.
+        # Otherwise the reading is the unit's, plus the calibration offset -
+        # which is suspended while an override is in effect, because it
+        # corrects the unit's own return-air sensor and that sensor is out of
+        # the loop just then.
         room = self._device.external_temperature_room_value
         if room is not None:
             self._attr_current_temperature = room

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -433,19 +433,27 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
 
     @property
     def external_temperature_room_value(self) -> float | None:
-        """The room temperature behind an override the unit is being lied to
-        about, or None when nothing is being bent.
+        """The room temperature we handed the unit, or None while it is
+        regulating on its own sensor.
 
-        With an overshoot configured, what the unit reports back is the value
-        it was handed, which is deliberately not the room. The number the user
-        supplied is - so that is what the climate entity shows, while the
-        Indoor Temperature sensor keeps reporting the unit verbatim.
+        Whoever supplies a room temperature has said what "the room" means for
+        this unit, so that is what the climate entity shows for as long as the
+        unit is actually using it. What comes back from the unit is not it: an
+        overshoot correction hands it a value that is deliberately not the
+        room, and even without one the echo sits half a kelvin off in the
+        protocol's coarser segment. Deciding this per overshoot - as this did
+        until the reading was found to move half a kelvin when an unrelated
+        option changed - makes the displayed room temperature depend on a
+        setting that has nothing to do with it, and every automation comparing
+        it against a threshold inherits that silently.
+
+        The Indoor Temperature sensor keeps reporting the unit verbatim, so
+        what the unit thinks is still visible - the two disagree exactly while
+        the unit is being fed.
         """
         if self._external_temperature_override is None or self._airco is None:
             return None
         if not self.external_temperature_applied:
-            return None
-        if not self._resolve_overshoot(self._airco.OperationMode):
             return None
         return self._external_temperature_override
 

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -315,10 +315,12 @@ async def test_update_state_uses_indoor_temp_without_override(device):
     assert entity._attr_current_temperature == 23.5
 
 
-async def test_update_state_shows_what_the_unit_reports_under_an_override(device):
-    # The unit echoes the injected value back, so the reading follows it on its
-    # own. The calibration offset drops out: it corrects the unit's own sensor,
-    # which is not what the unit is regulating on any more.
+async def test_update_state_shows_the_value_the_unit_is_being_fed(device):
+    # Whoever supplied the value has said what the room is, so that is what the
+    # card shows - not the unit's echo of it, which lands half a kelvin off in
+    # the protocol's coarser segment. The calibration offset drops out too: it
+    # corrects the unit's own sensor, which is not what the unit is regulating
+    # on any more.
     _set_options(device, {CONF_INDOOR_OFFSET: 1.5})
     device.airco.IndoorTemp = 22.0
     device.airco.Operation = True
@@ -329,7 +331,7 @@ async def test_update_state_shows_what_the_unit_reports_under_an_override(device
     _mark_reached_the_unit(device, 20.0)
     entity._update_state()
 
-    assert entity._attr_current_temperature == 20.5
+    assert entity._attr_current_temperature == 20.0
 
 
 async def test_update_state_keeps_indoor_temp_until_the_override_is_sent(device):
@@ -347,10 +349,12 @@ async def test_update_state_keeps_indoor_temp_until_the_override_is_sent(device)
     assert entity._attr_current_temperature == 23.5
 
 
-async def test_update_state_reapplies_the_offset_while_a_new_value_is_in_flight(device):
-    # A source sensor feeding the action reports a new value every cycle. Until
-    # the unit confirms the new one, it is still regulating on the old - and
-    # the display follows the unit rather than what has merely been armed.
+async def test_update_state_follows_the_newest_value_while_one_is_in_flight(device):
+    # A source sensor feeding the action reports a new value every cycle, and
+    # the unit only picks it up on the next frame. The card is showing the
+    # room, not the unit's progress towards it, so it follows the newest value
+    # rather than waiting a cycle - and the calibration offset stays out of it
+    # throughout, because the unit's own sensor is out of the loop.
     _set_options(device, {CONF_INDOOR_OFFSET: 1.5})
     device.airco.Operation = True
     device.airco.OperationMode = HVAC_TRANSLATION[HVACMode.COOL]
@@ -361,12 +365,12 @@ async def test_update_state_reapplies_the_offset_while_a_new_value_is_in_flight(
     await entity.async_set_external_temperature(temperature=20.25)
     entity._update_state()
 
-    assert entity._attr_current_temperature == 20.5
+    assert entity._attr_current_temperature == 20.25
 
     _mark_reached_the_unit(device, 20.25)
     entity._update_state()
 
-    assert entity._attr_current_temperature == 20.75
+    assert entity._attr_current_temperature == 20.25
 
 
 async def test_update_state_keeps_the_offset_while_the_unit_is_off_or_fan_only(device):
@@ -439,18 +443,23 @@ async def test_current_temperature_shows_the_room_not_the_bent_value(device):
     assert entity._attr_current_temperature == 22.0
 
 
-async def test_current_temperature_follows_the_unit_without_an_overshoot(device):
-    # Nothing is being bent, so there is nothing to correct back: both the
-    # card and the Indoor Temperature sensor mirror the unit.
+@pytest.mark.parametrize("overshoot", [0.0, 1.0])
+async def test_current_temperature_does_not_move_with_the_overshoot(device, overshoot):
+    # The reading used to switch source depending on whether an overshoot was
+    # set, which moved the displayed room temperature by half a kelvin when an
+    # unrelated option changed - and every automation comparing it against a
+    # threshold inherited that silently.
+    _set_options(device, {CONF_OVERSHOOT_COOL: overshoot})
     device.airco.Operation = True
     device.airco.OperationMode = HVAC_TRANSLATION[HVACMode.COOL]
     entity = _service_entity(device)
 
     await entity.async_set_external_temperature(temperature=22.0)
-    _mark_reached_the_unit(device, 22.0)
+    # What a frame carrying the value - bent or not - leaves behind.
+    _mark_reached_the_unit(device, 22.0 - overshoot)
     entity._update_state()
 
-    assert entity._attr_current_temperature == 22.5
+    assert entity._attr_current_temperature == 22.0
 def _with_external_temperature_source(device: Device) -> str:
     source = "sensor.living_room_temperature"
     _set_options(device, {CONF_EXTERNAL_TEMPERATURE_SOURCE: source})


### PR DESCRIPTION
`current_temperature` picked its source depending on whether a **Cooling/Heating overshoot** was set: with one, it showed the room value supplied; without one, the unit's echo of that same value. Those two are about half a kelvin apart, because the echo comes back in a coarser protocol segment — measured here at room 21.7, injected 21.75, entity 22.2.

So the displayed room temperature moved when an option that has nothing to do with it changed, and every automation comparing `current_temperature` against a threshold inherited the shift silently. That happened in my own setup: a heating safety net latched half a kelvin early.

Whoever supplies a room temperature has said what "the room" means for that unit, so the climate entity now shows it for as long as the unit is actually regulating on it — overshoot or not, source-driven or armed by an automation. When the override is not in effect (unit off, self-clean, source unavailable) the reading falls back to the unit's own sensor with the calibration offset applied, exactly as before.

The **Indoor Temperature** sensor is unchanged and still reports the unit verbatim, so what the unit thinks stays visible. The two disagree exactly while the unit is being fed, which is the honest state of affairs.

**Visible change:** anyone running a source with the overshoot at 0 will see the climate card's reading drop by about half a kelvin on upgrade — onto the value their own sensor reports. Belongs in the release notes.

Also settles the dry-mode request from #218: the card now reads correctly in every mode without applying a regulation correction in a mode nobody has measured.

378 tests, mypy clean.