### PR TITLE
Keep an operation-data request from outliving or overruling the poll

### DIFF
--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -469,20 +469,35 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
 
         The operation-data task needs the same, and more urgently: it spends
         most of its life asleep waiting out its offset (up to
-        SERVICE_DATA_OFFSET_MAX), so an unload almost always catches one
+        SERVICE_DATA_REQUEST_OFFSET), so an unload almost always catches one
         mid-sleep. hass cancels background tasks when *hass* stops, which a
         config-entry unload is not - and on a reload the request would go out
         from the old entry while the new one is already polling, through a
         second Repository whose request spacing knows nothing about the
         first. Two connections at once is what the module will not take.
+
+        Whatever either task was doing, its outcome stops mattering here, and
+        an unload that raises leaves entities loaded on an entry that no
+        longer updates. So a failure is logged and swallowed rather than
+        allowed out: a flush reports its own errors to the caller that queued
+        it (see _async_flush_queued_command), and the operation-data request
+        is optional by construction.
         """
         self._release_external_temperature_carrier()
         for task in (self._consolidation_task, self._service_data_task):
             if task is None:
                 continue
             task.cancel()
-            with suppress(asyncio.CancelledError):
+            try:
                 await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.debug(
+                    "Task cancelled at shutdown for [%s] had already failed",
+                    self.device_name,
+                    exc_info=True,
+                )
         self._consolidation_task = None
         self._service_data_task = None
         await super().async_shutdown()

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -360,6 +360,12 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         # set by our own successful writes and consumed by the next poll, so a
         # rise in `expires` can be attributed to us or to someone else.
         self._wrote_since_last_poll = False
+        # Narrower than the flag above and consumed by the same poll: only a
+        # frame that could actually move a setting sets this one. Our own
+        # operation-data request moves `expires` every cycle without carrying
+        # a single set-bit, and reading that as "a write happened" is what
+        # would leave every change made at the unit unattributable.
+        self._wrote_settings_since_last_poll = False
         # None until the adaptation has moved it, so the ceiling stays a
         # single source of truth.
         self._service_data_offset: timedelta | None = None
@@ -460,13 +466,25 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         DataUpdateCoordinator, so it has to be cancelled here too: a command
         queued moments before the entry unloads would otherwise still be sent
         afterwards and publish data to entities that are already gone.
+
+        The operation-data task needs the same, and more urgently: it spends
+        most of its life asleep waiting out its offset (up to
+        SERVICE_DATA_OFFSET_MAX), so an unload almost always catches one
+        mid-sleep. hass cancels background tasks when *hass* stops, which a
+        config-entry unload is not - and on a reload the request would go out
+        from the old entry while the new one is already polling, through a
+        second Repository whose request spacing knows nothing about the
+        first. Two connections at once is what the module will not take.
         """
         self._release_external_temperature_carrier()
-        if self._consolidation_task is not None:
-            self._consolidation_task.cancel()
+        for task in (self._consolidation_task, self._service_data_task):
+            if task is None:
+                continue
+            task.cancel()
             with suppress(asyncio.CancelledError):
-                await self._consolidation_task
-            self._consolidation_task = None
+                await task
+        self._consolidation_task = None
+        self._service_data_task = None
         await super().async_shutdown()
 
     def _release_external_temperature_carrier(self) -> None:
@@ -776,6 +794,8 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         """
         wrote = self._wrote_since_last_poll
         self._wrote_since_last_poll = False
+        wrote_settings = self._wrote_settings_since_last_poll
+        self._wrote_settings_since_last_poll = False
 
         expires_moved = (
             isinstance(expires, int)
@@ -784,7 +804,14 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         )
         if expires_moved and not wrote:
             self._note_foreign_write(f"expires moved {self._account_expires} -> {expires}")
-        self._note_unexpected_settings(expires_moved or wrote)
+        # Not `expires_moved or wrote`: our own operation-data request moves
+        # `expires` in most cycles and carries no set-bits, so that reading
+        # would call every change unattributable and never name the one thing
+        # this detector exists for. What is asked here is narrower - could a
+        # write, ours or anyone's, have moved a setting in this gap?
+        self._note_unexpected_settings(
+            wrote_settings or (expires_moved and not wrote)
+        )
         self._report_foreign_activity()
 
     def _note_foreign_write(self, evidence: str) -> None:
@@ -838,6 +865,14 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         operation-data request carries the power state back to a unit that
         needs it, a change we undo inside that same gap leaves the value
         exactly where we expect it.
+
+        The someone_wrote argument asks whether a set-bit could have been sent
+        in this gap, not whether any frame was: our own operation-data request
+        moves `expires` every cycle while changing nothing, and counting it
+        would leave nothing to attribute. The price is one wrong label rather
+        than one missing message - a foreign client writing in the same gap as
+        one of our requests reads as the unit itself here, because the module
+        gives us no second record of the write to tell them apart.
 
         Not every one of these is somebody's doing: the unit resets its own
         setpoint after a power cycle, and Vacant and self-clean move settings
@@ -1034,7 +1069,11 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         for attempt in (1, 2):
             try:
                 await self.set_airco(
-                    params, log_failure=False, timestamp_offset=timestamp_offset
+                    params,
+                    log_failure=False,
+                    timestamp_offset=timestamp_offset,
+                    is_status_request=True,
+                    retry_when_locked=False,
                 )
                 if attempt > 1:
                     _LOGGER.debug("Service data request succeeded on retry")
@@ -1053,7 +1092,9 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 # Someone else may hold the write lock. Unlike a user command
                 # this is not worth contesting: give the cycle up immediately
                 # rather than retrying into a lock we would only be renewing
-                # for ourselves if we won it.
+                # for ourselves if we won it. set_airco()'s own wait-and-retry
+                # is off for this call (retry_when_locked=False), or the
+                # refusal would arrive here already contested.
                 _LOGGER.debug(
                     "Service data request declined for [%s], skipping this "
                     "cycle: %s",
@@ -1345,12 +1386,26 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         *,
         log_failure: bool = True,
         timestamp_offset: int = 0,
+        is_status_request: bool = False,
+        retry_when_locked: bool = True,
     ) -> None:
         """Method to send airco command.
 
         log_failure=False leaves the reporting to the caller, for requests that
         have their own retry and a quieter failure story than a user command
         that never reached the unit - see _async_request_service_data().
+
+        is_status_request marks a frame that asks for readings instead of
+        changing anything: its block carries no set-bits (see
+        RacParser.status_request_to_byte), so the settings it echoes back are
+        the unit's own and claiming them as our expectation would hide
+        whatever the IR remote did while the request was in flight.
+
+        retry_when_locked=False hands the refusal straight back to the caller
+        instead of waiting the foreign write lock out below. For an optional
+        read that is the whole answer - the caller skips the cycle - and the
+        wait itself is the harm: it runs inside _send_lock, where a real user
+        command would be stuck behind it for up to WRITE_LOCK_MAX_WAIT.
 
         timestamp_offset shifts the `timestamp` this request stamps, and so the
         write lock it takes (deadline is timestamp + 60, the module has no RTC).
@@ -1408,6 +1463,8 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                     # retry, placed where the lock lapses rather than at a
                     # guessed interval - a retry that lands inside the same
                     # lock is a request spent on a refusal that was certain.
+                    if not retry_when_locked:
+                        raise
                     await asyncio.sleep(await self._async_write_lock_delay())
                     response = await self._api.send_airco_command(
                         self._airco_id, command, timestamp_offset=timestamp_offset
@@ -1422,8 +1479,17 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                         self._airco_id, command, timestamp_offset=timestamp_offset
                     )
                 # Only a successful write moves the module's `expires`, so
-                # only a successful write may claim the next rise in it.
+                # only a successful write may claim the next rise in it. A
+                # status request moves it too - it is a setAirconStat like any
+                # other - which is why the narrower flag below is a separate
+                # one and not this same value read twice.
                 self._wrote_since_last_poll = True
+                if not is_status_request or self._parser.carry_power_state:
+                    # A status request's block carries no set-bits, so nothing
+                    # in it can explain a setting that moved - unless this is
+                    # one of the units we carry the power state for (#329),
+                    # where the frame really does write Operation.
+                    self._wrote_settings_since_last_poll = True
                 new_airco = self._parser.translate_bytes(response)
                 self._carry_forward_home_leave_mode(new_airco)
                 self._carry_forward_service_data(new_airco)
@@ -1431,7 +1497,12 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 # Our own write is not a foreign one: move the expectation to
                 # what the unit reports back, or the next poll would read this
                 # command as somebody else's (see _note_unexpected_settings).
-                self._expected_settings = self._settings_snapshot()
+                # Not for a status request: it changes nothing, so its response
+                # is a reading of whatever the unit is doing now - including a
+                # change made at the unit since the poll, which taking it as
+                # our expectation would swallow whole.
+                if not is_status_request:
+                    self._expected_settings = self._settings_snapshot()
                 # After the write, and only for what the frame really carried:
                 # a command sent while the unit is off writes the sentinel, not
                 # the override.
