### PR TITLE
Pick up the device-registry and logging details Core integrations set

### DIFF
--- a/custom_components/mitsubishi_wf_rac/binary_sensor.py
+++ b/custom_components/mitsubishi_wf_rac/binary_sensor.py
@@ -19,7 +19,9 @@ from pywfrac import describe_error_code
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-PARALLEL_UPDATES = 1
+# Read-only as far as the device is concerned: the coordinator does the
+# polling, and nothing on this platform sends a request of its own.
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(

--- a/custom_components/mitsubishi_wf_rac/button.py
+++ b/custom_components/mitsubishi_wf_rac/button.py
@@ -16,7 +16,9 @@ from .coordinator import Device
 from .const import DOMAIN, SIGNAL_SET_ENERGY_TOTAL
 
 _LOGGER = logging.getLogger(__name__)
-PARALLEL_UPDATES = 1
+# Read-only as far as the device is concerned: the coordinator does the
+# polling, and nothing on this platform sends a request of its own.
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -60,6 +60,8 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+# The module accepts one connection at a time and wants a second between
+# requests, so entity actions that reach the device run one after another.
 PARALLEL_UPDATES = 1
 
 # The modes whose setpoint the unit actually regulates on. Off and fan-only

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import re
 from collections import deque
 from collections.abc import Mapping
 from datetime import datetime, timedelta
@@ -12,7 +13,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    DeviceInfo,
+    format_mac,
+)
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -1293,14 +1298,30 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Return a device description for device registry."""
-        return {
+        """Return a device description for device registry.
+
+        No "model": the only model field the protocol offers is ModelNr, a
+        capability grouping (0/1/2/3/64...), not a type name - it would put a
+        bare digit where users expect "SRK35ZS-WF". It goes into model_id
+        instead, which is what a machine-readable model identifier is for, and
+        stays available as its own diagnostic sensor.
+        """
+        info: DeviceInfo = {
             "sw_version": self._firmware,
             "identifiers": {(DOMAIN, self.airco_id)},
             "manufacturer": "Mitsubishi (WF-RAC)",
-            # "model": self.airco.ModelNr,
             "name": self.device_name,
         }
+        # airconId is MAC-derived, and on every module seen so far it is the
+        # bare MAC. Only claim it when it has exactly that shape - a differently
+        # shaped id would otherwise register as somebody else's hardware and
+        # merge two unrelated devices in the registry.
+        if re.fullmatch(r"[0-9a-fA-F]{12}", self.airco_id):
+            info["connections"] = {(CONNECTION_NETWORK_MAC, format_mac(self.airco_id))}
+        model_nr = getattr(self.airco, "ModelNrRaw", None)
+        if model_nr is not None:
+            info["model_id"] = str(model_nr)
+        return info
 
     @property
     def operator_id(self) -> str:
@@ -1436,6 +1457,13 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 )
             )
         except Exception as error:
-            raise UpdateFailed(error) from error
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+                translation_placeholders={
+                    "device": self.device_name,
+                    "error": str(error),
+                },
+            ) from error
 
         return self._airco

--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -6,8 +6,12 @@
   ],
   "config_flow": true,
   "documentation": "https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/",
+  "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues",
+  "loggers": [
+    "pywfrac"
+  ],
   "requirements": [
     "pywfrac==0.1.0"
   ],

--- a/custom_components/mitsubishi_wf_rac/number.py
+++ b/custom_components/mitsubishi_wf_rac/number.py
@@ -18,6 +18,8 @@ from pywfrac import HomeLeaveModeSetting
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+# The module accepts one connection at a time and wants a second between
+# requests, so entity actions that reach the device run one after another.
 PARALLEL_UPDATES = 1
 
 # Same bounds as the temp_rule_*/temp_setting_* fields in services.yaml's

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -29,6 +29,8 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+# The module accepts one connection at a time and wants a second between
+# requests, so entity actions that reach the device run one after another.
 PARALLEL_UPDATES = 1
 
 HOME_LEAVE_MODE_OFF = "off"

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -70,7 +70,9 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-PARALLEL_UPDATES = 1
+# Read-only as far as the device is concerned: the coordinator does the
+# polling, and nothing on this platform sends a request of its own.
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -121,6 +121,9 @@
     "cannot_connect": {
       "message": "Could not reach the Airco at {device}."
     },
+    "update_failed": {
+      "message": "Polling the Airco at {device} failed: {error}"
+    },
     "temperature_required": {
       "message": "A target temperature is required."
     },

--- a/custom_components/mitsubishi_wf_rac/switch.py
+++ b/custom_components/mitsubishi_wf_rac/switch.py
@@ -14,6 +14,8 @@ from .coordinator import Device
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+# The module accepts one connection at a time and wants a second between
+# requests, so entity actions that reach the device run one after another.
 PARALLEL_UPDATES = 1
 
 

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -61,6 +61,9 @@
     "cannot_connect": {
       "message": "Die Klimaanlage unter {device} war nicht erreichbar."
     },
+    "update_failed": {
+      "message": "Die Abfrage des Klimageräts unter {device} ist fehlgeschlagen: {error}"
+    },
     "temperature_required": {
       "message": "Eine Zieltemperatur ist erforderlich."
     },

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -61,6 +61,9 @@
     "cannot_connect": {
       "message": "Could not reach the Airco at {device}."
     },
+    "update_failed": {
+      "message": "Polling the Airco at {device} failed: {error}"
+    },
     "temperature_required": {
       "message": "A target temperature is required."
     },

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -61,6 +61,9 @@
     "cannot_connect": {
       "message": "{device} のエアコンに到達できませんでした。"
     },
+    "update_failed": {
+      "message": "{device} のエアコンへの問い合わせに失敗しました: {error}"
+    },
     "temperature_required": {
       "message": "目標温度を指定してください。"
     },

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -61,6 +61,9 @@
     "cannot_connect": {
       "message": "Nepavyko pasiekti kondicionieriaus adresu {device}."
     },
+    "update_failed": {
+      "message": "Nepavyko apklausti kondicionieriaus adresu {device}: {error}"
+    },
     "temperature_required": {
       "message": "Būtina nurodyti norimą temperatūrą."
     },

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -61,6 +61,9 @@
     "cannot_connect": {
       "message": "Kon de airco op {device} niet bereiken."
     },
+    "update_failed": {
+      "message": "Het opvragen van de airco op {device} is mislukt: {error}"
+    },
     "temperature_required": {
       "message": "Een doeltemperatuur is verplicht."
     },

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -61,6 +61,9 @@
     "cannot_connect": {
       "message": "无法连接到位于 {device} 的空调。"
     },
+    "update_failed": {
+      "message": "轮询 {device} 上的空调失败：{error}"
+    },
     "temperature_required": {
       "message": "需要指定目标温度。"
     },

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -61,6 +61,9 @@
     "cannot_connect": {
       "message": "無法連接到位於 {device} 的空調。"
     },
+    "update_failed": {
+      "message": "輪詢 {device} 上的空調失敗：{error}"
+    },
     "temperature_required": {
       "message": "需要指定目標溫度。"
     },

--- a/custom_components/mitsubishi_wf_rac/update.py
+++ b/custom_components/mitsubishi_wf_rac/update.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.update import UpdateDeviceClass, UpdateEntity
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -14,7 +15,9 @@ from .coordinator import Device
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-PARALLEL_UPDATES = 1
+# Read-only as far as the device is concerned: the coordinator does the
+# polling, and nothing on this platform sends a request of its own.
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
@@ -45,6 +48,10 @@ class FirmwareUpdateEntity(WfRacEntity, UpdateEntity):
     _attr_has_entity_name = True
     _attr_translation_key = "firmware_update"
     _attr_device_class = UpdateDeviceClass.FIRMWARE
+    # Reports only; installing is the module's own business (see the class
+    # docstring), so this belongs with the diagnostics rather than among the
+    # controls on the device page.
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, device: Device) -> None:
         super().__init__(device)

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import issue_registry as ir
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -711,6 +712,36 @@ async def test_properties_reflect_constructor_args(device):
     assert device.swing_selects_enabled_default is True
     assert device.device_info["name"] == "Test AC"
     assert device.device_info["identifiers"] == {("mitsubishi_wf_rac", "airco-id")}
+
+
+async def test_device_info_claims_the_mac_only_when_the_id_is_one(hass):
+    """airconId is MAC-derived and in practice the bare MAC, but the shape is
+    the only evidence we have. Registering a connection for an id that isn't
+    one would merge this device with whatever really holds that address.
+    """
+    args = (hass, MockConfigEntry(domain=DOMAIN), "Test AC", "127.0.0.1", 51443, "device-id", "operator-id")
+
+    not_a_mac = Device(*args, "airco-id", swing_selects_enabled_default=True)
+    assert "connections" not in not_a_mac.device_info
+    await not_a_mac.async_shutdown()
+
+    a_mac = Device(*args, "348E89C5A137", swing_selects_enabled_default=True)
+    assert a_mac.device_info["connections"] == {
+        (dr.CONNECTION_NETWORK_MAC, "34:8e:89:c5:a1:37")
+    }
+    await a_mac.async_shutdown()
+
+
+async def test_device_info_carries_the_model_number_as_model_id(device):
+    """ModelNr is a capability grouping, not a type name - it belongs in
+    model_id, and "model" stays empty rather than showing a bare digit.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+
+    info = device.device_info
+    assert info["model_id"] == str(device.airco.ModelNrRaw)
+    assert "model" not in info
 
 
 async def test_delete_account_success(device):

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -72,9 +72,21 @@ def _attached(hass, entity, entity_id):
     return entity
 
 
