### PR TITLE
Say where the empty command block is not inert

### DIFF
--- a/docs/wf-rac-module-reference.md
+++ b/docs/wf-rac-module-reference.md
@@ -609,21 +609,39 @@ Measured on two indoor units `[HW]`: `result: 0`, the complete operation-data
 trailer in the response, and power, mode, fan speed, setpoint and both vane
 axes unchanged — with the unit running and with it switched off.
 
-> **Not on every firmware.** On a module reporting `firmType` `WCBN4612L` this
-> block is **not** inert: the unit switches off the moment it arrives, and
-> again on every repetition. `[UR]` The set-bit convention of §4.3 appears not
-> to hold there for `command[2]`, whose bit `0x01` carries the power value and
-> bit `0x02` the set-bit — an all-zero byte then reads as "power off" rather
-> than "leave power alone". Whether the other fields are applied from their
-> zeros as well is untested; the unit being off hides most of them.
+> **Not on every unit.** One module reporting `firmType` `WCBN4612L` behaves
+> the opposite way: the indoor unit switches off the moment the block arrives,
+> and again on every repetition, until the operation-data sensor asking for it
+> is turned off. `[UR]` The reading that fits is that `command[2]` bit `0x01`
+> (the power *value*, whose set-bit is `0x02`) is applied without its set-bit,
+> so an all-zero byte means "off" rather than "leave alone". Whether the other
+> fields are applied from their zeros too is untested — a unit that is off
+> hides most of them.
 >
-> Two consequences for anyone implementing this. Operation data cannot be
-> polled that way on that branch at all, and neither can anything else that
-> rides on the same frame — on this integration that includes writing a room
-> temperature into `command[5]`, which has no frame of its own. And a
-> single-branch measurement is not a general one: this recipe was verified on
-> `WF-RAC-HTTPS 025/200` and reported broken on `WCBN4612L 029/999`, so treat
-> `firmType` as part of the test matrix rather than as a label.
+> **The module is not what differs.** `[FW]` It is tempting to write this off
+> as a firmware branch, and that is wrong. The bridge-MCU images for `WF-RAC`
+> and `WCBN4612L` are byte-identical, and against the third image
+> (`WF-RAC-HTTPS`) the command path is identical too: frame builder and the
+> pending-command comparison match instruction for instruction apart from one
+> relocated RAM variable, and the ROM mask that clears bits before sending is
+> the same 18 bytes. The MCU does not interpret the set-bits at all on the way
+> out — it copies `command[2..]` into its staging area and lets the unit decide.
+>
+> So the divergence is in the **indoor unit**, and `firmType` names the module,
+> not the unit. Do not gate behaviour on it; it is a label that happens to
+> correlate with one report.
+>
+> What the MCU does do is compare `command[2] & 3` against the unit's `DB0 & 3`
+> to decide whether its command has been taken, and it keeps re-sending while
+> they differ `[FW]`. A block with no set-bits therefore never confirms on a
+> unit that ignores it — harmless, but it stays pending and is re-sent. On a
+> unit that applies it, the unit goes off and the block then "confirms",
+> which is exactly the reported behaviour.
+>
+> One consequence either way: where this happens, operation data cannot be
+> polled at all, and neither can anything else riding on the same frame — for
+> this integration that includes writing a room temperature into `command[5]`,
+> which has no frame of its own.
 
 Carry `command[8]` as you would in a real command, though. It is the one field
 with no set-bit of its own, and dropping it clears the unit's echo of it in

--- a/docs/wf-rac-module-reference.md
+++ b/docs/wf-rac-module-reference.md
@@ -23,6 +23,7 @@ silently upgrade them.
 | `[FW]` | Read out of a firmware image (module or bridge MCU), static analysis |
 | `[APP]` | Read out of the official Smart M-Air app (version 1.4.009) |
 | `[EXT]` | External project documentation, chiefly [MHI-AC-Trace](https://github.com/absalom-muc/MHI-AC-Trace) / [MHI-AC-Ctrl](https://github.com/absalom-muc/MHI-AC-Ctrl) |
+| `[UR]` | Reported by a user on hardware I do not have. One report unless it says otherwise |
 | `[INF]` | Inference from the above. Plausible, **not** tested |
 
 ---
@@ -607,6 +608,22 @@ block with none of them set changes nothing while still carrying the trailer.
 Measured on two indoor units `[HW]`: `result: 0`, the complete operation-data
 trailer in the response, and power, mode, fan speed, setpoint and both vane
 axes unchanged — with the unit running and with it switched off.
+
+> **Not on every firmware.** On a module reporting `firmType` `WCBN4612L` this
+> block is **not** inert: the unit switches off the moment it arrives, and
+> again on every repetition. `[UR]` The set-bit convention of §4.3 appears not
+> to hold there for `command[2]`, whose bit `0x01` carries the power value and
+> bit `0x02` the set-bit — an all-zero byte then reads as "power off" rather
+> than "leave power alone". Whether the other fields are applied from their
+> zeros as well is untested; the unit being off hides most of them.
+>
+> Two consequences for anyone implementing this. Operation data cannot be
+> polled that way on that branch at all, and neither can anything else that
+> rides on the same frame — on this integration that includes writing a room
+> temperature into `command[5]`, which has no frame of its own. And a
+> single-branch measurement is not a general one: this recipe was verified on
+> `WF-RAC-HTTPS 025/200` and reported broken on `WCBN4612L 029/999`, so treat
+> `firmType` as part of the test matrix rather than as a label.
 
 Carry `command[8]` as you would in a real command, though. It is the one field
 with no set-bit of its own, and dropping it clears the unit's echo of it in


### PR DESCRIPTION
From [#329](https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues/329).

§5.6 told implementers that a command block with no set-bits changes nothing, and backed it with `[HW]`: measured on two indoor units, `result: 0`, full trailer, every setting untouched. Both of those units run `WF-RAC-HTTPS 025/200`. One branch, written up as a property of the protocol.

On `WCBN4612L` it is not true. With an operation-data sensor enabled the unit switches off in the second the request arrives, and again every 60 seconds; with the sensor disabled the request never goes out and the unit runs normally. The reporter established both directions himself, so this is not a correlation someone read off a log.

The most economical explanation is that `command[2]` bit `0x01` — the power *value*, whose set-bit is `0x02` — is applied there without its set-bit, so an all-zero byte reads as "power off" rather than "leave power alone". Whether the other zero fields are applied too is untested and the note says so; a unit that is off hides most of them.

Two things follow, and both are in the note:

- **Operation data cannot be polled that way on that branch at all**, and neither can anything that rides on the same frame — for this integration that includes writing a room temperature into `command[5]`, which has no frame of its own.
- **`firmType` belongs in the test matrix.** A recipe verified on one branch is not verified on the module.

Also adds a `[UR]` confidence tag. The legend had `[HW]`, `[FW]`, `[APP]`, `[EXT]` and `[INF]` and no way to mark something observed on hardware I do not own — which is precisely the weight this finding carries, and marking it `[HW]` would have repeated the mistake being corrected.

No code change here. The fix in the integration is a separate decision: a `firmType` gate costs both features on the whole branch on the strength of one report, while stopping when the symptom appears covers unknown firmware too. Nothing is shipped until that is settled; the operation-data sensors are opt-in, so nothing happens on an untouched installation.
