### PR TITLE
Open the cooling overshoot on the figure that has been measured

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,9 +327,9 @@ An action-driven override survives a restart and a reload. It is re-armed, not r
 
 ### When the room ends up past your setting
 
-With an external room temperature in use, most units cool the room further than asked before stopping - measured between 0.6 and 2 K across four different models, and the same figure repeats every cycle. Heating has so far looked correct.
+With a room temperature supplied, most units cool the room further than asked before stopping - measured between 0.6 and 1.3 K across four different models, three of them between 1.0 and 1.2, and the same figure repeats every cycle. That is the unit's own thermostat band, not a sensor error: its return-air sensor is out of the loop while it regulates on your value. Heating has so far looked correct.
 
-Set **Cooling overshoot** to how far it goes: aim for 22 °C, watch where the room settles, and enter the difference as a positive number. If your unit stops short instead and never quite gets there, a negative number corrects that the other way. The integration then hands the unit a room temperature that much lower, so the unit reaches its own stopping point exactly when your room is on target. Your setpoint and everything shown in Home Assistant stay the number you asked for.
+Set **Cooling overshoot** to how far it goes: aim for 22 °C, watch where the room settles, and enter the difference as a positive number. The field opens on 1 because that is what the units measured so far need; it is a starting point, not a measurement of yours, and it only takes effect once you save the options. If your unit stops short instead and never quite gets there, a negative number corrects that the other way. The integration then hands the unit a room temperature that much lower, so the unit reaches its own stopping point exactly when your room is on target. Your setpoint and everything shown in Home Assistant stay the number you asked for.
 
 Why here and not in Target Temp. Offset: on the units measured so far, a half-degree setpoint is rounded up to the next whole one, so that field is too coarse for a correction of less than a degree (owners of ZT and ZTL units report their models do take half degrees). The room temperature the unit is fed has 0.25 °C steps on every model, so correcting there is the finer of the two - and it leaves the setpoint matching what the official app shows.
 

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -537,8 +537,23 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlow):
         if self._source_configured:
             source_fields.update(
                 {
-                    vol.Optional(key, default=options.get(key, 0.0)): overshoot_validator
-                    for key in (CONF_OVERSHOOT_COOL, CONF_OVERSHOOT_HEAT)
+                    # Cooling starts at the figure four units have measured
+                    # (0.6-1.3 K past the setting, three of them 1.0-1.2), so
+                    # the field opens on a number that is roughly right
+                    # instead of on one that is certainly wrong. It is a
+                    # pre-fill and nothing more: the correction applies once
+                    # the form is saved, and _resolve_overshoot still reads 0
+                    # until then, so nobody's regulation moves without them
+                    # seeing the value first. Heating has looked symmetric
+                    # around the setting wherever it has been measured, so
+                    # there is no figure to offer.
+                    vol.Optional(
+                        key, default=options.get(key, suggested)
+                    ): overshoot_validator
+                    for key, suggested in (
+                        (CONF_OVERSHOOT_COOL, 1.0),
+                        (CONF_OVERSHOOT_HEAT, 0.0),
+                    )
                 }
             )
 

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -68,7 +68,7 @@
             },
             "data_description": {
               "external_temperature_source": "The unit regulates on this sensor. Leave it empty to put the unit back on its own sensor. Unavailable or unknown states do the same on the next frame.",
-              "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. If it stops short instead and never gets cold enough, enter a negative number.",
+              "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. Starts at 1 because that is what the units measured so far need - check where your own room settles and adjust. If it stops short instead and never gets cold enough, enter a negative number.",
               "overshoot_heat": "The same for heating: positive if the room ends up above your setting, negative if it stops short of it."
             }
           },
