### PR TITLE
Label the new section's fields in every language

### DIFF
--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -83,7 +83,17 @@
         "sections": {
           "indoor_temperature_source": {
             "name": "Quelle der Innentemperatur",
-            "description": "Gibt dem Gerät eine Raumtemperatur, die dort gemessen wird, wo es darauf ankommt, statt der am eigenen Ansauggitter."
+            "description": "Gibt dem Gerät eine Raumtemperatur, die dort gemessen wird, wo es darauf ankommt, statt der am eigenen Ansauggitter.",
+            "data": {
+              "external_temperature_source": "Sensor",
+              "overshoot_cool": "Überschwingen Kühlen",
+              "overshoot_heat": "Überschwingen Heizen"
+            },
+            "data_description": {
+              "external_temperature_source": "Das Gerät regelt auf diesen Sensor. Leer lassen, damit es wieder seinen eigenen benutzt; bei „unavailable“ oder „unknown“ geschieht dasselbe mit dem nächsten Frame.",
+              "overshoot_cool": "Wie weit der Raum über Ihre Einstellung hinausschießt, bevor das Gerät abschaltet. 22 °C eingestellt, Raum pendelt sich bei 21 °C ein: 1 eintragen. Startet bei 1, weil die bisher gemessenen Geräte das brauchen — prüfen Sie, wo Ihr Raum landet, und passen Sie an. Bleibt er stattdessen darüber und wird nie kalt genug, tragen Sie eine negative Zahl ein.",
+              "overshoot_heat": "Dasselbe fürs Heizen: positiv, wenn der Raum über Ihrer Einstellung landet, negativ, wenn er darunter bleibt."
+            }
           },
           "setpoint_offsets": {
             "name": "Sollwert-Korrekturen",
@@ -338,6 +348,9 @@
       },
       "external_control": {
         "name": "Externe Steuerung"
+      },
+      "external_temperature_active": {
+        "name": "Innentemperatur-Vorgabe"
       }
     },
     "update": {

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -83,7 +83,17 @@
         "sections": {
           "indoor_temperature_source": {
             "name": "室内温度の取得元",
-            "description": "エアコン自身の吸込口ではなく、実際に気になる場所で測った室温をエアコンに渡します。"
+            "description": "エアコン自身の吸込口ではなく、実際に気になる場所で測った室温をエアコンに渡します。",
+            "data": {
+              "external_temperature_source": "センサー",
+              "overshoot_cool": "冷房のオーバーシュート",
+              "overshoot_heat": "暖房のオーバーシュート"
+            },
+            "data_description": {
+              "external_temperature_source": "エアコンはこのセンサーの値で制御されます。空欄にすると自身のセンサーに戻ります。unavailable や unknown のときも次のフレームで同じように戻ります。",
+              "overshoot_cool": "エアコンが止まるまでに室温が設定値をどれだけ行き過ぎるかです。22 °C に設定して室温が 21 °C に落ち着くなら 1 と入力します。これまで測定した機器に必要な値が 1 のため、初期値は 1 です。ご自宅の室温がどこに落ち着くかを確認して調整してください。逆に手前で止まって十分に冷えない場合は負の値を入力します。",
+              "overshoot_heat": "暖房でも同じです。室温が設定値を超えて落ち着くなら正の値、届かないなら負の値にします。"
+            }
           },
           "setpoint_offsets": {
             "name": "設定温度の補正",
@@ -338,6 +348,9 @@
       },
       "external_control": {
         "name": "外部からの操作"
+      },
+      "external_temperature_active": {
+        "name": "室内温度の指定"
       }
     },
     "update": {

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -83,7 +83,17 @@
         "sections": {
           "indoor_temperature_source": {
             "name": "Vidaus temperatūros šaltinis",
-            "description": "Kondicionieriui perduodama kambario temperatūra, išmatuota ten, kur jums svarbu, o ne prie jo paties oro įsiurbimo grotelių."
+            "description": "Kondicionieriui perduodama kambario temperatūra, išmatuota ten, kur jums svarbu, o ne prie jo paties oro įsiurbimo grotelių.",
+            "data": {
+              "external_temperature_source": "Jutiklis",
+              "overshoot_cool": "Perviršis vėsinant",
+              "overshoot_heat": "Perviršis šildant"
+            },
+            "data_description": {
+              "external_temperature_source": "Kondicionierius reguliuoja pagal šį jutiklį. Palikite tuščią, kad grįžtų prie savojo; esant „unavailable“ ar „unknown“ tas pat įvyks su kitu kadru.",
+              "overshoot_cool": "Kiek kambarys peršoka jūsų nustatymą, kol kondicionierius sustoja. Nustatyta 22 °C, kambarys nusistovi ties 21 °C: įrašykite 1. Pradinė reikšmė 1, nes tiek reikia iki šiol išmatuotiems įrenginiams — pasižiūrėkite, kur nusistovi jūsų kambarys, ir pakoreguokite. Jei, priešingai, taip ir neatvėsta, įrašykite neigiamą skaičių.",
+              "overshoot_heat": "Tas pat šildant: teigiamas, jei kambarys lieka virš jūsų nustatymo, neigiamas — jei žemiau."
+            }
           },
           "setpoint_offsets": {
             "name": "Nustatytos temperatūros pataisos",
@@ -338,6 +348,9 @@
       },
       "external_control": {
         "name": "Išorinis valdymas"
+      },
+      "external_temperature_active": {
+        "name": "Nurodyta vidaus temperatūra"
       }
     },
     "update": {

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -83,7 +83,17 @@
         "sections": {
           "indoor_temperature_source": {
             "name": "Bron voor de binnentemperatuur",
-            "description": "Geeft de airco een kamertemperatuur die gemeten is waar het je om gaat, in plaats van die bij zijn eigen aanzuigrooster."
+            "description": "Geeft de airco een kamertemperatuur die gemeten is waar het je om gaat, in plaats van die bij zijn eigen aanzuigrooster.",
+            "data": {
+              "external_temperature_source": "Sensor",
+              "overshoot_cool": "Overshoot koelen",
+              "overshoot_heat": "Overshoot verwarmen"
+            },
+            "data_description": {
+              "external_temperature_source": "De airco regelt op deze sensor. Laat leeg om hem terug te zetten op zijn eigen sensor; bij 'unavailable' of 'unknown' gebeurt hetzelfde bij het volgende frame.",
+              "overshoot_cool": "Hoe ver de kamer voorbij je instelling gaat voordat de airco stopt. Ingesteld op 22 °C, kamer blijft op 21 °C staan: vul 1 in. Begint op 1, want dat is wat de tot nu toe gemeten toestellen nodig hebben — kijk waar jouw kamer uitkomt en pas aan. Blijft hij er juist boven en wordt het nooit koud genoeg, vul dan een negatief getal in.",
+              "overshoot_heat": "Hetzelfde voor verwarmen: positief als de kamer boven je instelling uitkomt, negatief als hij eronder blijft."
+            }
           },
           "setpoint_offsets": {
             "name": "Correcties op het instelpunt",
@@ -338,6 +348,9 @@
       },
       "external_control": {
         "name": "Externe bediening"
+      },
+      "external_temperature_active": {
+        "name": "Opgegeven binnentemperatuur"
       }
     },
     "update": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -83,7 +83,17 @@
         "sections": {
           "indoor_temperature_source": {
             "name": "室内温度来源",
-            "description": "把你真正在意的位置测得的室温交给空调，取代它自己回风口处的读数。"
+            "description": "把你真正在意的位置测得的室温交给空调，取代它自己回风口处的读数。",
+            "data": {
+              "external_temperature_source": "传感器",
+              "overshoot_cool": "制冷过冲",
+              "overshoot_heat": "制热过冲"
+            },
+            "data_description": {
+              "external_temperature_source": "空调按这个传感器的读数调节。留空即可让它回到自己的传感器；读数为 unavailable 或 unknown 时，也会在下一帧回退。",
+              "overshoot_cool": "空调停机前房间越过设定值的幅度。设为 22 °C，房间稳定在 21 °C：填 1。默认从 1 开始，因为目前测过的机器都需要这个值——看看你自己的房间稳定在哪里再调整。若反而停得太早、始终不够凉，请填负数。",
+              "overshoot_heat": "制热同理：房间高于设定值填正数，低于设定值填负数。"
+            }
           },
           "setpoint_offsets": {
             "name": "设定温度修正",
@@ -338,6 +348,9 @@
       },
       "external_control": {
         "name": "外部控制"
+      },
+      "external_temperature_active": {
+        "name": "室内温度指定"
       }
     },
     "update": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -83,7 +83,17 @@
         "sections": {
           "indoor_temperature_source": {
             "name": "室內溫度來源",
-            "description": "把你真正在意的位置量到的室溫交給空調，取代它自己回風口處的讀數。"
+            "description": "把你真正在意的位置量到的室溫交給空調，取代它自己回風口處的讀數。",
+            "data": {
+              "external_temperature_source": "感測器",
+              "overshoot_cool": "製冷過衝",
+              "overshoot_heat": "製熱過衝"
+            },
+            "data_description": {
+              "external_temperature_source": "空調依這個感測器的讀數調節。留空即可讓它回到自己的感測器；讀數為 unavailable 或 unknown 時，也會在下一個訊框回復。",
+              "overshoot_cool": "空調停機前房間越過設定值的幅度。設為 22 °C，房間穩定在 21 °C：填 1。預設從 1 開始，因為目前量測過的機器都需要這個值——看看你自己的房間穩定在哪裡再調整。若反而停得太早、始終不夠涼，請填負數。",
+              "overshoot_heat": "製熱同理：房間高於設定值填正數，低於設定值填負數。"
+            }
           },
           "setpoint_offsets": {
             "name": "設定溫度修正",
@@ -338,6 +348,9 @@
       },
       "external_control": {
         "name": "外部控制"
+      },
+      "external_temperature_active": {
+        "name": "室內溫度指定"
       }
     },
     "update": {

--- a/tests/unit/test_translation_keys.py
+++ b/tests/unit/test_translation_keys.py
@@ -96,6 +96,26 @@ def test_sections_cover_every_field_the_options_form_shows():
     }
 
 
+def test_a_translated_section_labels_every_field_in_it():
+    """A section whose fields carry no label in that language renders them as
+    their raw keys - `overshoot_cool` where a label belongs. Nothing else
+    catches it: the file is valid JSON, hassfest is happy, and it only shows
+    up to someone running Home Assistant in that language.
+
+    Translating a section at all therefore means translating its fields.
+    Leaving the whole section out stays fine - that falls back wholesale.
+    """
+    english = ENGLISH["options"]["step"]["init"]["sections"]
+    for path in (COMPONENT / "translations").glob("*.json"):
+        if path.stem == "en":
+            continue
+        body = json.loads(path.read_text(encoding="utf-8"))
+        sections = body.get("options", {}).get("step", {}).get("init", {}).get("sections", {})
+        for name, group in sections.items():
+            expected = set(english[name].get("data", {}))
+            assert set(group.get("data", {})) == expected, f"{path.stem}: {name}"
+
+
 def test_setup_and_options_steps_have_distinct_titles():
     """The options form grew out of a copy of the setup step and kept its
     heading while the fields diverged - it now holds offsets and polling


### PR DESCRIPTION
The options rework in #319 moved every field into a section, but only the English files got labels for the new **Indoor temperature source** group. The other six declare the section with no `data` at all, and the override binary sensor was added with an English-only name — visible as a raw `overshoot_cool` to anyone running Home Assistant in German, Dutch, Lithuanian, Japanese or either Chinese.

Fills all four missing keys per language: the entity name plus the sensor picker and both overshoot fields, with their descriptions.

A test now holds the line: a section a language translates at all must label every field in it. Leaving a section out entirely stays fine — that falls back wholesale, which is the case HA handles well.

380 tests, mypy clean.