### PR TITLE
Stop asking a unit for readings in a way that switches it off

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -26,7 +26,12 @@ from .const import (
     CONF_OPERATOR_ID, CONF_CREATE_SWING_MODE_SELECT,
     DOMAIN,
 )
-from .coordinator import AVAILABILITY_FAILURE_LIMIT_MIN, Device, registration_full_issue_id
+from .coordinator import (
+    AVAILABILITY_FAILURE_LIMIT_MIN,
+    Device,
+    registration_full_issue_id,
+    request_stops_unit_issue_id,
+)
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
@@ -252,3 +257,4 @@ async def async_remove_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEn
     # Entry-scoped, so it would otherwise dangle in the repair list forever
     # pointing at an entry_id that no longer resolves to anything.
     ir.async_delete_issue(hass, DOMAIN, registration_full_issue_id(entry.entry_id))
+    ir.async_delete_issue(hass, DOMAIN, request_stops_unit_issue_id(entry.entry_id))

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -42,6 +42,11 @@ CONF_CONNECTION_METHOD = "connection_method"
 ATTR_DEVICE_ID = "device_id"
 ATTR_CONNECTED_ACCOUNTS = "connected_accounts"
 ATTR_UPDATED_BY = "updated_by"
+# What the module reports in updatedBy when the change was made at the unit
+# itself rather than over the network - the IR remote, in practice. The other
+# values seen are "local" (any locally paired client, us included) and "aws"
+# (the manufacturer's cloud).
+UPDATED_BY_UNIT = "aircon"
 ATTR_ACCOUNT_EXPIRES = "account_expires"
 ATTR_LED_STATUS = "led_status"
 ATTR_AUTO_HEATING = "auto_heating"

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from contextlib import suppress
 from datetime import datetime, timedelta
 from collections.abc import Callable