-@pytest.mark.parametrize("module", [binary_sensor, button, climate, number, select, sensor, switch, update])
-def test_platforms_serialize_updates(module):
+@pytest.mark.parametrize("module", [climate, number, select, switch])
+def test_platforms_that_write_serialize_updates(module):
+    """The module takes one connection at a time, so anything that reaches it
+    from an entity action has to queue rather than fan out."""
     assert module.PARALLEL_UPDATES == 1
+
+
+@pytest.mark.parametrize("module", [binary_sensor, button, sensor, update])
+def test_platforms_that_only_read_do_not_serialize(module):
+    """The coordinator already centralizes the polling, and none of these send
+    a request of their own - button and sensor both act on the integration's
+    own energy total, not on the device. The quality scale asks for 0 there
+    rather than a limit that throttles nothing.
+    """
+    assert module.PARALLEL_UPDATES == 0
 
 
 async def test_platform_entity_composition_and_metadata(hass, platform_device):


### PR DESCRIPTION
Compared against [`homeassistant/components/sensibo`](https://github.com/home-assistant/core/tree/dev/homeassistant/components/sensibo) — the closest structural match in Core: climate integration, the same eight platforms, coordinator, entity services, its own update platform, quality scale platinum. Five differences were worth taking over.

### `manifest.json`: `loggers` and `integration_type`

`loggers` is the list Home Assistant's **Enable debug logging** button switches along with the integration's own logger. Since the protocol layer moved to `pywfrac` (#326) that button no longer covered it — the library logs under `pywfrac.repository` and `pywfrac.parser`, and nothing declared them. Turning on debug logging has been quietly missing the request/response detail ever since.

`integration_type` defaults to `hub` when absent, which describes one account with many devices behind it. Here it is one airco per config entry, so `device`.

### `device_info`

The airco now registers its MAC as a device-registry connection, so it links up with whatever else knows that address instead of standing alone in the registry. `airconId` is MAC-derived, but its shape is the only evidence we have — a connection claimed for an id that is not a MAC would merge this device with whatever really holds that address, so it is only set when the id is exactly twelve hex digits.

`ModelNr` comes out of the commented-out `model` and into `model_id`. It is a capability grouping (`0`/`1`/`2`/`3`/`64`), not a type name; as `model` it would have shown a bare digit where users expect `SRK35ZS-WF`. `model_id` is the field for a machine-readable model number, and the diagnostic sensor for it stays as it was.

### `PARALLEL_UPDATES`

Every platform had `1`. The rule asks for `0` on read-only platforms under a coordinator and a real limit only where entity actions reach the device, so the eight now split along that line:

| | value | why |
|---|---|---|
| `climate`, `number`, `select`, `switch` | `1` | the module takes one connection at a time |
| `binary_sensor`, `sensor`, `button`, `update` | `0` | nothing here sends a request of its own — `button` and `sensor` act on the integration's own energy total |

The reason sits next to the value now instead of being folded into one blanket number, and the test splits accordingly.

### Two smaller ones

`UpdateFailed` in the coordinator was the last user-facing error still raised untranslated. It now carries `translation_key` and names the device, in all seven languages.

The firmware update entity gets `EntityCategory.DIAGNOSTIC`. It reports and cannot install — the module only flashes itself while switched off — so it belongs with the diagnostics rather than among the controls on the device page.

272 tests pass, mypy clean.