### PR TITLE
Do not let one use of the IR remote silence the request for good

### DIFF
--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -42,11 +42,6 @@ CONF_CONNECTION_METHOD = "connection_method"
 ATTR_DEVICE_ID = "device_id"
 ATTR_CONNECTED_ACCOUNTS = "connected_accounts"
 ATTR_UPDATED_BY = "updated_by"
-# What the module reports in updatedBy when the change was made at the unit
-# itself rather than over the network - the IR remote, in practice. The other
-# values seen are "local" (any locally paired client, us included) and "aws"
-# (the manufacturer's cloud).
-UPDATED_BY_UNIT = "aircon"
 ATTR_ACCOUNT_EXPIRES = "account_expires"
 ATTR_LED_STATUS = "led_status"
 ATTR_AUTO_HEATING = "auto_heating"

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -47,10 +47,6 @@ ATTR_UPDATED_BY = "updated_by"
 # values seen are "local" (any locally paired client, us included) and "aws"
 # (the manufacturer's cloud).
 UPDATED_BY_UNIT = "aircon"
-# ...and what it reports for any locally paired client, which is every client
-# registered over the local API - this integration and any app on the same
-# network alike. The manufacturer's cloud reports "aws" instead.
-UPDATED_BY_HOST = "local"
 ATTR_ACCOUNT_EXPIRES = "account_expires"
 ATTR_LED_STATUS = "led_status"
 ATTR_AUTO_HEATING = "auto_heating"

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -47,6 +47,10 @@ ATTR_UPDATED_BY = "updated_by"
 # values seen are "local" (any locally paired client, us included) and "aws"
 # (the manufacturer's cloud).
 UPDATED_BY_UNIT = "aircon"
