### PR TITLE
Read the host from where the discovery refresh writes it

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -119,13 +119,30 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
         hass.config_entries.async_update_entry(entry, options=new_options, version=5)
+    if entry.version == 5:
+        # Move the host back into entry.data, where connection-critical data
+        # belongs. It has lived in options since v2 so the options dialog
+        # could edit it, which the reconfigure flow does now - and options
+        # was the wrong home for a second reason: the discovery helper that
+        # refreshes a changed address (_abort_if_unique_id_configured with
+        # updates=) only ever merges into entry.data, so a unit that moved to
+        # a new IP had the refresh written to a key setup never reads, and
+        # kept being polled at the old address.
+        new_data = dict(entry.data)
+        new_options = dict(entry.options)
+        if CONF_HOST in new_options:
+            new_data[CONF_HOST] = new_options.pop(CONF_HOST)
+
+        hass.config_entries.async_update_entry(
+            entry, data=new_data, options=new_options, version=6
+        )
 
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEntry) -> bool:
     """Establish connection with mitsubishi-wf-rac."""
-    device: str = entry.options[CONF_HOST]
+    device: str = entry.data[CONF_HOST]
     _device = await create_device_from_entry(entry, hass)
 
     await _device.update()  # initial update to get fresh values
@@ -161,7 +178,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEnt
 
 
 async def create_device_from_entry(entry: ConfigEntry, hass: HomeAssistant) -> Device:
-    device: str = entry.options[CONF_HOST]
+    device: str = entry.data[CONF_HOST]
     name: str = entry.data[CONF_NAME]
     device_id: str = entry.data[CONF_DEVICE_ID]
     operator_id: str = entry.data[CONF_OPERATOR_ID]
@@ -194,8 +211,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEn
 
     # The coordinator can hold a listener of its own (the carrier for an armed
     # external temperature override), which would outlive the entry and keep
-    # its refresh timer running.
-    await entry.runtime_data.device.async_shutdown()
+    # its refresh timer running. Only tear it down once the entities are
+    # really gone: if unloading the platforms failed they stay loaded, and a
+    # stopped coordinator would leave them on an entry that never updates
+    # again. An entry whose setup never stored its runtime data has no
+    # coordinator to shut down at all.
+    if unload_ok and (data := getattr(entry, "runtime_data", None)) is not None:
+        await data.device.async_shutdown()
 
     if unload_ok:
         _LOGGER.info("Unloaded entry for device [%s]", entry.data[CONF_NAME])

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -81,15 +81,6 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return entry
         return None
 
