### PR TITLE
Anchor the coil curve's cold end, and document opdata 0x05

### DIFF
--- a/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
+++ b/custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py
@@ -691,12 +691,13 @@ class RacParser:
         the whole byte range converts, heating included. A byte of 0 is the
         divider's own limit and carries no temperature, so it yields None.
 
-        The one point this disagrees with is the manual's 1.0 C frost cut-off,
-        where the curve reads ~5.5 C. That anchor is indirect: the threshold is
-        adjustable on the unit, and what gets sampled is the value before the
-        stop rather than the threshold. A reading taken against a thermometer
-        at byte 75 backs the curve (16.8 C measured, 17.0 C here), so the
-        measurement wins over the inference.
+        The cold end sits on the three frost-protection thresholds the
+        databook gives for this series - 8 C recovery, 5 C throttle, 2.5 C stop
+        - which a cooling run drove through in order; the curve reads 7.8, 5.0
+        and 2.4 C at the nearest bytes, so it is good to about one count there.
+        A reading against a thermometer at byte 75 backs the middle of the
+        range (16.8 C measured, 17.0 C here). Above byte 170 the curve is
+        extrapolation: nothing has been held against the coil that hot.
         """
         if not 0 < op2 < COIL_ADC_GAIN:
             _LOGGER.debug(

--- a/docs/wf-rac-module-reference.md
+++ b/docs/wf-rac-module-reference.md
@@ -655,6 +655,7 @@ operating points are not a calibration, so the formulas stay `[INF]`.
 | `0xB1` | TDSH [°C] | `OP2 / 2` | `00` in both — never moved |
 | `0x85` | Discharge pipe TD [°C] | `OP2 / 2 + 32`, **only for `OP2 >= 0x12`** | idle `14` ⇒ 42 °C · load `17` ⇒ **43.5 °C** |
 | `0x13` | Outdoor EEV [pulses] | `OP2` | idle `c8` ⇒ 200 · load `5f`/`66` ⇒ **95 / 102** (valve closes under load) |
+| `0x05` | Internal setpoint [°C] | `OP2 / 2`, `sel` = `0x13` | `2e` ⇒ **23.0 °C** while 22.5 °C was the value sent |
 | `0x82` | THO-R1 | outdoor heat exchanger, **no known conversion** | idle `3f` ⇒ 63 · load `49` ⇒ 73; tracks the outdoor unit, but not on the coil scale below |
 | `0x81` | THI-R1 [°C] | thermistor curve, see §5.4 | `20 5a ff` ⇒ raw 90, **`sel` = `0x20`** |
 | `0x87` | THI-R3 [°C] | thermistor curve, see §5.4 | `10 5a ff` ⇒ raw 90 |
@@ -673,6 +674,14 @@ Notes on the shape of the answers `[HW]`:
 - The second byte is a **selector**, not a fixed status marker. `0x10` and
   `0x20` follow the same indoor/outdoor convention as air temperature; `0x0D`
   and `0x32` answer with values outside that pattern and are not understood.
+- **`0x05` is not in the firmware's whitelist and answers anyway**, over the
+  generic path (§5.3), with the setpoint the unit is *using internally*. It is
+  not always the value that was sent: 22.5 °C came back as 23.0, 22.0 °C as
+  22.0 (three and ten measurements, SRK20ZS-WF). The unit resolves whole
+  degrees and rounds a half one up, so a half-degree step either lands a full
+  degree away or nowhere — which is what `ENHANCED_RESOLUTION` in MHI-AC-Ctrl
+  works around. `[HW]` A correction finer than a degree has to travel in the
+  injected room temperature instead (§5.6); that field has a 0.25 K grid.
 - `0x1E` and `0x1F` answer with all-`0xFF`. Both are codes MHI-AC-Ctrl requests
   *twice*, once per unit, using the `DB6` selector the bridge does not expose —
   the likeliest reading is "unit not selectable, so no value". Untested.
@@ -683,7 +692,9 @@ Notes on the shape of the answers `[HW]`:
   sharing the outdoor unit — they are outdoor-unit-level values, not
   per-indoor. `0x13` (EEV) differs per indoor unit, since each has its own
   expansion valve. Confirmed live: one indoor unit cooling, the other idle,
-  identical frequency/current/temperature on both, EEV 57 vs. 0. `[HW]`
+  identical frequency/current/temperature on both, EEV 57 vs. 0. `[HW]` So
+  `0x11` does **not** tell you whether *this* indoor unit is calling for
+  cooling on a multi-split — `state[9] & 0x02` (§4.6) does, and costs nothing.
 - `0x13`'s full-open pulse count is unknown. MHI-AC-Ctrl reads the same
   quantity as 16 bits (`DB12<<8 | DB11`, its `OU-EEV1`), while this bridge's
   `OP2` is a single byte — likely a narrowed/derived value, not a raw pass


### PR DESCRIPTION
Two documentation corrections, no behaviour change.

**`_coil_temp` docstring.** It justified the reservation at the cold end with "the manual's 1.0 C frost cut-off, where the curve reads ~5.5 C". That threshold is not in the databook for this series. The book gives three — 8 °C recovery, 5 °C throttle, 2.5 °C stop — and a cooling run drove through all three in order, with the curve reading 7.8, 5.0 and 2.4 °C at the nearest bytes. So the cold end is anchored to about one count rather than doubtful; the extrapolation that remains is above byte 170.

**Reference §5.4 gains `0x05`.** The code is not in the bridge firmware's whitelist and answers anyway, over the generic path, with the setpoint the unit is using internally: 22.5 °C comes back as 23.0, 22.0 °C as 22.0. That is where the "half degrees are rounded up" result comes from, so the reference should carry it — including the consequence that a finer correction has to travel in the injected room temperature (§5.6) instead.

Also a pointer from `0x11` back to `state[9] & 0x02`: on a multi-split, compressor frequency is an outdoor-unit value and does not say whether *this* indoor unit is calling for cooling.

381 tests green, mypy clean.