### PR TITLE
Fix three string gaps the config flow could walk into

### DIFF
--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -171,7 +171,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
         result = await repository.update_account_info(airco_id, hass.config.time_zone)
         if not result:
-            raise CannotConnect
+            raise CannotConnect(reason="no answer to the registration request")
         if int(result["result"]) == 2:
             raise TooManyDevicesRegistered
 

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -47,6 +47,7 @@
     "error": {
       "unexpected_error": "An unexpected error occurred. Please check the log for details.",
       "cannot_connect": "Could not connect with the Airco: {reason}",
+      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
       "name_invalid": "Name is already taken or is shorter than 3 characters",
       "host_already_configured": "Airco IP already configured as [{error_name}]",
       "too_many_devices_registered": "There are too many devices registered for this airco. Please delete a device (in the app) or do a factory reset of the module."
@@ -111,6 +112,10 @@
             "data": {
               "indoor_offset": "Indoor Temp. Sensor Offset",
               "outdoor_offset": "Outdoor Temp. Sensor Offset"
+            },
+            "data_description": {
+              "indoor_offset": "Added to the unit's own indoor reading before it is shown. Display only - it does not change what the unit does.",
+              "outdoor_offset": "The same, for the outdoor temperature the unit reports."
             }
           }
         }

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -3,6 +3,7 @@
     "error": {
       "unexpected_error": "Es ist ein unerwarteter Fehler aufgetreten. Weitere Informationen finden Sie im Protokoll.",
       "cannot_connect": "Konnte keine Verbindung zur Klimaanlage herstellen: {reason}",
+      "invalid_host": "Ungültiger Hostname oder ungültige IP-Adresse",
       "name_invalid": "Der Name ist bereits vergeben oder kürzer als 3 Zeichen",
       "host_already_configured": "Klima IP bereits konfiguriert als [{error_name}]",
       "too_many_devices_registered": "Für diese Klimaanlage sind zu viele Geräte registriert. Bitte löschen Sie ein Gerät (in der App) oder führen Sie einen Werksreset des Moduls durch."
@@ -143,6 +144,10 @@
             "data": {
               "indoor_offset": "Innentemperatur Sensor-Offset",
               "outdoor_offset": "Außentemperatur Sensor-Offset"
+            },
+            "data_description": {
+              "indoor_offset": "Wird zum Messwert des geräteeigenen Innenfühlers addiert, bevor er angezeigt wird. Nur die Anzeige — am Verhalten des Geräts ändert sich nichts.",
+              "outdoor_offset": "Dasselbe für die Außentemperatur, die das Gerät meldet."
             }
           }
         }

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -3,6 +3,7 @@
     "error": {
       "unexpected_error": "An unexpected error occurred. Please check the log for details.",
       "cannot_connect": "Could not connect with the Airco: {reason}",
+      "invalid_host": "Invalid hostname or IP address",
       "name_invalid": "Name is already taken or is shorter than 3 characters",
       "host_already_configured": "Airco IP already configured as [{error_name}]",
       "too_many_devices_registered": "There are too many devices registered for this airco. Please delete a device (in the app) or do a factory reset of the module."
@@ -143,6 +144,10 @@
             "data": {
               "indoor_offset": "Indoor Temp. Sensor Offset",
               "outdoor_offset": "Outdoor Temp. Sensor Offset"
+            },
+            "data_description": {
+              "indoor_offset": "Added to the unit's own indoor reading before it is shown. Display only - it does not change what the unit does.",
+              "outdoor_offset": "The same, for the outdoor temperature the unit reports."
             }
           }
         }

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -3,6 +3,7 @@
     "error": {
       "unexpected_error": "予期しないエラーが発生しました。詳細についてはログを確認してください。",
       "cannot_connect": "エアコンに接続できませんでした: {reason}",
+      "invalid_host": "ホスト名または IP アドレスが正しくありません",
       "name_invalid": "名前が既に使用されているか、3文字未満です。",
       "host_already_configured": "エアコンのIPは既に [{error_name}] として設定されています。",
       "too_many_devices_registered": "このエアコンには登録されているデバイスが多すぎます。デバイスを削除するか（アプリ内で）、モジュールを工場出荷時設定にリセットしてください。"
@@ -143,6 +144,10 @@
             "data": {
               "indoor_offset": "室内オフセット",
               "outdoor_offset": "室外オフセット"
+            },
+            "data_description": {
+              "indoor_offset": "エアコン内蔵センサーの測定値に加算してから表示します。表示だけで、動作は変わりません。",
+              "outdoor_offset": "エアコンが報告する外気温についても同様です。"
             }
           }
         }

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -3,6 +3,7 @@
     "error": {
       "unexpected_error": "Įvyko nežinoma klaida. Pasitikrinkite log failus",
       "cannot_connect": "Nepavyko prisijungti prie kondicionieriaus: {reason}",
+      "invalid_host": "Netinkamas serverio vardas arba IP adresas",
       "name_invalid": "Pavadinimas jau naudojamas arba yra trumpesnis nei 3 simboliai",
       "host_already_configured": "Kondicionieriaus IP jau nustatytas kaip [{error_name}]",
       "too_many_devices_registered": "Su kondicionieriumi susieta per daug įrenginių. Ištrinkitę įrenginį programėlėje arba atstatykite modulį į gamyklinę būseną."
@@ -143,6 +144,10 @@
             "data": {
               "indoor_offset": "Vidaus poslinkis",
               "outdoor_offset": "Lauko poslinkis"
+            },
+            "data_description": {
+              "indoor_offset": "Pridedama prie paties įrenginio vidaus jutiklio rodmens prieš jį parodant. Tik rodymui — įrenginio veikimo tai nekeičia.",
+              "outdoor_offset": "Tas pats ir lauko temperatūrai, kurią praneša įrenginys."
             }
           }
         }

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -3,6 +3,7 @@
     "error": {
       "unexpected_error": "Er is een onverwachte fout opgetreden. Raadpleeg het logboek voor details.",
       "cannot_connect": "Kan niet verbinden met de Airco: {reason} ",
+      "invalid_host": "Ongeldige hostnaam of IP-adres",
       "name_invalid": "De naam is al in gebruik, of is korter dan 3 tekens. ",
       "host_already_configured": "IP is al geconfigureerd voor [{error_name}]",
       "too_many_devices_registered": "Er zijn te veel apparaten geregistreerd op deze airco. Verwijder een apparaat of reset de module."
@@ -143,6 +144,10 @@
             "data": {
               "indoor_offset": "Binnen offset",
               "outdoor_offset": "Buiten offset"
+            },
+            "data_description": {
+              "indoor_offset": "Wordt bij de meting van de eigen binnensensor opgeteld voordat die getoond wordt. Alleen weergave — het gedrag van de unit verandert er niet door.",
+              "outdoor_offset": "Hetzelfde voor de buitentemperatuur die de unit meldt."
             }
           }
         }

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -3,6 +3,7 @@
     "error": {
       "unexpected_error": "发生了意外错误。请查看日志以获取详细信息。",
       "cannot_connect": "无法连接到空调：{reason}",
+      "invalid_host": "主机名或 IP 地址无效",
       "name_invalid": "名称已被占用或少于 3 个字符",
       "host_already_configured": "空调 IP 已被配置为 [{error_name}]",
       "too_many_devices_registered": "此空调已注册了太多设备。请在应用中删除一个设备或对模块进行出厂重置。"
@@ -143,6 +144,10 @@
             "data": {
               "indoor_offset": "室内偏移",
               "outdoor_offset": "室外偏移"
+            },
+            "data_description": {
+              "indoor_offset": "在显示之前加到空调自带室内传感器的读数上。仅影响显示，不改变空调的运行。",
+              "outdoor_offset": "空调报告的室外温度同理。"
             }
           }
         }

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -3,6 +3,7 @@
     "error": {
       "unexpected_error": "發生了意外錯誤。請查看日誌以獲取詳細信息。",
       "cannot_connect": "無法連接到空調：{reason}",
+      "invalid_host": "主機名稱或 IP 位址無效",
       "name_invalid": "名稱已被佔用或少於 3 個字元",
       "host_already_configured": "空調 IP 已被配置為 [{error_name}]",
       "too_many_devices_registered": "此空調已註冊了太多設備。請在應用中刪除一個設備或對模組進行出廠重置。"
@@ -143,6 +144,10 @@
             "data": {
               "indoor_offset": "室內偏移",
               "outdoor_offset": "室外偏移"
+            },
+            "data_description": {
+              "indoor_offset": "在顯示之前加到空調內建室內感測器的讀數上。僅影響顯示，不改變空調的運作。",
+              "outdoor_offset": "空調回報的室外溫度同理。"
             }
           }
         }