@@ -81,7 +81,7 @@
               "target_offset_heat": "Target Temp. Offset (Heating)"
             },
             "data_description": {
-              "target_offset": "Positive lowers the setting sent to the unit, negative raises it - the card keeps showing yours either way. Most units round a half degree up to the next whole one, so 0.5 here often acts as 1.",
+              "target_offset": "Positive lowers the setting sent to the unit, negative raises it - the card keeps showing yours either way. Most units round a half degree up to the next whole one, so 0.5 here often acts as 1. With an Indoor temperature source in use, the cooling overshoot above is the lever for a unit that overshoots - it is finer, and it leaves the setpoint matching the app.",
               "target_offset_cool": "Leave empty to use the general target temperature offset.",
               "target_offset_heat": "Leave empty to use the general target temperature offset."
             }

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -94,7 +94,7 @@
             },
             "data_description": {
               "external_temperature_source": "The unit regulates on this sensor. Leave it empty to put the unit back on its own sensor. Unavailable or unknown states do the same on the next frame.",
-              "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. If it stops short instead and never gets cold enough, enter a negative number.",
+              "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. Starts at 1 because that is what the units measured so far need - check where your own room settles and adjust. If it stops short instead and never gets cold enough, enter a negative number.",
               "overshoot_heat": "The same for heating: positive if the room ends up above your setting, negative if it stops short of it."
             }
           },
@@ -107,7 +107,7 @@
               "target_offset_heat": "Target Temp. Offset (Heating)"
             },
             "data_description": {
-              "target_offset": "Positive lowers the setting sent to the unit, negative raises it - the card keeps showing yours either way. Most units round a half degree up to the next whole one, so 0.5 here often acts as 1.",
+              "target_offset": "Positive lowers the setting sent to the unit, negative raises it - the card keeps showing yours either way. Most units round a half degree up to the next whole one, so 0.5 here often acts as 1. With an Indoor temperature source in use, the cooling overshoot above is the lever for a unit that overshoots - it is finer, and it leaves the setpoint matching the app.",
               "target_offset_cool": "Leave empty to use the general target temperature offset.",
               "target_offset_heat": "Leave empty to use the general target temperature offset."
             }

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -838,6 +838,39 @@ async def test_options_flow_only_offers_the_overshoots_with_a_source(hass: HomeA
     }
 
 
+async def test_options_flow_opens_the_cooling_overshoot_on_the_measured_figure(
+    hass: HomeAssistant,
+):
+    """Four units land 0.6-1.3 K past the setting, so a fresh field opening on
+    0 opens on a number that is certainly wrong. It is a pre-fill: a stored
+    value wins, and nothing is corrected until the form is saved.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room AC"},
+        options={
+            "host": "192.168.1.50",
+            CONF_EXTERNAL_TEMPERATURE_SOURCE: "sensor.hallway_temperature",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    validated = result["data_schema"](_form_input())[SECTION_INDOOR_TEMPERATURE_SOURCE]
+    assert validated[CONF_OVERSHOOT_COOL] == 1.0
+    # Heating has looked symmetric wherever it was measured - no figure to offer.
+    assert validated[CONF_OVERSHOOT_HEAT] == 0.0
+    # Nothing is applied by opening the form: the resolver still reads 0.
+    assert entry.options.get(CONF_OVERSHOOT_COOL) is None
+
+    hass.config_entries.async_update_entry(
+        entry, options={**entry.options, CONF_OVERSHOOT_COOL: 0.0}
+    )
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    validated = result["data_schema"](_form_input())[SECTION_INDOOR_TEMPERATURE_SOURCE]
+    assert validated[CONF_OVERSHOOT_COOL] == 0.0
+
+
 async def test_options_flow_keeps_values_it_never_showed(hass: HomeAssistant):
     """async_create_entry replaces the options wholesale, so a field the form
     did not render is dropped unless it is carried over by hand. Without that,


### PR DESCRIPTION
Settles the default question from #218.

**Cooling overshoot now opens on 1** instead of 0. Four units land 0.6–1.3 K past the setting with a room temperature supplied, three of them 1.0–1.2, and the figure repeats every cycle. Someone who configures a source and never touches the field currently gets the full overshoot; now the field offers a number that is roughly right.

It stays a pre-fill and not a stored default:

- a value already saved wins, including an explicit 0
- `_resolve_overshoot` still reads 0 until the options are saved, so nobody's regulation moves before they have seen the number
- heating opens on 0 — it has looked symmetric around the setting wherever it was measured, so there is no figure to offer

**`target_offset_cool` keeps no default.** What the four units measured is the unit's own thermostat band — its return-air sensor is out of the loop while it regulates on a supplied value. That option corrects the sensor bias instead, which is installation-dependent (the README says as much), and it applies without a source too, where the measurement does not hold. Its description now points at the overshoot as the right lever when a source is in use.

Also corrects the README's "0.6 and 2 K": the 2 K was a step response, not a settling point, and was retracted in the issue thread.

379 tests, mypy clean.