### PR TITLE
Add smdev0925's multi-split mode lockout resolver

### DIFF
--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -3,8 +3,17 @@
 Automation blueprints for units running this integration, contributed by people
 who use them on their own systems.
 
-There are none in here yet. This directory exists so there is somewhere to put
-them.
+## What is in here
+
+- **[MHI multi-split mode lockout resolver](automation/smdev0925/mhi-multi-split-mode-lockout.yaml)**
+  by [smdev0925](https://github.com/smdev0925) — one outdoor unit serves one
+  mode at a time, and MHI's AUTO latches its heat/cool choice, so a head that
+  went quiet hours ago can still be locking everyone else out. This stands the
+  side that just had its turn down to fan-only for a few minutes, which drops
+  the latch and lets the waiting side take the system. It decides nothing about
+  what a room needs: the vote is the unit's own Cool/Heat Status, and priority
+  is its Compressor Demand. Running on a four-head SCM80.
+  ([discussion](https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/discussions/328))
 
 ## Why they live here and not in the integration
 

--- a/blueprints/automation/smdev0925/mhi-multi-split-mode-lockout.yaml
+++ b/blueprints/automation/smdev0925/mhi-multi-split-mode-lockout.yaml
@@ -1,0 +1,391 @@
+blueprint:
+  name: MHI multi-split mode lockout resolver
+  author: smdev0925
+  homeassistant:
+    min_version: "2024.10.0"
+  description: >-
+    Resolves outdoor-unit mode lockout on an MHI multi-split by standing down
+    the side that just had its turn, using the units' own heat/cool decisions.
+
+
+    ## The problem
+
+
+    One outdoor unit, one mode at a time. Whichever head claims the compressor
+    first wins; heads wanting the opposite mode are locked out and their rooms
+    drift, showing "auto" while doing nothing. MHI's AUTO also *latches* its
+    heat/cool choice, so a lockout can persist long after the reason for it has
+    gone — including while the head holding the system sits idle.
+
+
+    ## The design — trust the unit
+
+
+    This automation makes no judgement about what any room needs. The unit
+    already decides that, per room, with its own sensor and its own logic.
+    Second-guessing it means running a competing thermostat off the same
+    return-air sensor, which in practice produced a system that hunted between
+    heat and cool every 15 minutes, chasing its own measurement error.
+
+
+    Two inputs, both straight from the unit. **Cool/Heat Status** is what a head
+    is asking the outdoor unit for — the vote, and the only demand signal.
+    **Compressor Demand** is whether the compressor is running for that head
+    right now. Room temperature and setpoint are logged as evidence only;
+    nothing branches on them. If you find yourself adding a threshold in degrees
+    here, the old design is creeping back in.
+
+
+    ## The rules
+
+
+    1. Votes unanimous — nothing to do, no lockout exists.
+
+    2. Votes split, someone calling — in use means priority. The side running
+       the compressor keeps it.
+
+    3. Votes split, nobody calling — the side most recently served stands down
+       to fan-only, dropping its latch, so the waiting side takes the system.
+       After the stand-down delay they return to their mode.
+
+
+    Fan-only is what drops the latch, because the Cool/Heat Status sensor
+    reports nothing in that state. Not dry: dry is still a cooling vote and
+    would keep blocking.
+
+
+    ## How each mode is treated
+
+
+    `auto` is a full participant — its vote is the unit's own judgement.
+    `cool`, `heat` and `dry` set a **hard mode lock**: while any head is
+    explicitly in cool the system is never handed away from cooling, and vice
+    versa (dry counts as cool). An idle head left on in the opposite mode still
+    gets hot gas bleeding through its coil on the shared circuit and runs its
+    fan, so it blows warm air into a room you asked to be cooled. Release the
+    lock by putting that head back to auto or switching it off. Setting one head
+    to `cool` and another to `heat` pins both sides at once: nothing can stand
+    down, and the automation says so in the logbook rather than rotating
+    silently. `fan_only` and `off` are ignored and never touched.
+
+
+    ## What it needs
+
+
+    Both required entities are **disabled by default** on each unit — enable
+    them per device before selecting them here:
+
+
+    - **Cool/Heat Status** (sensor) — the vote.
+
+    - **Compressor Demand** (binary sensor) — the priority signal.
+
+
+    The three lists are matched up by device, so their order does not matter;
+    what matters is that every head you list contributes all three entities.
+    A head missing its status sensor has no vote and no conflict is ever seen;
+    a head missing its demand sensor cannot be told apart from one that just had
+    its turn, so the automation declines to act rather than guess. Both fail
+    safe and silent.
+
+
+    ## Two things to know before changing the numbers
+
+
+    **After a Home Assistant restart** every demand sensor's last change is
+    young, so every head reads as calling and nothing rotates until the release
+    grace has passed. That settling window is a side effect of the grace period,
+    not a separate mechanism: shortening the grace shortens the window too.
+
+
+    **A stand-down that logs but does not stick** means the delay was too short
+    — it has to outlast the outdoor unit letting go *and* the waiting side
+    re-latching and starting to call. Lengthen it, never shorten it. And the
+    unit bursts on a mode change, running hard and overshooting for roughly 15
+    minutes; the cooldown has to stay longer than that, or each change starts
+    reacting to the overshoot from the last one.
+
+
+    ## One known exposure
+
+
+    Standing down and restoring happen in a single run with a delay between. If
+    that run is interrupted — a restart, a reload, a config check — the restore
+    never happens and those heads stay in fan-only. They then have no vote, so
+    the automation cannot see them to fix it. Set them back to auto by hand;
+    they show up in the trace as heads that are not participating.
+  domain: automation
+  input:
+    fleet:
+      name: The heads
+      icon: mdi:hvac
+      description: >-
+        Every indoor unit that should take part. Pick the same units in all
+        three lists.
+      input:
+        climate_entities:
+          name: Climate entities
+          selector:
+            entity:
+              multiple: true
+              filter:
+                - integration: mitsubishi_wf_rac
+                  domain: climate
+        judge_sensors:
+          name: Cool/Heat Status sensors
+          description: Disabled by default — enable one per unit first.
+          selector:
+            entity:
+              multiple: true
+              filter:
+                - integration: mitsubishi_wf_rac
+                  domain: sensor
+        demand_sensors:
+          name: Compressor Demand sensors
+          description: Disabled by default — enable one per unit first.
+          selector:
+            entity:
+              multiple: true
+              filter:
+                - integration: mitsubishi_wf_rac
+                  domain: binary_sensor
+    timing:
+      name: Timing
+      icon: mdi:timer-outline
+      collapsed: true
+      input:
+        release_grace_minutes:
+          name: Release grace
+          description: >-
+            How long a head still counts as in use after its compressor demand
+            drops. The bit goes off between compressor cycles, so without this a
+            head mid-job reads as finished and loses the system. Everything has
+            to be quiet this long before priority changes hands.
+          default: 10
+          selector:
+            number:
+              min: 2
+              max: 60
+              unit_of_measurement: minutes
+              mode: box
+        cooldown_minutes:
+          name: Cooldown between stand-downs
+          description: >-
+            Keep this longer than the unit's post-mode-change settle of roughly
+            15 minutes.
+          default: 20
+          selector:
+            number:
+              min: 18
+              max: 120
+              unit_of_measurement: minutes
+              mode: box
+        relax_delay:
+          name: Stand-down delay
+          description: >-
+            How long the standing-down heads sit in fan-only. Four minutes is
+            proven on a four-head SCM80.
+          default:
+            hours: 0
+            minutes: 4
+            seconds: 0
+          selector:
+            duration:
+
+mode: single
+max_exceeded: silent
+
+trace:
+  stored_traces: 25
+
+triggers:
+  - trigger: time_pattern
+    minutes: "/2"
+
+variables:
+  climate_entities: !input climate_entities
+  judge_sensors: !input judge_sensors
+  demand_sensors: !input demand_sensors
+  release_grace_minutes: !input release_grace_minutes
+  cooldown_minutes: !input cooldown_minutes
+  relax_delay: !input relax_delay
+
+  # One row per head that is on and can hold a latch. The three lists are
+  # matched by device rather than by position, so their order does not matter.
+  #   vote    = 'cooling' | 'heating' | 'none' (Cool/Heat Status - the demand)
+  #   calling = compressor running for this head, plus the grace period
+  #   since   = minutes since its demand last changed; smallest = most recent
+  #   temp/target are evidence only. Nothing branches on them.
+  fleet: >-
+    {% set ns = namespace(items=[]) %}
+    {% for c in climate_entities %}
+      {% set dev = device_id(c) %}
+      {% set mode = states(c) %}
+      {% if dev is not none and mode in ['auto', 'cool', 'heat', 'dry'] %}
+        {% set judge = judge_sensors | select('in', device_entities(dev)) | list | first %}
+        {% set demand = demand_sensors | select('in', device_entities(dev)) | list | first %}
+        {% set j = states(judge) if judge is not none else 'unknown' %}
+        {% set vote = j if j in ['cooling', 'heating'] else 'none' %}
+        {% set d = states[demand] if demand is not none else none %}
+        {% set since = 99999 if d is none
+                       else ((now() - d.last_changed).total_seconds() / 60) %}
+        {% set calling = d is not none and (d.state == 'on'
+                         or (d.state == 'off' and since < release_grace_minutes)) %}
+        {% set ns.items = ns.items + [{
+             'entity': c,
+             'mode': mode,
+             'vote': vote,
+             'calling': calling,
+             'since': since | round(1),
+             'temp': state_attr(c, 'current_temperature'),
+             'target': state_attr(c, 'temperature') }] %}
+      {% endif %}
+    {% endfor %}
+    {{ ns.items }}
+
+  # The two camps. A lockout exists if and only if both are occupied.
+  conflict: >-
+    {{ fleet | selectattr('vote', 'eq', 'cooling') | list | count > 0
+       and fleet | selectattr('vote', 'eq', 'heating') | list | count > 0 }}
+
+  # Anything actively running? If so it keeps the system, full stop.
+  in_use: "{{ fleet | selectattr('calling') | list }}"
+
+  # Which side just had its turn. The head whose demand changed most recently
+  # tells us what the compressor was last doing. Only consulted once everything
+  # has gone quiet, which is the only time it is meaningful.
+  last_served: >-
+    {% set ns = namespace(t=99999, mode='none') %}
+    {% for f in fleet if f.vote in ['cooling', 'heating'] %}
+      {% if f.since < ns.t %}
+        {% set ns.t = f.since %}
+        {% set ns.mode = f.vote %}
+      {% endif %}
+    {% endfor %}
+    {{ ns.mode }}
+
+  # ...so the other side is the one that has been waiting.
+  waiting_side: >-
+    {{ 'heating' if last_served == 'cooling'
+       else 'cooling' if last_served == 'heating'
+       else 'none' }}
+
+  # The heads that stand down: everything voting for the side that just had its
+  # turn. Fan-only drops the latch that holds the lock.
+  standdown: "{{ fleet | selectattr('vote', 'eq', last_served) | list }}"
+
+  # Modes an explicitly-set head requires. Never handed away. See the header.
+  protected_modes: >-
+    {% set ns = namespace(items=[]) %}
+    {% for f in fleet %}
+      {% if f.mode in ['cool', 'dry'] and 'cooling' not in ns.items %}
+        {% set ns.items = ns.items + ['cooling'] %}
+      {% elif f.mode == 'heat' and 'heating' not in ns.items %}
+        {% set ns.items = ns.items + ['heating'] %}
+      {% endif %}
+    {% endfor %}
+    {{ ns.items }}
+
+  # The heads whose explicit mode blocks this particular stand-down, and whether
+  # both modes are pinned at once - the state a user is most likely to create by
+  # hand, and the one worth telling them about.
+  locked_by: >-
+    {% set ns = namespace(items=[]) %}
+    {% for f in fleet %}
+      {% if (f.mode in ['cool', 'dry'] and last_served == 'cooling')
+         or (f.mode == 'heat' and last_served == 'heating') %}
+        {% set ns.items = ns.items + [f] %}
+      {% endif %}
+    {% endfor %}
+    {{ ns.items }}
+  deadlocked: >-
+    {{ 'cooling' in protected_modes and 'heating' in protected_modes }}
+
+conditions:
+  # A genuine split: heads are asking for both modes at once.
+  - condition: template
+    value_template: "{{ conflict }}"
+
+  # In use means priority. Somebody is running the compressor, so they keep it
+  # until they are done. The release grace rides through cycling.
+  - condition: template
+    value_template: "{{ in_use | count == 0 }}"
+
+  # We know which side just finished, and there is somebody to stand down.
+  - condition: template
+    value_template: >-
+      {{ last_served in ['cooling', 'heating'] and standdown | count > 0 }}
+
+  - condition: template
+    value_template: >-
+      {% set lt = this.attributes.get('last_triggered') %}
+      {{ lt is none or (now() - lt).total_seconds() >= cooldown_minutes * 60 }}
+
+actions:
+  # The mode lock is checked here rather than as a condition, so that being
+  # blocked by a manual mode is reported instead of failing silently. The
+  # cooldown above throttles it: at most one line per cooldown while the lock
+  # persists, rather than one every two minutes.
+  - choose:
+      - alias: Blocked by a head someone set to an explicit mode
+        conditions:
+          - condition: template
+            value_template: "{{ last_served in protected_modes }}"
+        sequence:
+          - action: logbook.log
+            data:
+              name: MHI Mode Lockout
+              message: >-
+                {{ 'DEADLOCK' if deadlocked else 'Held' }} by manual modes —
+                {{ waiting_side }} cannot get the system because
+                {{ locked_by | map(attribute='entity') | map('replace', 'climate.', '') | join(', ') }}
+                {{ 'is' if locked_by | count == 1 else 'are' }} set to
+                {{ locked_by | map(attribute='mode') | unique | join('/') }}.
+                {%- if deadlocked %} Both modes are pinned at once, so no
+                stand-down is possible at all.{% endif %}
+                Return {{ 'one of them' if locked_by | count > 1 else 'it' }}
+                to auto, or switch off, to release it.
+                Fleet: {% for f in fleet %}{{ f.entity | replace('climate.', '') }}
+                [{{ f.mode }} vote={{ f.vote }}]{{ ", " if not loop.last }}{% endfor %}
+
+    default:
+      - alias: Log it, with temperatures as evidence only
+        action: logbook.log
+        data:
+          name: MHI Mode Lockout
+          message: >-
+            {{ last_served }} had its turn — standing down
+            {{ standdown | map(attribute='entity') | map('replace', 'climate.', '') | join(', ') }}
+            so {{ waiting_side }} can run.
+            Fleet: {% for f in fleet %}{{ f.entity | replace('climate.', '') }}
+            [{{ f.mode }} vote={{ f.vote }} calling={{ 'Y' if f.calling else 'N' }}
+            idle={{ f.since }}m {{ f.temp }}/{{ f.target }}C]{{ ", " if not loop.last }}{% endfor %}
+
+      - alias: Stand that side down, dropping its latch
+        action: climate.set_hvac_mode
+        target:
+          entity_id: "{{ standdown | map(attribute='entity') | list }}"
+        data:
+          hvac_mode: fan_only
+
+      - alias: Let the outdoor unit release and the waiting side take over
+        delay: "{{ relax_delay }}"
+
+      - alias: Return each head to the mode it was in
+        repeat:
+          for_each: "{{ standdown }}"
+          sequence:
+            # Only write if the head is still where we put it. Every
+            # set_hvac_mode call takes the unit's ~60s command lease and the
+            # integration does not dedupe, so restoring a head that is already
+            # back would cost a round trip for nothing. If you changed its mode
+            # by hand during the window, your choice stands.
+            - if:
+                - condition: template
+                  value_template: "{{ states(repeat.item.entity) == 'fan_only' }}"
+              then:
+                - action: climate.set_hvac_mode
+                  target:
+                    entity_id: "{{ repeat.item.entity }}"
+                  data:
+                    hvac_mode: "{{ repeat.item.mode }}"

--- a/tests/integration/test_blueprints.py
+++ b/tests/integration/test_blueprints.py
@@ -1,0 +1,125 @@
+"""The blueprints shipped in blueprints/ are checked the way HA loads them.
+
+They are not part of the integration download - HACS installs
+custom_components/ and nothing else - but a broken one costs whoever imports it
+an error with no obvious owner, and the person who contributed it cannot see
+this repo's CI.
+"""
+
+from pathlib import Path
+
+import pytest
+from homeassistant.components.automation.config import (
+    AUTOMATION_BLUEPRINT_SCHEMA,
+    PLATFORM_SCHEMA,
+)
+from homeassistant.components.blueprint import models
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.template import Template
+from homeassistant.util.yaml import loader
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.mitsubishi_wf_rac.const import DOMAIN
+
+BLUEPRINTS = sorted(
+    (Path(__file__).parent.parent.parent / "blueprints" / "automation").rglob("*.yaml")
+)
+LOCKOUT = next(p for p in BLUEPRINTS if p.name.startswith("mhi-multi-split"))
+
+HEADS = {
+    "bedroom": ("cooling", "off"),
+    "living_room": ("heating", "on"),
+}
+
+
+def _load(path: Path) -> models.Blueprint:
+    return models.Blueprint(
+        loader.load_yaml(str(path)),
+        expected_domain="automation",
+        path=str(path),
+        schema=AUTOMATION_BLUEPRINT_SCHEMA,
+    )
+
+
+@pytest.mark.parametrize("path", BLUEPRINTS, ids=lambda p: p.name)
+async def test_blueprint_loads_and_its_automation_validates(path: Path) -> None:
+    """Both halves: the blueprint block, and the automation it produces once
+    the inputs are filled in. The second is what actually runs, and a
+    substitution can be valid YAML and still not be an automation.
+    """
+    blueprint = _load(path)
+    inputs = models.BlueprintInputs(
+        blueprint,
+        {
+            "use_blueprint": {
+                "path": path.name,
+                "input": {name: [] for name in blueprint.inputs},
+            }
+        },
+    )
+
+    PLATFORM_SCHEMA(inputs.async_substitute())
+
+
+async def test_the_lockout_blueprint_pairs_each_head_by_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """The three entity lists are matched up by device, not by position.
+
+    That is the one part of this blueprint that is not the contributor's own
+    tested automation: his listed climate/judge/demand together per head, and
+    turning that into three flat selectors means the pairing has to be derived.
+    Feeding the lists in different orders is the case that would go unnoticed -
+    it would still run, just with one head's vote read off another head's
+    sensor.
+    """
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    climates, judges, demands = [], [], []
+    for room, (judge_state, demand_state) in HEADS.items():
+        device = device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id, identifiers={(DOMAIN, room)}
+        )
+        for domain, suffix, state in (
+            ("climate", "thermostat", "auto"),
+            ("sensor", "cool_hot_judge", judge_state),
+            ("binary_sensor", "compressor_demand", demand_state),
+        ):
+            registered = entity_registry.async_get_or_create(
+                domain,
+                DOMAIN,
+                f"{room}-{suffix}",
+                device_id=device.id,
+                suggested_object_id=f"{room}_{suffix}",
+            )
+            hass.states.async_set(registered.entity_id, state)
+            {"climate": climates, "sensor": judges, "binary_sensor": demands}[
+                domain
+            ].append(registered.entity_id)
+
+    # Reversed on purpose: same heads, different order.
+    variables = {
+        "climate_entities": climates,
+        "judge_sensors": list(reversed(judges)),
+        "demand_sensors": list(reversed(demands)),
+        "release_grace_minutes": 10,
+    }
+    fleet_template = _load(LOCKOUT).data["variables"]["fleet"]
+    fleet = Template(fleet_template, hass).async_render(variables)
+
+    votes = {row["entity"].split(".")[1]: row["vote"] for row in fleet}
+    assert votes == {
+        "bedroom_thermostat": "cooling",
+        "living_room_thermostat": "heating",
+    }
+    # Both count as holding the system: the living room's demand is on, and the
+    # bedroom's went off just now, which is inside the release grace. That is
+    # the property the blueprint's restart behaviour rests on - everything
+    # reads as calling until the grace has passed, so nothing rotates on a
+    # half-populated state machine.
+    assert all(row["calling"] for row in fleet)