@@ -1509,7 +1580,10 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         setpoint change - would go out in that same block without its
         set-bit and be silently ignored by the unit.
         """
-        await self.set_airco({AirconCommands.HomeLeaveModeStatusRequest: True})
+        await self.set_airco(
+            {AirconCommands.HomeLeaveModeStatusRequest: True},
+            is_status_request=True,
+        )
 
     async def async_set_home_leave_mode(
         self, cooling: HomeLeaveModeSetting, heating: HomeLeaveModeSetting

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -72,6 +72,7 @@ from ..unit.live_captures import LIVE_CAPTURES
 
 OFF_PAYLOAD, _ = LIVE_CAPTURES["off"]
 ON_COOL_PAYLOAD, _ = LIVE_CAPTURES["on_cool"]
+ON_HEAT_PAYLOAD, _ = LIVE_CAPTURES["on_heat"]
 
 
 def _stats_response(payload: str) -> dict:
@@ -1049,6 +1050,8 @@ async def test_service_data_request_uses_active_segment_codes(device, monkeypatc
         timestamp_offset=-round(
             coordinator_module.SERVICE_DATA_STAMP_BACKDATE.total_seconds()
         ),
+        is_status_request=True,
+        retry_when_locked=False,
     )
 
 
@@ -1080,6 +1083,8 @@ async def test_raw_service_data_sensor_requests_its_segment_code(device, monkeyp
         timestamp_offset=-round(
             coordinator_module.SERVICE_DATA_STAMP_BACKDATE.total_seconds()
         ),
+        is_status_request=True,
+        retry_when_locked=False,
     )
 
 
@@ -1369,6 +1374,34 @@ async def test_service_data_request_gives_up_immediately_when_refused_as_a_write
     set_airco.assert_awaited_once()
 
 
+async def test_a_refused_service_data_request_is_not_retried_inside_set_airco(
+    device, monkeypatch
+):
+    """The test above mocks set_airco() away, so it cannot see that set_airco()
+    answers a refusal with a wait-and-retry of its own - which for this request
+    is the very contest it is trying to avoid, and blocks _send_lock (and with
+    it any user command) for as long as the foreign lock runs.
+    """
+    _shorten_service_data_timing(monkeypatch)
+    _activate_service_data_contexts(device, monkeypatch)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device._api.send_airco_command = AsyncMock(
+        side_effect=WfRacWriteRefusedError("result 1")
+    )
+
+    device._maybe_request_service_data()
+    await asyncio.sleep(0)
+    task = device._service_data_task
+    assert task is not None
+    # The wait matters as much as the second send: it happens inside
+    # _send_lock, so a request that sits it out holds every user command up
+    # behind it. A task still running here is a task in that wait.
+    await asyncio.wait_for(task, 1)
+
+    assert device._api.send_airco_command.await_count == 1
+
+
 async def test_set_airco_waits_and_retries_once_when_the_write_lock_is_held(
     device, monkeypatch
 ):
@@ -1401,12 +1434,45 @@ async def test_set_airco_waits_and_retries_once_when_the_write_lock_is_held(
 
 async def test_service_data_request_does_not_overlap_an_active_request(device, monkeypatch):
     _activate_service_data_contexts(device, monkeypatch)
-    device._service_data_task = MagicMock()
-    device._service_data_task.done.return_value = False
+
+    async def _still_asleep() -> None:
+        await asyncio.sleep(10)
+
+    # A real task rather than a stand-in: the fixture's teardown shuts the
+    # coordinator down, and async_shutdown() now cancels and awaits this
+    # attribute, which a MagicMock cannot answer.
+    device._service_data_task = asyncio.create_task(_still_asleep())
 
     device._maybe_request_service_data()
 
     assert device._last_service_data_request is None
+
+
+async def test_shutdown_cancels_a_request_still_waiting_out_its_offset(
+    device, monkeypatch
+):
+    """The request sleeps out its offset for most of its life, so an unload
+    lands in that sleep more often than not. hass only cancels background
+    tasks when hass itself stops - on a config-entry reload the request would
+    go out afterwards, from a Repository whose spacing knows nothing about the
+    one the new entry is already polling through.
+    """
+    _activate_service_data_contexts(device, monkeypatch)
+    monkeypatch.setattr(
+        coordinator_module, "SERVICE_DATA_REQUEST_OFFSET", timedelta(seconds=30)
+    )
+    device.set_airco = set_airco = AsyncMock()
+
+    device._maybe_request_service_data()
+    await asyncio.sleep(0)
+    task = device._service_data_task
+    assert task is not None and not task.done()
+
+    await device.async_shutdown()
+
+    assert task.cancelled()
+    set_airco.assert_not_awaited()
+    assert device._service_data_task is None
 
 
 async def test_add_account_returns_none_on_api_error(device):
@@ -2100,6 +2166,31 @@ async def test_a_setting_that_changed_with_no_write_is_read_as_the_unit_itself(
     await device.update()
     device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
 
+    with caplog.at_level(logging.DEBUG):
+        await device.update()
+
+    assert "changed at the unit itself" in caplog.text
+    assert device.foreign_activity is False
+
+
+async def test_a_change_at_the_unit_survives_the_operation_data_request(
+    device, monkeypatch, caplog
+):
+    """The request changes nothing, so what comes back is a reading - and in
+    the 5-30s it sits behind the poll, that reading can already carry an IR
+    command. Claiming it as our expectation would leave the next poll with
+    nothing to compare and the change unreported.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+
+    # Someone picks up the remote between the poll and the request: mode and
+    # setpoint are already the new ones when the request's response arrives.
+    device._api.send_airco_command = AsyncMock(return_value=ON_HEAT_PAYLOAD)
+    await _run_service_data_request(device, monkeypatch)
+    device._api.send_airco_command.assert_awaited_once()
+
+    device._api.get_aircon_stats.return_value = _stats_response(ON_HEAT_PAYLOAD)
     with caplog.at_level(logging.DEBUG):
         await device.update()
 

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -1475,6 +1475,23 @@ async def test_shutdown_cancels_a_request_still_waiting_out_its_offset(
     assert device._service_data_task is None
 
 
+async def test_shutdown_does_not_fail_on_a_task_that_had_already_raised(device):
+    """An unload that raises leaves the entities loaded on an entry that will
+    never update again, so a leftover failure is logged here, not propagated.
+    """
+
+    async def _boom() -> None:
+        raise RuntimeError("nothing retrieved this")
+
+    task = asyncio.create_task(_boom())
+    await asyncio.sleep(0)
+    device._service_data_task = task
+
+    await device.async_shutdown()
+
+    assert device._service_data_task is None
+
+
 async def test_add_account_returns_none_on_api_error(device):
     device._api.update_account_info.side_effect = WfRacError("failed")
 


### PR DESCRIPTION
Three defects found reviewing `2026.9.9-beta2` before cutting the final, all in the operation-data request - the optional second request per cycle that asks for the extension segments and sits 5-30s behind the poll.

### The request outlives the entry

It sleeps out its offset in a background task that nothing cancels. hass cancels background tasks when *hass* stops, which a config entry unload is not, so an unload lands in that sleep more often than not and the request goes out afterwards. On a reload that means a second `Repository`, whose request spacing knows nothing about the one the new entry is already polling through - and the module takes one connection at a time. `async_shutdown()` now cancels it alongside the consolidation task it already handled.

Cancelling means awaiting, and awaiting a task that already failed re-raises its exception out of the unload, leaving the entry half loaded on a coordinator that no longer polls. Both tasks report their failures elsewhere - a queued command to whoever queued it, and this request is optional by construction - so a leftover failure is logged here rather than propagated.

### Its refusal never reached the code that handles it

`set_airco()` answers a refused write by waiting the foreign write lock out and sending again. That is right for a user command; for this request it is exactly the contest `_async_request_service_data()` documents itself as avoiding, and the wait runs inside `_send_lock`, so a real user command is stuck behind an optional sensor read for as long as the foreign lock lasts. `retry_when_locked=False` hands the refusal straight back, and the cycle is skipped as intended.

The existing test could not catch this: it mocks `set_airco()` away, so the retry inside it never ran.

### Its response was taken as our own expectation

The request changes nothing - its block carries no set-bits - so what comes back is a reading, and in the 5-30s it sits behind the poll that reading can already carry an IR command. Storing it as `_expected_settings` left the next poll with nothing to compare, so a change made at the unit was never reported at all.

Its `expires` does move, though, so the poll now separates "we sent something" from "we sent something that could move a setting". Counting the request as a write would make every change unattributable instead, since it moves `expires` in nearly every cycle. What that leaves is one wrong label rather than one missing message: a foreign client writing in the same gap as one of our requests now reads as the unit itself, because the module offers no second record to tell them apart. Noted in the docstring.

The home/leave status request had the same expectation bug and gets the same flag; it keeps its retry, being user-initiated.

### Verification

292 tests, mypy clean, coverage 96%. Each fix has a test that fails without it - checked by reverting the line in question one at a time.
