### PR TITLE
Show a configured source even before the unit is using it

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ The climate entity exposes the following entity services (use as `mitsubishi_wf_
 | `set_vertical_swing_mode` | `swing_mode` | Set the vertical (up/down) louver position. |
 | `request_home_leave_mode_status` | — | Ask the unit to report its Home Leave Mode thresholds/airflow (only on supporting models). |
 | `set_home_leave_mode` | `temp_rule_cooling`, `temp_setting_cooling`, `air_flow_cooling`, `temp_rule_heating`, `temp_setting_heating`, `air_flow_heating` | Write new Home Leave Mode thresholds/airflow (only on supporting models). |
-| `set_external_temperature` | `temperature` (optional) | Provide a room temperature to the AC, overriding the one its own indoor sensor reads. Omit `temperature` or pass `null` to revert to the internal sensor. See below. |
+| `set_external_temperature` | `temperature` (optional) | Provide a room temperature to the AC, replacing the one its own indoor sensor reads. Omit `temperature` or pass `null` to revert to the internal sensor. See below. |
 
 ## Indoor temperature override
 
@@ -323,7 +323,7 @@ What an armed override costs is one request per poll cycle, which holds the unit
 
 **While an override is in effect, the unit stops reporting its own sensor.** Measured on hardware: the value you inject comes back on the next cycle as the unit's reported room temperature, half a kelvin above what you sent - the two protocol fields it travels in differ by that much with or without an override. So the Indoor Temperature sensor follows your override as well and is no longer a measurement of the room; the climate entity shows the value you supplied instead, and your own sensor remains the measurement. Clearing the override brings the real reading back within a cycle.
 
-An action-driven override survives a restart and a reload. It is re-armed, not re-sent: the unit stays on whatever it last received until the next frame goes out. With a configured source, its current state is used instead of a restored value. The Indoor Temperature sensor shows what the unit reports throughout, so it keeps agreeing with the official app. `current_temperature` does not: while the unit is regulating on a value you supplied, the climate entity shows that value.
+An action-driven override survives a restart and a reload. It is re-armed, not re-sent: the unit stays on whatever it last received until the next frame goes out. With a configured source, its current state is used instead of a restored value. The Indoor Temperature sensor shows what the unit reports throughout, so it keeps agreeing with the official app. `current_temperature` does not: with an **Indoor temperature source** configured, the climate entity shows that sensor's reading - including while the unit is off or in `fan_only`, where nothing is written and the unit's own reading means least. An override armed from an automation instead of a source is only shown once the unit is actually using it: there is no sensor behind it, so before then it is an intention rather than a measurement.
 
 ### When the room ends up past your setting
 

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    CONF_EXTERNAL_TEMPERATURE_SOURCE,
     CONF_OVERSHOOT_COOL,
     CONF_OVERSHOOT_HEAT,
     DOMAIN,
@@ -450,9 +451,24 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         The Indoor Temperature sensor keeps reporting the unit verbatim, so
         what the unit thinks is still visible - the two disagree exactly while
         the unit is being fed.
+
+        With a source entity configured this holds even while the unit is not
+        using the value - off, in fan_only, or a restart away from having sent
+        one. A source keeps measuring the room whatever the unit is doing, and
+        deciding whether to switch the unit on is exactly when someone reads
+        that number (#218). The unit's own reading is at its least meaningful
+        then anyway: nothing is drawing air past its sensor.
+
+        A value armed from an automation is different and keeps the stricter
+        rule. There is no source behind it, so it is a number someone pushed
+        once, and showing it as the room while the unit is not even using it
+        would be showing an intention rather than a measurement.
         """
         if self._external_temperature_override is None or self._airco is None:
             return None
+        source = self.options.get(CONF_EXTERNAL_TEMPERATURE_SOURCE)
+        if isinstance(source, str) and source:
+            return self._external_temperature_override
         if not self.external_temperature_applied:
             return None
         return self._external_temperature_override

--- a/custom_components/mitsubishi_wf_rac/services.yaml
+++ b/custom_components/mitsubishi_wf_rac/services.yaml
@@ -183,7 +183,7 @@ set_home_leave_mode:
               value: "4"
 # Service ID
 set_external_temperature:
-  name: Set indoor temperature override
+  name: Set indoor temperature
   description: >-
     Arms a room temperature for the AC to regulate on instead of the one its
     own indoor sensor reads. The value is not sent by this action; it rides along on

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -349,6 +349,26 @@ async def test_update_state_keeps_indoor_temp_until_the_override_is_sent(device)
     assert entity._attr_current_temperature == 23.5
 
 
+async def test_update_state_shows_a_source_even_before_the_unit_uses_it(device):
+    # Deciding whether to switch the unit on is exactly when someone reads the
+    # room temperature off the card, and that is a moment when the unit is not
+    # using the supplied value - nothing writes byte 5 while it is off. A
+    # source keeps measuring the room regardless, so it is shown anyway; the
+    # unit's own sensor means least just then, with no air moving past it.
+    _set_options(device, {CONF_INDOOR_OFFSET: 1.5})
+    _with_external_temperature_source(device)
+    device.airco.IndoorTemp = 22.0
+    device.airco.Operation = False
+    entity = _service_entity(device)
+
+    device.set_external_temperature_override(20.0)
+    entity._update_state()
+
+    assert entity._attr_current_temperature == 20.0
+    # The override is still correctly reported as not in effect.
+    assert device.external_temperature_applied is False
+
+
 async def test_update_state_follows_the_newest_value_while_one_is_in_flight(device):
     # A source sensor feeding the action reports a new value every cycle, and
     # the unit only picks it up on the next frame. The card is showing the


### PR DESCRIPTION
Two points from @mungojam in #218, both landing before `beta3` went out.

**The card fell back to the unit's own reading while the unit was off.** Nothing writes byte 5 in `off` or `fan_only`, so the override counts as unapplied and the display reverted. As he puts it, deciding whether to switch the unit on is exactly when the current temperature matters — and it is exactly the moment the unit's own sensor means least, with no air being drawn past it.

With a source configured, the climate entity now shows that sensor's reading whatever the unit is doing. The source keeps measuring the room either way.

A value armed from an automation keeps the stricter rule: there is no sensor behind it, so before the unit is actually using it, showing it as the room would be showing an intention rather than a measurement. The **Indoor temperature override** binary sensor continues to report whether the unit is really regulating on the value, which is the honest place for that question.

**The action is `Set indoor temperature` now**, not `... override`. @thomasvnl's rule was that "override" reads as a yes/no — it belongs on the binary sensor, and an action that takes a temperature is not a boolean. @mungojam pointed out I had applied that rule everywhere except here. The action id is unchanged.

381 tests, mypy clean.