+# ...and what it reports for any locally paired client, which is every client
+# registered over the local API - this integration and any app on the same
+# network alike. The manufacturer's cloud reports "aws" instead.
+UPDATED_BY_HOST = "local"
 ATTR_ACCOUNT_EXPIRES = "account_expires"
 ATTR_LED_STATUS = "led_status"
 ATTR_AUTO_HEATING = "auto_heating"

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -31,7 +31,6 @@ from .const import (
     MIN_TIME_BETWEEN_UPDATES,
     OPERATION_MODE_COOL,
     OPERATION_MODE_HEAT,
-    UPDATED_BY_UNIT,
 )
 from pywfrac import (
     Aircon,
@@ -129,6 +128,20 @@ SERVICE_DATA_MIN_SPACING = SERVICE_DATA_REQUEST_INTERVAL * 0.75
 # interval: what has to stay clear is the poll, and the polls in between are
 # just as much in the way as the one the request was scheduled from.
 SERVICE_DATA_REQUEST_OFFSET = MIN_TIME_BETWEEN_UPDATES / 2
+
+# ...but half a cycle is a guess, and an expensive one. What we hold when the
+# request goes out is that old, and everything that happened in between is
+# invisible: a command from the remote in that gap is neither seen nor
+# attributable afterwards, because our own write moves both `expires` and
+# `updatedBy` past it. How much distance a module actually needs differs
+# between installations, so measure it per device instead of assuming the
+# worst everywhere: start at the safe end, walk down while requests keep
+# succeeding, and jump back up the moment one is refused for being too close.
+SERVICE_DATA_OFFSET_MIN = timedelta(seconds=5)
+SERVICE_DATA_OFFSET_STEP = timedelta(seconds=5)
+# Down slowly, up sharply: a lost cycle costs every operation-data sensor a
+# reading, while sitting one step wider than necessary costs only freshness.
+SERVICE_DATA_OFFSET_GOOD_CYCLES = 5
 
 # A refused request costs a full cycle of every operation-data sensor, and
 # these refusals are transient, so one retry is worth the extra request.
@@ -330,7 +343,6 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         self._firmware = ""
         self._connected_accounts = -1
         self._updated_by: str | None = None
-        self._unit_change_seen_at: datetime | None = None
         self._stopped_on_request = 0
         self._account_expires: int | None = None
         self._led_status: int | None = None
@@ -348,6 +360,11 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         # set by our own successful writes and consumed by the next poll, so a
         # rise in `expires` can be attributed to us or to someone else.
         self._wrote_since_last_poll = False
+        # None until the adaptation has moved it, so the ceiling stays a
+        # single source of truth.
+        self._service_data_offset: timedelta | None = None
+        self._service_data_good_cycles = 0
+        self._expected_settings: dict[str, Any] | None = None
         # When we last sent a real (set-bit) command, so an operation-data
         # request within one lock's span of it stamps honestly instead of
         # trimming that command's lease - see _service_data_stamp_backdate().
@@ -640,14 +657,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             # Not part of the airconStat blob, present alongside it in the same
             # response. Tolerate absence (.get()) since it's undocumented and
             # could be missing on older firmware.
-            updated_by = response.get("updatedBy")
-            if updated_by == UPDATED_BY_UNIT and self._updated_by != UPDATED_BY_UNIT:
-                # The transition, not the value: updatedBy names the last
-                # writer and keeps naming it until somebody else writes, so a
-                # unit left alone after its owner used the remote reports
-                # "aircon" indefinitely.
-                self._unit_change_seen_at = datetime.now()
-            self._updated_by = updated_by
+            self._updated_by = response.get("updatedBy")
             self._detect_foreign_activity(response.get("expires"))
             self._account_expires = response.get("expires")
             self._led_status = response.get("ledStat")
@@ -767,22 +777,96 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         wrote = self._wrote_since_last_poll
         self._wrote_since_last_poll = False
 
-        if (
+        expires_moved = (
             isinstance(expires, int)
             and isinstance(self._account_expires, int)
             and expires > self._account_expires
-            and not wrote
-        ):
-            if self._foreign_activity_since is None:
-                self._foreign_activity_since = datetime.now()
-            self._foreign_activity_until = datetime.now() + FOREIGN_ACTIVITY_BACKOFF
-            _LOGGER.debug(
-                "Another client wrote to [%s]: expires moved %s -> %s",
-                self.device_name,
-                self._account_expires,
-                expires,
-            )
+        )
+        if expires_moved and not wrote:
+            self._note_foreign_write(f"expires moved {self._account_expires} -> {expires}")
+        self._note_unexpected_settings(expires_moved or wrote)
         self._report_foreign_activity()
+
+    def _note_foreign_write(self, evidence: str) -> None:
+        if self._foreign_activity_since is None:
+            self._foreign_activity_since = datetime.now()
+        self._foreign_activity_until = datetime.now() + FOREIGN_ACTIVITY_BACKOFF
+        _LOGGER.debug("Another client wrote to [%s]: %s", self.device_name, evidence)
+
+    def _settings_snapshot(self) -> dict[str, Any] | None:
+        """The fields nothing but a write changes.
+
+        Deliberately none of the measurements: temperatures, currents and the
+        operation-data values move on their own every cycle. Vacant and
+        self-clean are left out for the same reason one step removed - the
+        unit turns those on by itself, and both drag a setpoint with them.
+        """
+        if self._airco is None:
+            return None
+        return {
+            name: getattr(self._airco, name)
+            for name in (
+                "Operation",
+                "OperationMode",
+                "PresetTemp",
+                "AirFlow",
+                "WindDirectionUD",
+                "WindDirectionLR",
+                "Entrust",
+            )
+        }
+
+    def _note_unexpected_settings(self, someone_wrote: bool) -> None:
+        """Notice a setting that changed without us changing it.
+
+        The third and least deniable signal, and the only one our own traffic
+        cannot erase. `expires` and `updatedBy` both record who wrote last and
+        are overwritten by our next write, so either is masked when a request
+        of ours lands in the same gap - and half of every gap is ours. A
+        setting is not a record of a write, it is the result of one, and
+        nothing we send afterwards puts it back.
+
+        What it adds is the case no write lock was taken for. Only a
+        setAirconStat moves `expires`, so a setting that changed while
+        `expires` stood still was not changed over the network at all: that is
+        the IR remote, a timer in the unit, or one of the unit's own modes.
+        Standing down for three minutes would be pointless there - nobody
+        holds the lock we would be avoiding - so this only says so, and the
+        stand-down stays with the writes it was built for.
+
+        One case is invisible here by construction, and it is ours: while the
+        operation-data request carries the power state back to a unit that
+        needs it, a change we undo inside that same gap leaves the value
+        exactly where we expect it.
+
+        Not every one of these is somebody's doing: the unit resets its own
+        setpoint after a power cycle, and Vacant and self-clean move settings
+        with nobody asking.
+        """
+        current = self._settings_snapshot()
+        expected = self._expected_settings
+        self._expected_settings = current
+        if current is None or expected is None or current == expected:
+            return
+        changed = ", ".join(
+            f"{name} {expected[name]} -> {value}"
+            for name, value in current.items()
+            if expected[name] != value
+        )
+        if someone_wrote:
+            _LOGGER.debug(
+                "[%s] changed while a write was in flight, so who did it "
+                "cannot be told from here: %s",
+                self.device_name,
+                changed,
+            )
+            return
+        _LOGGER.debug(
+            "[%s] was changed at the unit itself - nothing took the write "
+            "lock: %s",
+            self.device_name,
+            changed,
+        )
 
     async def _async_write_lock_delay(self) -> float:
         """Seconds to wait before retrying a write the unit just refused.
@@ -933,7 +1017,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         refusal is visible here: a queued command is flushed by a detached
         task that deliberately swallows its errors.
         """
-        await asyncio.sleep(SERVICE_DATA_REQUEST_OFFSET.total_seconds())
+        await asyncio.sleep(self.service_data_offset.total_seconds())
         # The state this is built from is almost irrelevant: a status request
         # carries no set-bits, so the unit applies none of it (see
         # RacParser.status_request_to_byte). Byte 5 is the one exception, since
@@ -944,24 +1028,6 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         # timestamp below trades away part of the lock for. The offset stays
         # because it is about spacing requests, not about what they contain -
         # a second request too soon after the poll is what the module refuses.
-        if self._parser.carry_power_state and self._unit_changed_recently():
-            # Carrying the power state means asserting it, and what we hold is
-            # up to a poll old. Somebody is reaching for the remote right now,
-            # so give up the cycle rather than assert a value that may already
-            # be stale - switching a unit back on that its owner just switched
-            # off is a worse failure than a missing reading.
-            #
-            # Recency, not the bare value: updatedBy keeps naming the last
-            # writer, so testing it directly would skip every cycle from the
-            # first use of the remote onwards and quietly turn the sensors off
-            # for good.
-            _LOGGER.debug(
-                "Skipping the operation-data request for [%s]: the unit was "
-                "just changed at the unit itself and this device needs the "
-                "power state carried",
-                self.device_name,
-            )
-            return
         params = {AirconCommands.ServiceDataStatusRequest: service_data_codes}
         timestamp_offset = -round(self._service_data_stamp_backdate().total_seconds())
         was_running = self._airco is not None and self._airco.Operation
@@ -973,6 +1039,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 if attempt > 1:
                     _LOGGER.debug("Service data request succeeded on retry")
                 self._check_request_stopped_unit(was_running)
+                self._note_service_data_offset_survived()
                 # Notify, but deliberately not through async_set_updated_data():
                 # that resets the refresh timer, and this runs half a cycle
                 # after the poll - every cycle - so it would push the next poll
@@ -996,6 +1063,11 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 return
             except WfRacCommandError as ex:
                 if attempt == 1:
+                    # A refusal here is the module saying the request came too
+                    # close to something else, which is exactly what the offset
+                    # is for - so widen it, whether or not the retry gets
+                    # through.
+                    self._widen_service_data_offset()
                     _LOGGER.debug("Service data request refused (%s); retrying", ex)
                     await asyncio.sleep(SERVICE_DATA_RETRY_DELAY.total_seconds())
                     continue
@@ -1132,15 +1204,57 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             self._clear_registration_full_issue()
         return result
 
-    def _unit_changed_recently(self) -> bool:
-        """Whether the unit reported a change of its own within the last cycle.
+    @property
+    def service_data_offset(self) -> timedelta:
+        """How long after a poll the operation-data request goes out."""
+        if self._service_data_offset is None:
+            return SERVICE_DATA_REQUEST_OFFSET
+        return self._service_data_offset
 
-        updatedBy names the last successful writer and goes on naming it until
-        somebody else writes, so its value alone says nothing about when. What
-        matters here is that somebody is at the unit *now*.
+    def _widen_service_data_offset(self) -> None:
+        """Put more distance between the poll and the request after a refusal.
+
+        Doubling rather than stepping: a refused request costs every
+        operation-data sensor a reading, and several in a row is what an
+        offset that is much too short looks like, so overshooting once is
+        cheaper than creeping up on it.
         """
-        return self._unit_change_seen_at is not None and (
-            datetime.now() - self._unit_change_seen_at < MIN_TIME_BETWEEN_UPDATES
+        if self.service_data_offset >= SERVICE_DATA_REQUEST_OFFSET:
+            return
+        self._service_data_good_cycles = 0
+        self._service_data_offset = min(
+            self.service_data_offset * 2, SERVICE_DATA_REQUEST_OFFSET
+        )
+        _LOGGER.debug(
+            "Moving the operation-data request for [%s] to %.0fs after the "
+            "poll: the module refused it where it was",
+            self.device_name,
+            self.service_data_offset.total_seconds(),
+        )
+
+    def _note_service_data_offset_survived(self) -> None:
+        """Move the request back towards the poll while requests keep landing.
+
+        Closer is better for everything except crowding: what the request
+        carries, and what any judgement about who changed the unit rests on,
+        is as old as the last poll.
+        """
+        if self.service_data_offset <= SERVICE_DATA_OFFSET_MIN:
+            return
+        self._service_data_good_cycles += 1
+        if self._service_data_good_cycles < SERVICE_DATA_OFFSET_GOOD_CYCLES:
+            return
+        self._service_data_good_cycles = 0
+        self._service_data_offset = max(
+            self.service_data_offset - SERVICE_DATA_OFFSET_STEP,
+            SERVICE_DATA_OFFSET_MIN,
+        )
+        _LOGGER.debug(
+            "Moving the operation-data request for [%s] to %.0fs after the "
+            "poll: %s cycles without a refusal",
+            self.device_name,
+            self.service_data_offset.total_seconds(),
+            SERVICE_DATA_OFFSET_GOOD_CYCLES,
         )
 
     def _check_request_stopped_unit(self, was_running: bool) -> None:
@@ -1314,6 +1428,10 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 self._carry_forward_home_leave_mode(new_airco)
                 self._carry_forward_service_data(new_airco)
                 self._airco = new_airco
+                # Our own write is not a foreign one: move the expectation to
+                # what the unit reports back, or the next poll would read this
+                # command as somebody else's (see _note_unexpected_settings).
+                self._expected_settings = self._settings_snapshot()
                 # After the write, and only for what the frame really carried:
                 # a command sent while the unit is off writes the sentinel, not
                 # the override.

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -31,7 +31,6 @@ from .const import (
     MIN_TIME_BETWEEN_UPDATES,
     OPERATION_MODE_COOL,
     OPERATION_MODE_HEAT,
-    UPDATED_BY_HOST,
     UPDATED_BY_UNIT,
 )
 from pywfrac import (
@@ -1169,18 +1168,13 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         if self._airco is None or self._airco.Operation:
             self._stopped_on_request = 0
             return
-        if self._updated_by != UPDATED_BY_HOST:
-            # Someone else stopped it: the unit itself ("aircon", which is what
-            # the IR remote looks like from here) or the manufacturer's cloud
-            # ("aws"). Only a locally paired writer can have been us.
-            _LOGGER.debug(
-                "[%s] stopped during our operation-data request, but the last "
-                "writer reports as %s - not treating it as ours",
-                self.device_name,
-                self._updated_by,
-            )
-            self._stopped_on_request = 0
-            return
+        # Deliberately not filtered by updatedBy. It is only ever refreshed by
+        # a poll, so at this point it names whoever wrote last *before* us -
+        # and on a unit started with the IR remote that is the remote, every
+        # time. Requiring it to name a local writer would have meant never
+        # detecting the fault on a unit its owner switches on by remote, which
+        # is the likeliest way to meet it at all. The repetition below carries
+        # the weight instead.
         self._stopped_on_request += 1
         if self._stopped_on_request < STOPPED_ON_REQUEST_BEFORE_CARRYING:
             # Once is a coincidence worth surviving: "local" covers us and any

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -31,6 +31,7 @@ from .const import (
     MIN_TIME_BETWEEN_UPDATES,
     OPERATION_MODE_COOL,
     OPERATION_MODE_HEAT,
+    UPDATED_BY_HOST,
     UPDATED_BY_UNIT,
 )
 from pywfrac import (
@@ -152,6 +153,12 @@ FOREIGN_ACTIVITY_BACKOFF = timedelta(minutes=3)
 # than repeated - two clients are genuinely fighting over the unit at that
 # point.
 WRITE_LOCK_RETRY_DELAY = timedelta(seconds=10)
+
+# How often a unit has to stop inside our own operation-data request before we
+# accept that the request is what stops it. See _check_request_stopped_unit():
+# the signal we have cannot separate us from another local client, so one
+# occurrence is a coincidence and two in a row is not.
+STOPPED_ON_REQUEST_BEFORE_CARRYING = 2
 
 # The lock runs 60 seconds, so a longer wait than that means the deadline was
 # stamped by a client whose clock is off rather than that the lock is really
@@ -324,6 +331,8 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         self._firmware = ""
         self._connected_accounts = -1
         self._updated_by: str | None = None
+        self._unit_change_seen_at: datetime | None = None
+        self._stopped_on_request = 0
         self._account_expires: int | None = None
         self._led_status: int | None = None
         self._auto_heating: int | None = None
@@ -632,7 +641,14 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             # Not part of the airconStat blob, present alongside it in the same
             # response. Tolerate absence (.get()) since it's undocumented and
             # could be missing on older firmware.
-            self._updated_by = response.get("updatedBy")
+            updated_by = response.get("updatedBy")
+            if updated_by == UPDATED_BY_UNIT and self._updated_by != UPDATED_BY_UNIT:
+                # The transition, not the value: updatedBy names the last
+                # writer and keeps naming it until somebody else writes, so a
+                # unit left alone after its owner used the remote reports
+                # "aircon" indefinitely.
+                self._unit_change_seen_at = datetime.now()
+            self._updated_by = updated_by
             self._detect_foreign_activity(response.get("expires"))
             self._account_expires = response.get("expires")
             self._led_status = response.get("ledStat")
@@ -929,15 +945,20 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         # timestamp below trades away part of the lock for. The offset stays
         # because it is about spacing requests, not about what they contain -
         # a second request too soon after the poll is what the module refuses.
-        if self._parser.carry_power_state and self._updated_by == UPDATED_BY_UNIT:
-            # Carrying the power state means asserting it, and the state we
-            # hold is up to a poll old. Someone just used the remote, so skip
-            # the cycle rather than assert a value that may already be stale -
-            # switching a unit back on that its owner just switched off is a
-            # worse failure than a missing reading.
+        if self._parser.carry_power_state and self._unit_changed_recently():
+            # Carrying the power state means asserting it, and what we hold is
+            # up to a poll old. Somebody is reaching for the remote right now,
+            # so give up the cycle rather than assert a value that may already
+            # be stale - switching a unit back on that its owner just switched
+            # off is a worse failure than a missing reading.
+            #
+            # Recency, not the bare value: updatedBy keeps naming the last
+            # writer, so testing it directly would skip every cycle from the
+            # first use of the remote onwards and quietly turn the sensors off
+            # for good.
             _LOGGER.debug(
                 "Skipping the operation-data request for [%s]: the unit was "
-                "last changed at the unit itself and this device needs the "
+                "just changed at the unit itself and this device needs the "
                 "power state carried",
                 self.device_name,
             )
@@ -1112,6 +1133,17 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             self._clear_registration_full_issue()
         return result
 
+    def _unit_changed_recently(self) -> bool:
+        """Whether the unit reported a change of its own within the last cycle.
+
+        updatedBy names the last successful writer and goes on naming it until
+        somebody else writes, so its value alone says nothing about when. What
+        matters here is that somebody is at the unit *now*.
+        """
+        return self._unit_change_seen_at is not None and (
+            datetime.now() - self._unit_change_seen_at < MIN_TIME_BETWEEN_UPDATES
+        )
+
     def _check_request_stopped_unit(self, was_running: bool) -> None:
         """Notice a unit that switches off because we asked it for readings.
 
@@ -1135,12 +1167,32 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         if not was_running or self._parser.carry_power_state:
             return
         if self._airco is None or self._airco.Operation:
+            self._stopped_on_request = 0
             return
-        if self._updated_by == UPDATED_BY_UNIT:
+        if self._updated_by != UPDATED_BY_HOST:
+            # Someone else stopped it: the unit itself ("aircon", which is what
+            # the IR remote looks like from here) or the manufacturer's cloud
+            # ("aws"). Only a locally paired writer can have been us.
             _LOGGER.debug(
-                "[%s] stopped during our operation-data request, but the unit "
-                "reports the change as its own - not treating it as ours",
+                "[%s] stopped during our operation-data request, but the last "
+                "writer reports as %s - not treating it as ours",
                 self.device_name,
+                self._updated_by,
+            )
+            self._stopped_on_request = 0
+            return
+        self._stopped_on_request += 1
+        if self._stopped_on_request < STOPPED_ON_REQUEST_BEFORE_CARRYING:
+            # Once is a coincidence worth surviving: "local" covers us and any
+            # app on the same network, so an app switching the unit off in the
+            # second our request lands looks exactly like this. The real fault
+            # repeats every cycle; a coincidence does not repeat twice running.
+            _LOGGER.debug(
+                "[%s] stopped during our operation-data request (%s of %s "
+                "before the request starts carrying the power state)",
+                self.device_name,
+                self._stopped_on_request,
+                STOPPED_ON_REQUEST_BEFORE_CARRYING,
             )
             return
         self._parser.carry_power_state = True

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -114,10 +114,15 @@ def _shorten_service_data_timing(monkeypatch, offset_ms: int = 5) -> None:
         coordinator_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5)
     )
     monkeypatch.setattr(
+        coordinator_module, "SERVICE_DATA_RETRY_DELAY", timedelta(milliseconds=5)
+    )
+    # The ceiling doubles as the starting value, so shrinking it is what makes
+    # the request fire inside a test.
+    monkeypatch.setattr(
         coordinator_module, "SERVICE_DATA_REQUEST_OFFSET", timedelta(milliseconds=offset_ms)
     )
     monkeypatch.setattr(
-        coordinator_module, "SERVICE_DATA_RETRY_DELAY", timedelta(milliseconds=5)
+        coordinator_module, "SERVICE_DATA_OFFSET_MIN", timedelta(milliseconds=1)
     )
 
 