-from typing import Any
+from typing import Any, override
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -31,6 +31,7 @@ from .const import (
     MIN_TIME_BETWEEN_UPDATES,
     OPERATION_MODE_COOL,
     OPERATION_MODE_HEAT,
+    UPDATED_BY_UNIT,
 )
 from pywfrac import (
     Aircon,
@@ -222,6 +223,11 @@ POLL_TIMEOUT = 2 * REQUEST_TIMEOUT + MIN_TIME_BETWEEN_REQUESTS + timedelta(secon
 AVAILABILITY_FAILURE_LIMIT_MIN = 3
 
 
+def request_stops_unit_issue_id(entry_id: str) -> str:
+    """Repair-issue id for a unit that stops when asked for operation data."""
+    return f"request_stops_unit_{entry_id}"
+
+
 def registration_full_issue_id(entry_id: str) -> str:
     """Repair-issue id for a full account table on this entry's airco.
 
@@ -230,6 +236,50 @@ def registration_full_issue_id(entry_id: str) -> str:
     issue behind) - one format, so the two can never drift apart.
     """
     return f"too_many_devices_{entry_id}"
+
+
+class _ServiceDataParser(RacParser):
+    """RacParser whose operation-data request can carry the unit's own power
+    state back to it.
+
+    The request is built with no set-bits, which on the hardware this was
+    developed against changes nothing (see RacParser.status_request_to_byte).
+    On at least one module - firmType WCBN4612L, issue #329 - the zero in
+    command[2] is applied anyway and reads as "power off", so the unit stops
+    the second the request arrives and again every 60s after that.
+
+    Carrying the current power value together with its set-bit makes the frame
+    confirm the state instead of changing it. Measured against the two indoor
+    units here: result 0, full operation-data trailer, nothing altered, with
+    the unit running and with it switched off.
+
+    Off by default and switched on per device by _note_unit_stopped_on_request(),
+    because it costs something the empty frame does not: the state it carries
+    is up to a poll old, so on a unit that honours set-bits properly this turns
+    a read into a real power write.
+    """
+
+    carry_power_state = False
+
+    @override
+    def status_request_to_byte(self, aircon_stat: AirconStat) -> bytearray:
+        stat_byte = super().status_request_to_byte(aircon_stat)
+        if self.carry_power_state:
+            # Same encoding as command_to_byte(): bit 0 the value, bit 1 the
+            # set-bit that makes the value count.
+            stat_byte[2] |= 3 if aircon_stat.Operation else 2
+        # BETA DEBUG (#329) - remove before the final release. The whole
+        # question in that issue is what this frame contains, and reconstructing
+        # it from the base64 in the request log is a step nobody should have to
+        # take twice.
+        _LOGGER.debug(
+            "Operation-data request block: %s (carrying power state: %s, "
+            "unit is %s)",
+            bytes(stat_byte).hex(" "),
+            self.carry_power_state,
+            "on" if aircon_stat.Operation else "off",
+        )
+        return stat_byte
 
 
 class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instance-attributes
@@ -259,7 +309,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             method=connection_method,
             cert_path=hass.config.path(AC_CERT_FILENAME),
         )
-        self._parser = RacParser()
+        self._parser = _ServiceDataParser()
         self._hass = hass
 
         # Protected state
@@ -601,7 +651,13 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         firm_type = response.get("firmType", "unknown")
         mcu_ver = (response.get("mcu") or {}).get("firmVer", "unknown")
         wireless_ver = (response.get("wireless") or {}).get("firmVer", "unknown")
-        self._firmware = f"{firm_type}, mcu: {mcu_ver}, wireless: {wireless_ver}"
+        firmware = f"{firm_type}, mcu: {mcu_ver}, wireless: {wireless_ver}"
+        if firmware != self._firmware:
+            # BETA DEBUG (#329) - remove before the final release. Which
+            # firmware branch a report comes from decided the whole diagnosis
+            # there, and it was two rounds of asking to find out.
+            _LOGGER.debug("[%s] reports firmware %s", self.device_name, firmware)
+        self._firmware = firmware
 
         self._firm_type = response.get("firmType")
         self._wireless_firmware_ver = (response.get("wireless") or {}).get("firmVer")
@@ -873,8 +929,22 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         # timestamp below trades away part of the lock for. The offset stays
         # because it is about spacing requests, not about what they contain -
         # a second request too soon after the poll is what the module refuses.
+        if self._parser.carry_power_state and self._updated_by == UPDATED_BY_UNIT:
+            # Carrying the power state means asserting it, and the state we
+            # hold is up to a poll old. Someone just used the remote, so skip
+            # the cycle rather than assert a value that may already be stale -
+            # switching a unit back on that its owner just switched off is a
+            # worse failure than a missing reading.
+            _LOGGER.debug(
+                "Skipping the operation-data request for [%s]: the unit was "
+                "last changed at the unit itself and this device needs the "
+                "power state carried",
+                self.device_name,
+            )
+            return
         params = {AirconCommands.ServiceDataStatusRequest: service_data_codes}
         timestamp_offset = -round(self._service_data_stamp_backdate().total_seconds())
+        was_running = self._airco is not None and self._airco.Operation
         for attempt in (1, 2):
             try:
                 await self.set_airco(
@@ -882,6 +952,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 )
                 if attempt > 1:
                     _LOGGER.debug("Service data request succeeded on retry")
+                self._check_request_stopped_unit(was_running)
                 # Notify, but deliberately not through async_set_updated_data():
                 # that resets the refresh timer, and this runs half a cycle
                 # after the poll - every cycle - so it would push the next poll
@@ -1040,6 +1111,57 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         else:
             self._clear_registration_full_issue()
         return result
+
+    def _check_request_stopped_unit(self, was_running: bool) -> None:
+        """Notice a unit that switches off because we asked it for readings.
+
+        The operation-data request carries no set-bits, so on the hardware this
+        was developed against it changes nothing. On at least one module
+        (firmType WCBN4612L, issue #329) the zero in command[2] is applied as
+        "power off" instead, and since the request repeats every 60s the unit
+        cannot be kept running at all while any operation-data sensor is
+        enabled.
+
+        Rather than guess from firmType - the bridge MCU handles this frame
+        identically across firmware branches, so the branch is the wrong thing
+        to gate on - this watches for the symptom and reacts once. From then on
+        the request carries the unit's own power state back to it, which
+        confirms the state instead of changing it.
+
+        updatedBy is what keeps this honest: "aircon" means the change was made
+        at the unit, so somebody reached for the remote in the same second and
+        this is not our doing.
+        """
+        if not was_running or self._parser.carry_power_state:
+            return
+        if self._airco is None or self._airco.Operation:
+            return
+        if self._updated_by == UPDATED_BY_UNIT:
+            _LOGGER.debug(
+                "[%s] stopped during our operation-data request, but the unit "
+                "reports the change as its own - not treating it as ours",
+                self.device_name,
+            )
+            return
+        self._parser.carry_power_state = True
+        _LOGGER.warning(
+            "[%s] switched off in the same request in which we asked it for "
+            "operation data. That request carries no settings, so this module "
+            "applies a field it should ignore. From now on the request carries "
+            "the unit's own power state back to it, which should stop this. "
+            "If the unit keeps switching off, disable its operation-data "
+            "sensors (compressor, current, temperatures) and please report it",
+            self.device_name,
+        )
+        ir.async_create_issue(
+            self._hass,
+            DOMAIN,
+            request_stops_unit_issue_id(self.entry_id),
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="request_stops_unit",
+            translation_placeholders={"device_name": self.device_name},
+        )
 
     def _report_registration_full(self) -> None:
         ir.async_create_issue(

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -62,6 +62,10 @@
     "too_many_devices": {
       "title": "Too many accounts registered on {device_name}",
       "description": "This unit has room for four registered accounts and all four are taken, so Home Assistant cannot register itself. The module never frees a slot by itself: registrations do not expire, and a new one is refused rather than replacing an older one. In the Smart M-Air app, remove this unit from a phone that no longer needs it - each account can only remove itself, and several phones sharing one Smart M-Air account take up a single slot between them. Then reload this integration. If nobody can free a slot - a phone that is long gone still holds one - the module has to be set up again from scratch."
+    },
+    "request_stops_unit": {
+      "title": "{device_name} switches off when asked for operation data",
+      "description": "The diagnostic sensors for compressor, current and temperatures are read with an extra request once a minute. That request carries no settings - it only asks - but this module applies part of it anyway and reads it as \"switch off\", so the unit stops every time it arrives.\n\nHome Assistant has switched that request to a form that carries the unit's own power state back to it, which should stop the unit switching off while keeping the sensors working. Watch it for a few minutes.\n\nIf it still switches off, turn off the operation-data sensors on this device (compressor frequency, operating current, hot gas temperature, EEV position and the coil temperatures) and remove any indoor temperature source configured in the integration's options - both rely on that request. Then please report it, including your module's firmware version: this behaviour differs between units and only a report from an affected one can settle it."
     }
   },
   "options": {

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -97,6 +97,10 @@
     "too_many_devices": {
       "title": "Zu viele Konten an {device_name} registriert",
       "description": "Diese Klimaanlage hat Platz für vier registrierte Konten, und alle vier sind belegt - Home Assistant kann sich deshalb nicht registrieren. Das Modul gibt von sich aus keinen Platz frei: Registrierungen laufen nicht ab, und eine neue wird abgewiesen, statt eine ältere zu ersetzen. Entfernen Sie das Gerät in der Smart-M-Air-App auf einem Telefon, das es nicht mehr braucht - jedes Konto kann nur sich selbst entfernen, und mehrere Telefone mit demselben Smart-M-Air-Konto belegen zusammen nur einen Platz. Laden Sie danach diese Integration neu. Wenn niemand einen Platz freigeben kann - etwa weil ein längst abgegebenes Telefon einen belegt -, muss das Modul neu eingerichtet werden."
+    },
+    "request_stops_unit": {
+      "title": "{device_name} schaltet sich ab, wenn Betriebsdaten abgefragt werden",
+      "description": "Die Diagnosesensoren für Verdichter, Strom und Temperaturen werden einmal pro Minute mit einer zusätzlichen Anfrage geholt. Diese Anfrage enthält keine Einstellungen — sie fragt nur — aber dieses Modul wendet einen Teil davon trotzdem an und liest ihn als „ausschalten“, sodass das Gerät jedes Mal stehen bleibt.\n\nHome Assistant hat die Anfrage jetzt auf eine Form umgestellt, die den Ein-/Aus-Zustand des Geräts an dieses zurückgibt. Damit sollte das Abschalten aufhören, ohne dass die Sensoren ausfallen. Bitte einige Minuten beobachten.\n\nSchaltet es sich weiterhin ab, deaktivieren Sie an diesem Gerät die Betriebsdaten-Sensoren (Verdichterfrequenz, Betriebsstrom, Heißgastemperatur, EEV-Position und die Wärmetauschertemperaturen) und entfernen Sie eine in den Optionen eingetragene Raumtemperaturquelle — beides hängt an dieser Anfrage. Melden Sie es anschließend bitte, mit der Firmwareversion Ihres Moduls: Dieses Verhalten unterscheidet sich je Gerät, und nur eine Meldung von einem betroffenen kann es klären."
     }
   },
   "options": {

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -97,6 +97,10 @@
     "too_many_devices": {
       "title": "Too many accounts registered on {device_name}",
       "description": "This unit has room for four registered accounts and all four are taken, so Home Assistant cannot register itself. The module never frees a slot by itself: registrations do not expire, and a new one is refused rather than replacing an older one. In the Smart M-Air app, remove this unit from a phone that no longer needs it - each account can only remove itself, and several phones sharing one Smart M-Air account take up a single slot between them. Then reload this integration. If nobody can free a slot - a phone that is long gone still holds one - the module has to be set up again from scratch."
+    },
+    "request_stops_unit": {
+      "title": "{device_name} switches off when asked for operation data",
+      "description": "The diagnostic sensors for compressor, current and temperatures are read with an extra request once a minute. That request carries no settings - it only asks - but this module applies part of it anyway and reads it as \"switch off\", so the unit stops every time it arrives.\n\nHome Assistant has switched that request to a form that carries the unit's own power state back to it, which should stop the unit switching off while keeping the sensors working. Watch it for a few minutes.\n\nIf it still switches off, turn off the operation-data sensors on this device (compressor frequency, operating current, hot gas temperature, EEV position and the coil temperatures) and remove any indoor temperature source configured in the integration's options - both rely on that request. Then please report it, including your module's firmware version: this behaviour differs between units and only a report from an affected one can settle it."
     }
   },
   "options": {

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -44,6 +44,7 @@ from custom_components.mitsubishi_wf_rac.coordinator import (
 from pywfrac import (
     Aircon,
     AirconCommands,
+    AirconStat,
 )
 from pywfrac.parser import (
     RacParser,
@@ -1886,3 +1887,98 @@ async def test_service_data_that_never_arrived_stays_quiet_until_it_is_due(
     device._carry_forward_service_data(Aircon())
 
     assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+# --- a unit that stops when asked for readings (#329) ----------------------
+
+
+async def _run_service_data_request(device, monkeypatch):
+    monkeypatch.setattr(
+        coordinator_module, "SERVICE_DATA_REQUEST_OFFSET", timedelta(milliseconds=1)
+    )
+    monkeypatch.setattr(
+        device, "async_contexts", lambda: {SERVICE_DATA_EEV_PULSES}
+    )
+    device._maybe_request_service_data()
+    await asyncio.sleep(0.05)
+
+
+async def test_a_unit_that_stops_on_our_request_gets_its_power_state_carried(
+    device, monkeypatch
+):
+    """The request carries no set-bits, so nothing should change - but one
+    module applies command[2] anyway and reads the zero as "off" (#329).
+
+    Detected from the symptom rather than from firmType: the bridge MCU
+    handles this frame identically across firmware branches, so the branch
+    would be the wrong thing to gate on.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    assert device.airco.Operation is True
+    assert device._parser.carry_power_state is False
+
+    # The unit answers our own request having switched itself off.
+    device._api.send_airco_command = AsyncMock(return_value=OFF_PAYLOAD)
+    await _run_service_data_request(device, monkeypatch)
+
+    assert device._parser.carry_power_state is True
+
+
+async def test_a_unit_switched_off_at_the_unit_is_not_blamed_on_us(
+    device, monkeypatch
+):
+    """updatedBy "aircon" means somebody reached for the remote in the same
+    second. Reacting to that would switch the request over on a device that
+    was never affected - and carrying the power state has a cost of its own.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+
+    response = _stats_response(OFF_PAYLOAD)
+    response["updatedBy"] = "aircon"
+    device._api.get_aircon_stats.return_value = response
+    device._api.send_airco_command = AsyncMock(return_value=OFF_PAYLOAD)
+    await device.update()
+    await _run_service_data_request(device, monkeypatch)
+
+    assert device._parser.carry_power_state is False
+
+
+async def test_carrying_the_power_state_sets_the_set_bit_with_the_value(device):
+    """Bit 0 is the value, bit 1 the set-bit that makes it count. Without the
+    set-bit the value is what a well-behaved unit ignores - and what the
+    affected one applies.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    stat = AirconStat.from_aircon(device.airco)
+    stat.ServiceDataStatusRequest = (SERVICE_DATA_EEV_PULSES,)
+
+    assert device._parser.status_request_to_byte(stat)[2] == 0
+
+    device._parser.carry_power_state = True
+    assert device._parser.status_request_to_byte(stat)[2] == 3
+
+    stat.Operation = False
+    assert device._parser.status_request_to_byte(stat)[2] == 2
+
+
+async def test_a_carried_request_is_skipped_right_after_the_remote_was_used(
+    device, monkeypatch
+):
+    """Carrying the power state means asserting it, and the state is up to a
+    poll old. Switching a unit back on that its owner just switched off is a
+    worse failure than a missing reading.
+    """
+    response = _stats_response(ON_COOL_PAYLOAD)
+    response["updatedBy"] = "aircon"
+    device._api.get_aircon_stats.return_value = response
+    await device.update()
+    device._parser.carry_power_state = True
+    set_airco = AsyncMock()
+    device.set_airco = set_airco
+
+    await _run_service_data_request(device, monkeypatch)
+
+    set_airco.assert_not_awaited()


### PR DESCRIPTION
Closes the mechanism behind [#329](https://github.com/blues-sechseck/Mitsubishi-WF-RAC-Integration/issues/329).

### What happens

The operation-data request (compressor, current, temperatures) sends a command block with **no set-bits**. On the MHI bus a value only applies when its set-bit travels with it, so that block is supposed to change nothing — it exists only to carry the trailer that asks for readings.

On one module, `firmType` `WCBN4612L`, the zero in `command[2]` is applied anyway and reads as "power off". The unit stops in the second the request arrives, and again every 60 seconds, for as long as any operation-data sensor is enabled. The reporter established both directions himself: sensors on, unit stops; sensors off, request never goes out, unit runs.

### Why this is not gated on `firmType`

That was the obvious fix and it is wrong. Comparing the bridge-MCU images: `WCBN4612L` and `WF-RAC` ship the **same** MCU firmware, and against the third image (`WF-RAC-HTTPS`) the command path is identical too — frame builder and the pending-command comparison match instruction for instruction apart from one relocated RAM variable, and the 18-byte ROM mask is the same. The MCU never interprets the set-bits on the way out; it copies `command[2..]` through and lets the unit decide.

So `firmType` names the module, not the unit, and gating on it would gate on a label that happens to correlate with one report. This watches for the symptom instead: a unit that was running and is off in the answer to our own request.

### What it switches to

The unit's own power state, carried with its set-bit, so the frame confirms the state instead of changing it. Verified on both indoor units here — the real request, once as today and once carrying, three rounds alternating, with the unit running and with it switched off:

| Unit | `command[2]` | `result` | State after | Operation data |
| --- | --- | --- | --- | --- |
| off | `0x00` (today) | 0 | unchanged | all three codes |
| off | `0x02` | 0 | unchanged | all three codes |
| **on** | `0x00` (today) | 0 | unchanged | all three codes |
| **on** | `0x03` | 0 | unchanged | all three codes |

That rules out the failure this could have caused: the bridge MCU keeps a command pending until `command[2] & 3` matches the unit's `DB0 & 3`, and a mismatch surfaces as `result` 11/12 — a carried value the unit encoded differently would have cost every reading, every cycle. Twelve requests, twelve times `result: 0`.

### The two guards, and why they are not optional

Carrying the power state costs something the empty frame does not: the state is up to a poll old, so the frame is an assertion rather than a read. Switching a unit back on that its owner just switched off is a worse failure than a missing reading.

So it is never on by default — only after the symptom has actually been seen on that device — and a carried request is skipped entirely when `updatedBy` reports the last change as made at the unit itself, which is what the IR remote looks like from here.

A repair issue explains what happened and what to do if it does not help.

### Temporary debug output

Two lines marked `BETA DEBUG` go out again before the final release: the request's command block, and the module's firmware line. Both are exactly what the diagnosis in #329 took, and both cost a round of asking for them.

---

282 tests green, coverage 96 %, `mypy` clean.