--- a/tests/unit/test_translation_keys.py
+++ b/tests/unit/test_translation_keys.py
@@ -120,6 +120,40 @@ def test_sections_cover_every_field_the_options_form_shows():
     }
 
 
+def test_every_error_the_flow_raises_has_a_message():
+    """A KnownError's error_name is what async_show_form puts in `errors`, and
+    the UI looks it up under config.error. A name with no entry renders as the
+    raw key - which is how `invalid_host` reached users unnoticed: nothing else
+    fails, the form just shows a word nobody wrote.
+    """
+    from custom_components.mitsubishi_wf_rac import config_flow
+
+    raised = {
+        cls.error_name
+        for cls in vars(config_flow).values()
+        if isinstance(cls, type)
+        and issubclass(cls, config_flow.KnownError)
+        and cls is not config_flow.KnownError
+    }
+
+    assert raised <= set(STRINGS["config"]["error"]), (
+        raised - set(STRINGS["config"]["error"])
+    )
+    assert raised <= set(ENGLISH["config"]["error"]), (
+        raised - set(ENGLISH["config"]["error"])
+    )
+
+
+def test_a_section_describes_every_field_it_shows():
+    """The guard above covers the top-level step fields; the sections carry
+    their own data/data_description pair and were missed by it.
+    """
+    for section, group in STRINGS["options"]["step"]["init"]["sections"].items():
+        fields = set(group.get("data", {}))
+        described = set(group.get("data_description", {}))
+        assert fields <= described, f"{section}: {fields - described}"
+
+
 def test_a_translated_section_labels_every_field_in_it():
     """A section whose fields carry no label in that language renders them as
     their raw keys - `overshoot_cool` where a label belongs. Nothing else


### PR DESCRIPTION
All three are in the released version. They surfaced while porting the integration to Home Assistant Core, whose test framework asserts that every translation a config flow reaches actually exists — something neither hassfest nor our own checks look at for a custom integration.

### `invalid_host` was never written

`InvalidHost` is raised for a host shorter than three characters (`config_flow.py`), and its `error_name` is `invalid_host`. That key has never existed in `strings.json` or in any of the seven translations. The form showed the raw key where a message belongs.

### `cannot_connect` printed its own placeholder

The message is `Could not connect with the Airco: {reason}`, and every path fills `reason` in — except the registration branch, which raised a bare `CannotConnect`. That one printed `{reason}` verbatim. It now says what failed.

### The sensor offsets had no descriptions

`Indoor Temp. Sensor Offset` and `Outdoor Temp. Sensor Offset` carried labels but no `data_description`, so the dialog gave no hint that they are display-only. The guard added alongside the setup-step descriptions only checked `step.data` and never looked inside the sections.

### Guards

Two tests, both verified to fail without the fix:

- `test_every_error_the_flow_raises_has_a_message` walks the `KnownError` subclasses and asserts every `error_name` resolves in `strings.json` and `translations/en.json`. This is the check that would have caught `invalid_host` when it was introduced.
- `test_a_section_describes_every_field_it_shows` requires each options section to describe the fields it renders — the gap the existing top-level guard left open.

274 tests pass, mypy clean. All seven languages carry the new strings.