-    def _find_entry_matching_option(
-        self, key: str, matches: Callable[[Any], bool]
-    ) -> config_entries.ConfigEntry | None:
-        """Returns the first entry where matches(entry.options[key]) returns True"""
-        for entry in self._async_current_entries():
-            if key in entry.options and matches(entry.options[key]):
-                return entry
-        return None
-
     async def _async_register_airco(
             self,
             hass: HomeAssistant,
@@ -112,7 +103,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Is this hostname or IP address already configured on a *different*
             # entry? During reconfigure, the entry being edited already owns
             # this host among its own options, so it must not flag itself.
-            existing_entry = self._find_entry_matching_option(
+            existing_entry = self._find_entry_matching(
                 CONF_HOST, lambda h: h == data[CONF_HOST]
             )
             if existing_entry and existing_entry.entry_id != exclude_entry_id:
@@ -213,13 +204,20 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self.hass, user_input, allow_port_fallback=allow_port_fallback
                 )
 
+                # A unit reached at a second address would otherwise become a
+                # second entry, whose entities collide with the first one's -
+                # the manual step has no unique id to abort on. The airco id
+                # the registration just returned is the unit's own identity.
+                if self._find_entry_matching(
+                    CONF_AIRCO_ID, lambda a: a == info[CONF_AIRCO_ID]
+                ):
+                    return self.async_abort(reason="already_configured")
+
                 data_input = user_input.copy()
                 options_input = {
-                    CONF_HOST: user_input[CONF_HOST],
                     CONF_AVAILABILITY_RETRY_LIMIT: AVAILABILITY_FAILURE_LIMIT_MIN,
                     CONF_FIRMWARE_UPDATE_CHECK: False,
                 }
-                data_input.pop(CONF_HOST)
 
                 return self.async_create_entry(
                     title=info[CONF_NAME],
@@ -336,7 +334,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         reconfigure_entry = self._get_reconfigure_entry()
         current = {
             CONF_NAME: reconfigure_entry.data[CONF_NAME],
-            CONF_HOST: reconfigure_entry.options[CONF_HOST],
+            CONF_HOST: reconfigure_entry.data[CONF_HOST],
             CONF_PORT: reconfigure_entry.data[CONF_PORT],
         }
 
@@ -363,13 +361,11 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
 
                 new_data = {**reconfigure_entry.data, **data}
-                new_options = {**reconfigure_entry.options, CONF_HOST: new_data.pop(CONF_HOST)}
 
                 return self.async_update_reload_and_abort(
                     reconfigure_entry,
                     title=info[CONF_NAME],
                     data=new_data,
-                    options=new_options,
                 )
             except KnownError as error:
                 errors, placeholders = error.get_errors_and_placeholders(
@@ -413,7 +409,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(node_name)
         self._abort_if_unique_id_configured(updates=info)
 
-        existing_entry = self._find_entry_matching_option(CONF_HOST, lambda h: h == host)
+        existing_entry = self._find_entry_matching(CONF_HOST, lambda h: h == host)
         if existing_entry:
             _LOGGER.debug("already configured!")
             return self.async_abort(reason="already_configured")
@@ -503,10 +499,6 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlowWithReload):
             for key, value in self.config_entry.options.items():
                 if key not in self._rendered_option_keys():
                     data.setdefault(key, value)
-            # Host moved to the reconfigure flow (validated against the
-            # device) - keep the entry's existing value, since this form no
-            # longer collects it.
-            data[CONF_HOST] = self.config_entry.options[CONF_HOST]
             return self.async_create_entry(title="", data=data)
 
         options = self.config_entry.options

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -86,8 +86,8 @@ async def test_user_flow_success_creates_entry(hass: HomeAssistant):
     assert result["title"] == "Living Room AC"
     # CONF_HOST moves from data to options (see _async_create_common) - not
     # duplicated across both.
-    assert "host" not in result["data"]
-    assert result["options"]["host"] == "192.168.1.50"
+    assert result["data"]["host"] == "192.168.1.50"
+    assert "host" not in result["options"]
     assert result["data"][CONF_AIRCO_ID] == "airco-1"
     # Off by default for new entries too - see CONF_FIRMWARE_UPDATE_CHECK.
     assert result["options"][CONF_FIRMWARE_UPDATE_CHECK] is False
@@ -127,8 +127,8 @@ async def test_user_flow_invalid_name_shows_error(hass: HomeAssistant):
 async def test_user_flow_host_already_configured_shows_error(hass: HomeAssistant):
     MockConfigEntry(
         domain=DOMAIN,
-        data={"name": "Existing AC"},
-        options={"host": "192.168.1.50"},
+        data={"name": "Existing AC", "host": "192.168.1.50"},
+        options={},
     ).add_to_hass(hass)
 
     repo = _mock_repository()
@@ -150,8 +150,8 @@ async def test_user_flow_host_already_configured_shows_error(hass: HomeAssistant
 async def test_user_flow_force_update_bypasses_duplicate_host_check(hass: HomeAssistant):
     MockConfigEntry(
         domain=DOMAIN,
-        data={"name": "Existing AC"},
-        options={"host": "192.168.1.50"},
+        data={"name": "Existing AC", "host": "192.168.1.50"},
+        options={},
     ).add_to_hass(hass)
 
     repo = _mock_repository()
@@ -245,10 +245,11 @@ async def test_user_flow_reuses_operator_and_device_id_from_existing_entry(hass:
         domain=DOMAIN,
         data={
             "name": "Existing AC",
+            "host": "192.168.1.60",
             CONF_OPERATOR_ID: "shared-operator-id",
             CONF_DEVICE_ID: "shared-device-id",
         },
-        options={"host": "192.168.1.60"},
+        options={},
     ).add_to_hass(hass)
 
     repo = _mock_repository()
@@ -273,14 +274,16 @@ def _existing_entry(
 ):
     entry = MockConfigEntry(
         domain=DOMAIN,
+        version=6,
         data={
             "name": name,
+            "host": host,
             "port": port,
             CONF_AIRCO_ID: "airco-1",
             CONF_OPERATOR_ID: "operator-1",
             CONF_DEVICE_ID: "device-1",
         },
-        options={"host": host, CONF_FIRMWARE_UPDATE_CHECK: False},
+        options={CONF_FIRMWARE_UPDATE_CHECK: False},
     )
     entry.add_to_hass(hass)
     return entry
@@ -313,7 +316,8 @@ async def test_reconfigure_flow_updates_host_and_reloads(hass: HomeAssistant):
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert entry.options["host"] == "192.168.1.60"
+    assert entry.data["host"] == "192.168.1.60"
+    assert "host" not in entry.options
     # Everything not touched by the form survives the update.
     assert entry.data[CONF_OPERATOR_ID] == "operator-1"
     assert entry.data[CONF_DEVICE_ID] == "device-1"
@@ -341,8 +345,8 @@ async def test_reconfigure_flow_allows_resubmitting_the_same_host(hass: HomeAssi
 async def test_reconfigure_flow_rejects_another_entrys_host(hass: HomeAssistant):
     MockConfigEntry(
         domain=DOMAIN,
-        data={"name": "Bedroom AC"},
-        options={"host": "192.168.1.99"},
+        data={"name": "Bedroom AC", "host": "192.168.1.99"},
+        options={},
     ).add_to_hass(hass)
     entry = _existing_entry(hass, host="192.168.1.50")
 
@@ -356,7 +360,7 @@ async def test_reconfigure_flow_rejects_another_entrys_host(hass: HomeAssistant)
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"host": "host_already_configured"}
-    assert entry.options["host"] == "192.168.1.50"
+    assert entry.data["host"] == "192.168.1.50"
 
 
 async def test_reconfigure_flow_cannot_connect_shows_error(hass: HomeAssistant):
@@ -373,7 +377,7 @@ async def test_reconfigure_flow_cannot_connect_shows_error(hass: HomeAssistant):
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
-    assert entry.options["host"] == "192.168.1.50"
+    assert entry.data["host"] == "192.168.1.50"
 
 
 # --- zeroconf discovery -------------------------------------------------
@@ -404,8 +408,8 @@ async def test_zeroconf_discovery_shows_confirm_form(hass: HomeAssistant):
 async def test_zeroconf_discovery_aborts_if_host_already_configured(hass: HomeAssistant):
     MockConfigEntry(
         domain=DOMAIN,
-        data={"name": "Existing AC"},
-        options={"host": "192.168.1.50"},
+        data={"name": "Existing AC", "host": "192.168.1.50"},
+        options={},
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -430,7 +434,7 @@ async def test_zeroconf_discovery_confirm_creates_entry(hass: HomeAssistant):
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["options"]["host"] == "192.168.1.50"
+    assert result["data"]["host"] == "192.168.1.50"
     assert result["data"]["port"] == 51443
 
 
@@ -550,7 +554,7 @@ async def test_options_flow_saves_submitted_values(hass: HomeAssistant):
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50"},
+        options={},
     )
     entry.add_to_hass(hass)
 
@@ -570,9 +574,9 @@ async def test_options_flow_saves_submitted_values(hass: HomeAssistant):
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_TARGET_OFFSET] == 0.5
     assert result["data"][CONF_EXTERNAL_TEMPERATURE_SOURCE] == "sensor.living_room_temperature"
-    # host isn't a form field anymore (moved to the reconfigure flow), but
-    # the entry's existing value must survive an options save regardless.
-    assert result["data"]["host"] == "192.168.1.50"
+    # The host is connection data now, so it is not in the options at all and
+    # an options save cannot touch it.
+    assert "host" not in result["data"]
 
 
 async def test_options_flow_refuses_its_own_entity_as_source(hass: HomeAssistant):
@@ -586,7 +590,7 @@ async def test_options_flow_refuses_its_own_entity_as_source(hass: HomeAssistant
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50"},
+        options={},
     )
     entry.add_to_hass(hass)
     own = er.async_get(hass).async_get_or_create(
@@ -611,7 +615,7 @@ async def test_options_flow_accepts_a_foreign_temperature_sensor(hass: HomeAssis
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50"},
+        options={},
     )
     entry.add_to_hass(hass)
     er.async_get(hass).async_get_or_create(
@@ -648,7 +652,7 @@ async def test_options_flow_enforces_offset_range(hass: HomeAssistant, key, valu
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50"},
+        options={},
     )
     entry.add_to_hass(hass)
 
@@ -667,7 +671,7 @@ async def test_options_flow_rejects_a_retry_limit_below_the_floor(hass: HomeAssi
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50"},
+        options={},
     )
     entry.add_to_hass(hass)
 
@@ -691,7 +695,7 @@ async def test_options_flow_defaults_firmware_update_check_to_off(hass: HomeAssi
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50"},
+        options={},
     )
     entry.add_to_hass(hass)
 
@@ -706,7 +710,7 @@ async def test_options_flow_saves_submitted_firmware_update_check(hass: HomeAssi
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50"},
+        options={},
     )
     entry.add_to_hass(hass)
 
@@ -724,7 +728,7 @@ async def test_options_flow_saves_submitted_per_mode_offsets(hass: HomeAssistant
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50"},
+        options={},
     )
     entry.add_to_hass(hass)
 
@@ -779,7 +783,7 @@ async def test_options_flow_leaves_per_mode_offsets_unset_when_omitted(hass: Hom
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50"},
+        options={},
     )
     entry.add_to_hass(hass)
 
@@ -804,7 +808,7 @@ async def test_options_flow_only_offers_the_overshoots_with_a_source(hass: HomeA
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50"},
+        options={},
     )
     entry.add_to_hass(hass)
 
@@ -930,7 +934,7 @@ async def test_options_form_fields_all_have_a_label(hass: HomeAssistant):
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Living Room AC"},
-        options={"host": "192.168.1.50"},
+        options={},
     )
     entry.add_to_hass(hass)
 

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -32,7 +32,7 @@ _DATA = {
     "port": 51443,
 }
 
-_CURRENT_VERSION = 5
+_CURRENT_VERSION = 6
 
 
 def _entry(hass: HomeAssistant, version: int, data: dict, options: dict) -> MockConfigEntry:
@@ -41,15 +41,20 @@ def _entry(hass: HomeAssistant, version: int, data: dict, options: dict) -> Mock
     return entry
 
 
-async def test_migrate_v1_moves_host_into_options(hass: HomeAssistant):
-    """A v1 entry runs through every step in one go."""
+async def test_migrate_v1_leaves_the_host_in_data(hass: HomeAssistant):
+    """A v1 entry runs through every step in one go.
+
+    v2 moved the host into options and v6 moved it back, so an entry that
+    starts before both ends up where it began - which is the point: setup and
+    the discovery address refresh both read entry.data.
+    """
     entry = _entry(hass, 1, {**_DATA, CONF_HOST: "192.168.1.50"}, {})
 
     assert await async_migrate_entry(hass, entry)
 
     assert entry.version == _CURRENT_VERSION
-    assert CONF_HOST not in entry.data
-    assert entry.options[CONF_HOST] == "192.168.1.50"
+    assert CONF_HOST not in entry.options
+    assert entry.data[CONF_HOST] == "192.168.1.50"
 
 
 async def test_migrate_drops_the_check_and_floors_the_retry_limit(hass: HomeAssistant):
@@ -70,7 +75,7 @@ async def test_migrate_drops_the_check_and_floors_the_retry_limit(hass: HomeAssi
         assert entry.version == _CURRENT_VERSION
         assert CONF_AVAILABILITY_CHECK not in entry.options
         assert entry.options[CONF_AVAILABILITY_RETRY_LIMIT] == expected_limit
-        assert entry.options[CONF_HOST] == "192.168.1.50"
+        assert entry.data[CONF_HOST] == "192.168.1.50"
 
 
 async def test_migrate_v3_drops_dead_availability_retry_key(hass: HomeAssistant):
@@ -101,20 +106,21 @@ async def test_migrate_keeps_unrelated_options(hass: HomeAssistant):
 
 
 async def test_migrate_is_idempotent_at_current_version(hass: HomeAssistant):
-    options = {CONF_HOST: "192.168.1.50"}
-    entry = _entry(hass, _CURRENT_VERSION, _DATA, options)
+    options = {"indoor_offset": -1.5}
+    entry = _entry(hass, _CURRENT_VERSION, {**_DATA, CONF_HOST: "192.168.1.50"}, options)
 
     assert await async_migrate_entry(hass, entry)
 
     assert entry.version == _CURRENT_VERSION
     assert entry.options == options
+    assert entry.data[CONF_HOST] == "192.168.1.50"
 
 
 async def test_device_is_built_without_availability_options(hass: HomeAssistant):
     """Tolerance is a property of the module's behaviour, not a setting - an
     entry carrying nothing but the host must still get it.
     """
-    entry = _entry(hass, _CURRENT_VERSION, _DATA, {CONF_HOST: "192.168.1.50"})
+    entry = _entry(hass, _CURRENT_VERSION, {**_DATA, CONF_HOST: "192.168.1.50"}, {})
 
     device = await create_device_from_entry(entry, hass)
 
@@ -126,7 +132,7 @@ async def test_remove_entry_clears_the_registration_full_repair_issue(hass: Home
     must not survive the entry it was raised against, or it stays in the
     Repairs list forever pointing at nothing.
     """
-    entry = _entry(hass, _CURRENT_VERSION, _DATA, {CONF_HOST: "192.168.1.50"})
+    entry = _entry(hass, _CURRENT_VERSION, {**_DATA, CONF_HOST: "192.168.1.50"}, {})
     ir.async_create_issue(
         hass,
         DOMAIN,

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -59,9 +59,16 @@ async def test_options_flow_reloads_itself(hass: HomeAssistant):
 
     entry = MockConfigEntry(
         domain=DOMAIN,
-        version=5,
-        data={"name": "AC", "device_id": "d", "operator_id": "o", "airco_id": "a", "port": 51443},
-        options={CONF_HOST: "127.0.0.1"},
+        version=6,
+        data={
+            "name": "AC",
+            CONF_HOST: "127.0.0.1",
+            "device_id": "d",
+            "operator_id": "o",
+            "airco_id": "a",
+            "port": 51443,
+        },
+        options={},
     )
     entry.add_to_hass(hass)
     device = MagicMock(available=True, connection_method=None, update=AsyncMock())


### PR DESCRIPTION
Three fixes found while porting the integration to Home Assistant Core, all of them present in `2026.9.8`.

### Rediscovery never updated a changed address

`_abort_if_unique_id_configured(updates=...)` merges only into `entry.data`, but the host has lived in `entry.options` since the v1 → v2 migration. So when a unit came back on a new IP, Home Assistant wrote the refreshed address to a key nothing reads, and setup kept polling the old one. Silent: no error, the device just goes unavailable and stays that way until someone reconfigures it by hand.

Migration v5 → v6 moves the host back into `entry.data`, where connection data belongs. Nothing is lost by that: the options dialog stopped offering the host when the reconfigure flow took it over, so the only thing `options` still did with it was hide it from the refresh.

### Unloading could leave entities on a dead coordinator

`async_unload_entry` shut the coordinator down unconditionally. If unloading the platforms failed, the entities stayed loaded next to a coordinator that would never update again. It also assumed `runtime_data` exists, which an entry whose setup failed early does not have.

### Adding a unit by hand twice

The manual step has no unique id to abort on, so the same unit reached at a second address became a second config entry — whose entities then collide with the first one's, because entity unique ids are built from the airco id. The registration already returns that airco id, so the flow now matches on it and aborts as `already_configured`.

---

274 tests green, coverage 96 %, `mypy` clean. The migration is covered both ways: a v1 entry ends up with the host in `data` (v2 moved it out, v6 moves it back), and an entry already at the current version is left alone.