@@ -1892,9 +1897,12 @@ async def test_service_data_that_never_arrived_stays_quiet_until_it_is_due(
 # --- a unit that stops when asked for readings (#329) ----------------------
 
 
-async def _run_service_data_request(device, monkeypatch):
+async def _run_service_data_request(device, monkeypatch, ceiling_ms: int = 1):
+    # The ceiling doubles as the starting value, so it has to stay small
+    # enough for the request to fire inside a test - and, where the
+    # adaptation itself is under test, large enough to leave room above.
     monkeypatch.setattr(
-        coordinator_module, "SERVICE_DATA_REQUEST_OFFSET", timedelta(milliseconds=1)
+        coordinator_module, "SERVICE_DATA_REQUEST_OFFSET", timedelta(milliseconds=ceiling_ms)
     )
     # Cycles run back to back here; the real spacing would swallow every
     # request after the first.
@@ -2018,47 +2026,99 @@ async def test_carrying_the_power_state_sets_the_set_bit_with_the_value(device):
     assert device._parser.status_request_to_byte(stat)[2] == 2
 
 
-async def test_a_carried_request_is_skipped_right_after_the_remote_was_used(
+async def test_the_request_moves_back_towards_the_poll_while_it_keeps_landing(
     device, monkeypatch
 ):
-    """Carrying the power state means asserting it, and the state is up to a
-    poll old. Switching a unit back on that its owner just switched off is a
-    worse failure than a missing reading.
+    """Half a cycle was a guess. Closer is better for everything except
+    crowding: what the request carries, and any judgement about who changed
+    the unit, is as old as the last poll.
     """
-    response = _stats_response(ON_COOL_PAYLOAD)
-    response["updatedBy"] = "aircon"
-    device._api.get_aircon_stats.return_value = response
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
-    device._parser.carry_power_state = True
-    set_airco = AsyncMock()
-    device.set_airco = set_airco
+    device._api.send_airco_command = AsyncMock(return_value=ON_COOL_PAYLOAD)
+    monkeypatch.setattr(
+        coordinator_module, "SERVICE_DATA_OFFSET_STEP", timedelta(milliseconds=1)
+    )
+    monkeypatch.setattr(
+        coordinator_module, "SERVICE_DATA_OFFSET_MIN", timedelta(milliseconds=1)
+    )
+    device._service_data_offset = timedelta(milliseconds=5)
 
-    await _run_service_data_request(device, monkeypatch)
+    for _ in range(coordinator_module.SERVICE_DATA_OFFSET_GOOD_CYCLES):
+        await _run_service_data_request(device, monkeypatch, ceiling_ms=20)
 
-    set_airco.assert_not_awaited()
+    assert device.service_data_offset == timedelta(milliseconds=4)
 
 
-async def test_the_skip_lets_go_once_the_remote_is_done(device, monkeypatch):
-    """updatedBy keeps naming the last writer, and after somebody uses the IR
-    remote nothing writes again - we stopped, and a poll does not count.
-
-    Testing the value rather than its recency therefore skipped every cycle
-    from the first press onwards, which reads as "the unit stays on now" while
-    the readings it was all about had quietly stopped arriving.
+async def test_a_refused_request_pushes_it_away_from_the_poll_again(
+    device, monkeypatch
+):
+    """A refusal is the module saying the request came too close to something
+    else, which is what the offset exists to prevent.
     """
-    response = _stats_response(ON_COOL_PAYLOAD)
-    response["updatedBy"] = "aircon"
-    device._api.get_aircon_stats.return_value = response
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
-    device._parser.carry_power_state = True
-    set_airco = AsyncMock()
-    device.set_airco = set_airco
+    device._service_data_offset = timedelta(milliseconds=1)
+    device._api.send_airco_command = AsyncMock(side_effect=WfRacCommandError("501"))
 
-    # A cycle later, with nobody having touched the unit since. Aged by hand
-    # rather than with a frozen clock: the request path sleeps, and a frozen
-    # clock never lets that sleep finish.
-    device._unit_change_seen_at -= coordinator_module.MIN_TIME_BETWEEN_UPDATES
+    await _run_service_data_request(device, monkeypatch, ceiling_ms=20)
+
+    assert device.service_data_offset == timedelta(milliseconds=2)
+
+
+async def test_the_offset_never_goes_below_the_floor_or_above_the_ceiling(
+    device, monkeypatch
+):
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
-    await _run_service_data_request(device, monkeypatch)
 
-    set_airco.assert_awaited()
+    device._api.send_airco_command = AsyncMock(return_value=ON_COOL_PAYLOAD)
+    monkeypatch.setattr(
+        coordinator_module, "SERVICE_DATA_OFFSET_MIN", timedelta(milliseconds=2)
+    )
+    monkeypatch.setattr(
+        coordinator_module, "SERVICE_DATA_OFFSET_STEP", timedelta(milliseconds=1)
+    )
+    device._service_data_offset = timedelta(milliseconds=2)
+    for _ in range(coordinator_module.SERVICE_DATA_OFFSET_GOOD_CYCLES * 2):
+        await _run_service_data_request(device, monkeypatch, ceiling_ms=20)
+    assert device.service_data_offset == timedelta(milliseconds=2)
+
+    device._service_data_offset = timedelta(milliseconds=20)
+    device._api.send_airco_command = AsyncMock(side_effect=WfRacCommandError("501"))
+    await _run_service_data_request(device, monkeypatch, ceiling_ms=20)
+    assert device.service_data_offset == timedelta(milliseconds=20)
+
+
+async def test_a_setting_that_changed_with_no_write_is_read_as_the_unit_itself(
+    device, caplog
+):
+    """Only a setAirconStat moves the write lock, so a setting that changed
+    while expires stood still was not changed over the network.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+
+    with caplog.at_level(logging.DEBUG):
+        await device.update()
+
+    assert "changed at the unit itself" in caplog.text
+    assert device.foreign_activity is False
+
+
+async def test_our_own_command_is_not_read_as_somebody_elses(device, caplog):
+    """The expectation moves with what the unit reports back to our own write,
+    or every command we send would come back as a foreign one.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device._api.send_airco_command = AsyncMock(return_value=OFF_PAYLOAD)
+    await device.set_airco({AirconCommands.Operation: False})
+
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
+    with caplog.at_level(logging.DEBUG):
+        await device.update()
+
+    assert "changed at the unit" not in caplog.text
+    assert device.foreign_activity is False

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -1958,22 +1958,25 @@ async def test_a_single_stop_during_our_request_is_not_enough(device, monkeypatc
     assert device._parser.carry_power_state is False
 
 
-async def test_a_stop_reported_as_the_clouds_is_not_blamed_on_us(device, monkeypatch):
-    """Only a locally paired writer can have been us; "aws" is the
-    manufacturer's cloud acting on the unit.
-    """
-    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
-    await device.update()
+async def test_a_unit_started_by_remote_is_still_detected(device, monkeypatch):
+    """The likeliest way to meet this fault is to switch the unit on at the
+    unit and watch it stop.
 
-    response = _stats_response(OFF_PAYLOAD)
-    response["updatedBy"] = "aws"
-    device._api.get_aircon_stats.return_value = response
+    updatedBy is only refreshed by a poll, so at the moment of the check it
+    names whoever wrote last *before* us - on a unit started by remote, the
+    remote. Filtering the check by it would have meant never detecting the
+    fault on exactly the units whose owners run into it.
+    """
+    running_by_remote = _stats_response(ON_COOL_PAYLOAD)
+    running_by_remote["updatedBy"] = "aircon"
+    device._api.get_aircon_stats.return_value = running_by_remote
     device._api.send_airco_command = AsyncMock(return_value=OFF_PAYLOAD)
-    for _ in range(3):
+
+    for _ in range(2):
         await device.update()
         await _run_service_data_request(device, monkeypatch)
 
-    assert device._parser.carry_power_state is False
+    assert device._parser.carry_power_state is True
 
 
 async def test_a_unit_switched_off_at_the_unit_is_not_blamed_on_us(

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -1896,6 +1896,11 @@ async def _run_service_data_request(device, monkeypatch):
     monkeypatch.setattr(
         coordinator_module, "SERVICE_DATA_REQUEST_OFFSET", timedelta(milliseconds=1)
     )
+    # Cycles run back to back here; the real spacing would swallow every
+    # request after the first.
+    monkeypatch.setattr(
+        coordinator_module, "SERVICE_DATA_MIN_SPACING", timedelta(0)
+    )
     monkeypatch.setattr(
         device, "async_contexts", lambda: {SERVICE_DATA_EEV_PULSES}
     )
@@ -1903,7 +1908,7 @@ async def _run_service_data_request(device, monkeypatch):
     await asyncio.sleep(0.05)
 
 
-async def test_a_unit_that_stops_on_our_request_gets_its_power_state_carried(
+async def test_a_unit_that_stops_on_our_request_twice_gets_its_power_state_carried(
     device, monkeypatch
 ):
     """The request carries no set-bits, so nothing should change - but one
@@ -1911,7 +1916,8 @@ async def test_a_unit_that_stops_on_our_request_gets_its_power_state_carried(
 
     Detected from the symptom rather than from firmType: the bridge MCU
     handles this frame identically across firmware branches, so the branch
-    would be the wrong thing to gate on.
+    would be the wrong thing to gate on. Twice, because the signal cannot
+    separate us from another client on the same network.
     """
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
@@ -1921,8 +1927,53 @@ async def test_a_unit_that_stops_on_our_request_gets_its_power_state_carried(
     # The unit answers our own request having switched itself off.
     device._api.send_airco_command = AsyncMock(return_value=OFF_PAYLOAD)
     await _run_service_data_request(device, monkeypatch)
+    assert device._parser.carry_power_state is False
 
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    await _run_service_data_request(device, monkeypatch)
     assert device._parser.carry_power_state is True
+
+
+async def test_a_single_stop_during_our_request_is_not_enough(device, monkeypatch):
+    """"local" is what the module reports for us and for any app on the same
+    network alike, so one occurrence can just as well be somebody switching
+    the unit off in the second our request lands. The real fault repeats.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device._api.send_airco_command = AsyncMock(return_value=OFF_PAYLOAD)
+    await _run_service_data_request(device, monkeypatch)
+
+    # A cycle in which the unit keeps running clears the count again.
+    device._api.send_airco_command = AsyncMock(return_value=ON_COOL_PAYLOAD)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    await _run_service_data_request(device, monkeypatch)
+
+    device._api.send_airco_command = AsyncMock(return_value=OFF_PAYLOAD)
+    await device.update()
+    await _run_service_data_request(device, monkeypatch)
+
+    assert device._parser.carry_power_state is False
+
+
+async def test_a_stop_reported_as_the_clouds_is_not_blamed_on_us(device, monkeypatch):
+    """Only a locally paired writer can have been us; "aws" is the
+    manufacturer's cloud acting on the unit.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+
+    response = _stats_response(OFF_PAYLOAD)
+    response["updatedBy"] = "aws"
+    device._api.get_aircon_stats.return_value = response
+    device._api.send_airco_command = AsyncMock(return_value=OFF_PAYLOAD)
+    for _ in range(3):
+        await device.update()
+        await _run_service_data_request(device, monkeypatch)
+
+    assert device._parser.carry_power_state is False
 
 
 async def test_a_unit_switched_off_at_the_unit_is_not_blamed_on_us(
@@ -1982,3 +2033,29 @@ async def test_a_carried_request_is_skipped_right_after_the_remote_was_used(
     await _run_service_data_request(device, monkeypatch)
 
     set_airco.assert_not_awaited()
+
+
+async def test_the_skip_lets_go_once_the_remote_is_done(device, monkeypatch):
+    """updatedBy keeps naming the last writer, and after somebody uses the IR
+    remote nothing writes again - we stopped, and a poll does not count.
+
+    Testing the value rather than its recency therefore skipped every cycle
+    from the first press onwards, which reads as "the unit stays on now" while
+    the readings it was all about had quietly stopped arriving.
+    """
+    response = _stats_response(ON_COOL_PAYLOAD)
+    response["updatedBy"] = "aircon"
+    device._api.get_aircon_stats.return_value = response
+    await device.update()
+    device._parser.carry_power_state = True
+    set_airco = AsyncMock()
+    device.set_airco = set_airco
+
+    # A cycle later, with nobody having touched the unit since. Aged by hand
+    # rather than with a frozen clock: the request path sleeps, and a frozen
+    # clock never lets that sleep finish.
+    device._unit_change_seen_at -= coordinator_module.MIN_TIME_BETWEEN_UPDATES
+    await device.update()
+    await _run_service_data_request(device, monkeypatch)
+
+    set_airco.assert_awaited()


### PR DESCRIPTION
Two faults in the guards that shipped with #339, both found by walking the case a tester will actually hit: turn the unit on with the IR remote, watch it stop, turn it on again.

### The skip never let go

A carried operation-data request was skipped whenever `updatedBy` reported the unit itself as the last writer. But `updatedBy` names the last writer and goes on naming it until somebody else writes — and once the request is being skipped, nobody does, because a poll is a read.

So the first press of the remote stopped the request **permanently**. The unit does stay on after that, which is exactly what makes it dangerous: it reads as the fix working, while the operation-data sensors the whole thing is about have quietly stopped receiving anything, and a configured indoor temperature source never reaches the unit again.

It was also guarding the wrong moment. The risk is a remote command *between* our poll and our request — and at that poll `updatedBy` does not say `aircon` yet. The old test therefore caught the harmless case (remote used before the poll, already reflected in the state we hold) and missed the one it was written for.

It now skips on the **transition** to `aircon` and lets go one cycle later. That is as close to "somebody is at the unit right now" as this signal gets; it does not close the window between poll and request, and nothing observable does.

### One stop was enough to switch over

`local` is what the module reports for us **and** for any app on the same network — the value cannot separate them. A single stop inside our request can just as well be someone switching the unit off in that second with the app, and one coincidence flipped the device over permanently.

Detection now needs two consecutive stops. The real fault repeats every cycle; a coincidence does not repeat twice running. It costs one more shutdown on an affected unit, which is worth it. A cycle in which the unit keeps running clears the count.

A stop reported as the cloud's (`aws`) is not ours either and no longer counts at all.

---

285 tests green, coverage 96 %, `mypy` clean. Four new tests, including the IR sequence above.
