### PR TITLE
Report a refused command back to the action that issued it

### DIFF
--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -60,9 +60,14 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-# The module accepts one connection at a time and wants a second between
-# requests, so entity actions that reach the device run one after another.
-PARALLEL_UPDATES = 1
+# Zero, not one, although this platform writes: the serialisation the module
+# needs already lives in the coordinator, which holds a send lock around the
+# request and spaces requests by MIN_TIME_BETWEEN_REQUESTS. A platform
+# semaphore on top of that only stops actions issued together - a scene, an
+# automation step that fans out - from reaching the coordinator's
+# consolidation window together, and those are exactly the ones worth
+# merging into a single frame.
+PARALLEL_UPDATES = 0
 
 # The modes whose setpoint the unit actually regulates on. Off and fan-only
 # have no setpoint of their own - see _setpoint_range_for_mode.

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -5,12 +5,14 @@ import logging
 import re
 from collections import deque
 from collections.abc import Mapping
+from contextlib import suppress
 from datetime import datetime, timedelta
 from collections.abc import Callable
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import (
@@ -378,8 +380,18 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         """Release the override's own operation-data subscription along with
         the coordinator. A listener outstanding after unload would keep the
         refresh timer alive for an entry that no longer exists.
+
+        The consolidation task is created on hass rather than owned by
+        DataUpdateCoordinator, so it has to be cancelled here too: a command
+        queued moments before the entry unloads would otherwise still be sent
+        afterwards and publish data to entities that are already gone.
         """
         self._release_external_temperature_carrier()
+        if self._consolidation_task is not None:
+            self._consolidation_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._consolidation_task
+            self._consolidation_task = None
         await super().async_shutdown()
 
     def _release_external_temperature_carrier(self) -> None:
@@ -1159,6 +1171,12 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             self._consolidation_task = self.hass.async_create_task(
                 self._async_flush_queued_command()
             )
+        # Every caller awaits the one flush its parameters ended up in, so a
+        # refusal by the unit reaches the action that caused it instead of
+        # being logged into the void. Shielded because the task is shared: a
+        # caller giving up (a cancelled service call) must not take the other
+        # callers' command down with it.
+        await asyncio.shield(self._consolidation_task)
 
     def _carry_forward_home_leave_mode(self, new_airco: Aircon) -> None:
         """The unit reports the Tag-248 HomeLeaveMode extension segment exactly
@@ -1231,14 +1249,23 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         self._last_command_at = datetime.now()
         try:
             await self.set_airco(params)
-        except (WfRacError, KeyError, TypeError, ValueError):
-            # Already logged in set_airco(). This runs as a detached task
-            # (nothing awaits it), so without this the re-raised error becomes
-            # an orphaned "Task exception was never retrieved" with zero
-            # HA-visible feedback that the command never reached the unit.
-            # Still notify below so entities pick up self.available if the
-            # same failure already flipped it.
-            pass
+        except (WfRacError, KeyError, TypeError, ValueError) as ex:
+            # Already logged in set_airco(). Push the current state out first
+            # so entities pick up self.available if the same failure flipped
+            # it, then report: async_queue_command() awaits this task, so the
+            # error lands on the action that issued the command instead of
+            # becoming an orphaned "Task exception was never retrieved".
+            # Wrapped rather than re-raised - a library exception in a service
+            # call is a traceback, not something the user can read.
+            self.async_set_updated_data(self._airco)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_failed",
+                translation_placeholders={
+                    "device": self.device_name,
+                    "error": str(ex),
+                },
+            ) from ex
         # Immediately push the (possibly unchanged, on failure) state to all
         # entities instead of leaving them to wait for the next poll (up to
         # MIN_TIME_BETWEEN_UPDATES later).

--- a/custom_components/mitsubishi_wf_rac/number.py
+++ b/custom_components/mitsubishi_wf_rac/number.py
@@ -18,9 +18,14 @@ from pywfrac import HomeLeaveModeSetting
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-# The module accepts one connection at a time and wants a second between
-# requests, so entity actions that reach the device run one after another.
-PARALLEL_UPDATES = 1
+# Zero, not one, although this platform writes: the serialisation the module
+# needs already lives in the coordinator, which holds a send lock around the
+# request and spaces requests by MIN_TIME_BETWEEN_REQUESTS. A platform
+# semaphore on top of that only stops actions issued together - a scene, an
+# automation step that fans out - from reaching the coordinator's
+# consolidation window together, and those are exactly the ones worth
+# merging into a single frame.
+PARALLEL_UPDATES = 0
 
 # Same bounds as the temp_rule_*/temp_setting_* fields in services.yaml's
 # set_home_leave_mode action.

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -29,9 +29,14 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-# The module accepts one connection at a time and wants a second between
-# requests, so entity actions that reach the device run one after another.
-PARALLEL_UPDATES = 1
+# Zero, not one, although this platform writes: the serialisation the module
+# needs already lives in the coordinator, which holds a send lock around the
+# request and spaces requests by MIN_TIME_BETWEEN_REQUESTS. A platform
+# semaphore on top of that only stops actions issued together - a scene, an
+# automation step that fans out - from reaching the coordinator's
+# consolidation window together, and those are exactly the ones worth
+# merging into a single frame.
+PARALLEL_UPDATES = 0
 
 HOME_LEAVE_MODE_OFF = "off"
 HOME_LEAVE_MODE_AWAY_COOL = "away_cool"

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -129,6 +129,9 @@
     "update_failed": {
       "message": "Polling the Airco at {device} failed: {error}"
     },
+    "command_failed": {
+      "message": "Sending the command to the Airco at {device} failed: {error}"
+    },
     "temperature_required": {
       "message": "A target temperature is required."
     },

--- a/custom_components/mitsubishi_wf_rac/switch.py
+++ b/custom_components/mitsubishi_wf_rac/switch.py
@@ -14,9 +14,14 @@ from .coordinator import Device
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-# The module accepts one connection at a time and wants a second between
-# requests, so entity actions that reach the device run one after another.
-PARALLEL_UPDATES = 1
+# Zero, not one, although this platform writes: the serialisation the module
+# needs already lives in the coordinator, which holds a send lock around the
+# request and spaces requests by MIN_TIME_BETWEEN_REQUESTS. A platform
+# semaphore on top of that only stops actions issued together - a scene, an
+# automation step that fans out - from reaching the coordinator's
+# consolidation window together, and those are exactly the ones worth
+# merging into a single frame.
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -65,6 +65,9 @@
     "update_failed": {
       "message": "Die Abfrage des Klimageräts unter {device} ist fehlgeschlagen: {error}"
     },
+    "command_failed": {
+      "message": "Das Senden des Befehls an das Klimagerät unter {device} ist fehlgeschlagen: {error}"
+    },
     "temperature_required": {
       "message": "Eine Zieltemperatur ist erforderlich."
     },

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -65,6 +65,9 @@
     "update_failed": {
       "message": "Polling the Airco at {device} failed: {error}"
     },
+    "command_failed": {
+      "message": "Sending the command to the Airco at {device} failed: {error}"
+    },
     "temperature_required": {
       "message": "A target temperature is required."
     },

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -65,6 +65,9 @@
     "update_failed": {
       "message": "{device} のエアコンへの問い合わせに失敗しました: {error}"
     },
+    "command_failed": {
+      "message": "{device} のエアコンへのコマンド送信に失敗しました: {error}"
+    },
     "temperature_required": {
       "message": "目標温度を指定してください。"
     },

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -65,6 +65,9 @@
     "update_failed": {
       "message": "Nepavyko apklausti kondicionieriaus adresu {device}: {error}"
     },
+    "command_failed": {
+      "message": "Nepavyko nusiųsti komandos kondicionieriui adresu {device}: {error}"
+    },
     "temperature_required": {
       "message": "Būtina nurodyti norimą temperatūrą."
     },

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -65,6 +65,9 @@
     "update_failed": {
       "message": "Het opvragen van de airco op {device} is mislukt: {error}"
     },
+    "command_failed": {
+      "message": "Het verzenden van de opdracht naar de airco op {device} is mislukt: {error}"
+    },
     "temperature_required": {
       "message": "Een doeltemperatuur is verplicht."
     },

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -65,6 +65,9 @@
     "update_failed": {
       "message": "轮询 {device} 上的空调失败：{error}"
     },
+    "command_failed": {
+      "message": "向 {device} 上的空调发送命令失败：{error}"
+    },
     "temperature_required": {
       "message": "需要指定目标温度。"
     },

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -65,6 +65,9 @@
     "update_failed": {
       "message": "輪詢 {device} 上的空調失敗：{error}"
     },
+    "command_failed": {
+      "message": "向 {device} 上的空調傳送命令失敗：{error}"
+    },
     "temperature_required": {
       "message": "需要指定目標溫度。"
     },

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import issue_registry as ir
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -612,18 +613,72 @@ async def test_set_airco_lock_prevents_stale_snapshot_race(device):
 
 
 async def test_async_queue_command_coalesces_into_one_send(device, monkeypatch):
+    """Commands issued together still leave as a single frame.
+
+    Together, not one after the other: each caller now awaits the flush its
+    parameters landed in, so a second command awaited after the first has
+    missed the window by definition. What consolidation is for is the case
+    that arrives concurrently - a scene, an automation step that fans out -
+    which is why the platforms run with PARALLEL_UPDATES = 0.
+    """
     monkeypatch.setattr(coordinator_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
     device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
     await device.update()
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
 
-    await device.async_queue_command({AirconCommands.AirFlow: 2})
-    await device.async_queue_command({AirconCommands.PresetTemp: 25.0})
-
-    await asyncio.sleep(0.05)
+    await asyncio.gather(
+        device.async_queue_command({AirconCommands.AirFlow: 2}),
+        device.async_queue_command({AirconCommands.PresetTemp: 25.0}),
+    )
 
     device._api.send_airco_command.assert_awaited_once()
     assert device.airco.AirFlow == 2
+    assert device.airco.PresetTemp == 25.0
+
+
+async def test_async_queue_command_reports_a_refusal_to_its_caller(device, monkeypatch):
+    """A command the unit refused has to reach the action that issued it.
+
+    It used to be sent by a detached task that logged the failure and dropped
+    it, so a service call reported success for a command that never arrived.
+    """
+    monkeypatch.setattr(coordinator_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    device._api.send_airco_command = AsyncMock(
+        side_effect=WfRacConnectionError("offline")
+    )
+
+    with pytest.raises(HomeAssistantError) as raised:
+        await device.async_queue_command({AirconCommands.Operation: True})
+
+    assert raised.value.translation_key == "command_failed"
+
+
+async def test_a_caller_giving_up_does_not_cancel_the_shared_command(
+    device, monkeypatch
+):
+    """The flush is one task shared by everyone in the window.
+
+    A caller that goes away - a cancelled service call - must not take the
+    other callers' command down with it, which is what the shield is for.
+    """
+    monkeypatch.setattr(coordinator_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=20))
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    await device.update()
+    device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
+
+    leaving = asyncio.ensure_future(
+        device.async_queue_command({AirconCommands.AirFlow: 2})
+    )
+    staying = asyncio.ensure_future(
+        device.async_queue_command({AirconCommands.PresetTemp: 25.0})
+    )
+    await asyncio.sleep(0)
+    leaving.cancel()
+    await staying
+
+    device._api.send_airco_command.assert_awaited_once()
     assert device.airco.PresetTemp == 25.0
 
 
@@ -660,8 +715,8 @@ async def test_async_queue_command_notifies_listeners_even_on_failure(device, mo
     listener = MagicMock()
     unsubscribe = device.async_add_listener(listener)
     try:
-        await device.async_queue_command({AirconCommands.Operation: True})
-        await asyncio.sleep(0.05)
+        with pytest.raises(HomeAssistantError):
+            await device.async_queue_command({AirconCommands.Operation: True})
         listener.assert_called()
     finally:
         unsubscribe()

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -72,19 +72,17 @@ def _attached(hass, entity, entity_id):
     return entity
 
 
-@pytest.mark.parametrize("module", [climate, number, select, switch])
-def test_platforms_that_write_serialize_updates(module):
-    """The module takes one connection at a time, so anything that reaches it
-    from an entity action has to queue rather than fan out."""
-    assert module.PARALLEL_UPDATES == 1
+@pytest.mark.parametrize(
+    "module", [binary_sensor, button, climate, number, select, sensor, switch, update]
+)
+def test_no_platform_serializes_on_top_of_the_coordinator(module):
+    """Zero everywhere, including the platforms that write.
 
-
-@pytest.mark.parametrize("module", [binary_sensor, button, sensor, update])
-def test_platforms_that_only_read_do_not_serialize(module):
-    """The coordinator already centralizes the polling, and none of these send
-    a request of their own - button and sensor both act on the integration's
-    own energy total, not on the device. The quality scale asks for 0 there
-    rather than a limit that throttles nothing.
+    The serialisation the module needs (one connection, a second between
+    requests) lives in the coordinator's send lock, not in a platform
+    semaphore. A semaphore on top only keeps actions issued together out of
+    the same consolidation window - and those are the ones worth merging into
+    a single frame.
     """
     assert module.PARALLEL_UPDATES == 0
 


### PR DESCRIPTION
Backported from the Home Assistant Core port, where the `action-exceptions` quality rule made the gap visible.

### A refused command reported success

`async_queue_command()` returned as soon as the parameters were queued. A detached task sent them a moment later and swallowed whatever the unit answered, because nothing awaited that task and a re-raised error would only have become an orphaned "Task exception was never retrieved". So a service call reported success for a command that never reached the unit, and the only trace was a log line nobody was watching.

Every caller now awaits the one flush its parameters ended up in, and a failure comes back as a translated `HomeAssistantError` rather than a library exception. The await is shielded because the flush is shared: a caller that gives up — a cancelled service call — must not take the other callers' command down with it. `async_shutdown()` cancels a flush still in flight, so a command queued moments before an unload cannot publish to entities that are already gone.

This is the most likely explanation for "the command never arrived" reports where the log shows a `result: 2` or a write refusal: the unit said no, and Home Assistant said yes.

### `PARALLEL_UPDATES = 0` on the writing platforms

Awaiting the command is what makes this necessary. With `PARALLEL_UPDATES = 1` the second action does not start until the first has been sent, so a scene that sets mode, temperature and fan speed left as three frames where it used to leave as one — three writes, three 60-second write locks.

The semaphore was never what serialised the requests. That is the coordinator's send lock plus `MIN_TIME_BETWEEN_REQUESTS`, and both are untouched. A platform semaphore on top only kept actions issued together from reaching the consolidation window together, and those are exactly the ones worth merging.

Commands awaited one after another still leave as separate frames. That is unavoidable once each one is awaited, and the consolidation test now says so instead of testing the sequential case.

---

276 tests green, coverage 96 %, `mypy` clean. `command_failed` is added to `strings.json` and all seven translations.