### PR DESCRIPTION
The first blueprint in `blueprints/`, from [discussion #328](https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/discussions/328). It is @smdev0925's automation, running on his four-head SCM80; it stays under his name.

### What it does

One outdoor unit serves one mode at a time, and MHI's AUTO *latches* its heat/cool choice — so a head that went quiet hours ago can still be locking everyone else out while needing nothing itself. The blueprint stands the side that just had its turn down to `fan_only`, which is what drops the latch, waits for the outdoor unit to let go, and puts it back.

It decides nothing about what a room needs. The vote is each unit's own **Cool/Heat Status**, priority is its **Compressor Demand**, and temperatures are logged as evidence only. An earlier temperature-driven version of his automation hunted between heat and cool every 15 minutes, chasing its own measurement error; this one does not read them.

### What changed against his gist

His version carried one hardcoded entity triple per head. The blueprint takes three flat entity selectors instead and **pairs them by device**, so the order the three lists come in does not matter and renaming an entity does not break anything.

That pairing is the only part that is not his tested automation, so it has a test of its own: with the lists fed in different orders it would otherwise still run, just reading one head's vote off another head's sensor. The second test loads every blueprint in `blueprints/` the way Home Assistant does and validates the automation each one produces once its inputs are filled in — these ship outside the HACS download, so nobody importing one gets to see this CI.

The rest is his, including the parts that read like scar tissue and are: the release grace that rides through compressor cycling (and, as a side effect, keeps the automation quiet until Home Assistant has settled after a restart), the four-minute stand-down that has to outlast the outdoor unit letting go *and* the waiting side re-latching, and the cooldown that has to outlast the unit's ~15-minute burst after a mode change. The header says why each of them is what it is, so nobody shortens one without knowing what they are giving up.

---

276 tests green.