### PR TITLE
Say what a manual run found, and name the sensor it asks for

### DIFF
--- a/blueprints/automation/smdev0925/mhi-multi-split-mode-lockout.yaml
+++ b/blueprints/automation/smdev0925/mhi-multi-split-mode-lockout.yaml
@@ -132,8 +132,10 @@ blueprint:
                 - integration: mitsubishi_wf_rac
                   domain: climate
         judge_sensors:
-          name: Cool/Heat Status sensors
-          description: Disabled by default — enable one per unit first.
+          name: Cool Hot Judge sensors
+          description: >-
+            Disabled by default — enable one per unit first. It is the sensor
+            called "Cool Hot Judge" on each indoor unit's device page.
           selector:
             entity:
               multiple: true
@@ -142,7 +144,7 @@ blueprint:
                   domain: sensor
         demand_sensors:
           name: Compressor Demand sensors
-          description: Disabled by default — enable one per unit first.
+          description: Enabled by default — one per unit, nothing to switch on.
           selector:
             entity:
               multiple: true
@@ -327,6 +329,29 @@ actions:
   # cooldown above throttles it: at most one line per cooldown while the lock
   # persists, rather than one every two minutes.
   - choose:
+      # Reachable only when the automation is triggered by hand: a manual run
+      # skips the conditions above, and without this it would fall through to
+      # the stand-down with nothing to stand down.
+      - alias: Nothing to resolve — reached only on a manual run
+        conditions:
+          - condition: template
+            value_template: >-
+              {{ not conflict or in_use | count > 0
+                 or last_served not in ['cooling', 'heating']
+                 or standdown | count == 0 }}
+        sequence:
+          - action: logbook.log
+            data:
+              name: MHI Mode Lockout
+              message: >-
+                Manual run ignored — nothing to resolve.
+                {%- if not conflict %} The heads do not disagree.
+                {%- elif in_use | count > 0 %}
+                {{ in_use | map(attribute='entity') | map('replace', 'climate.', '') | join(', ') }}
+                {{ 'is' if in_use | count == 1 else 'are' }} still running, so
+                the mode is not free.
+                {%- else %} There is nothing to stand down.{% endif %}
+
       - alias: Blocked by a head someone set to an explicit mode
         conditions:
           - condition: template

--- a/tests/integration/test_blueprints.py
+++ b/tests/integration/test_blueprints.py
@@ -123,3 +123,71 @@ async def test_the_lockout_blueprint_pairs_each_head_by_device(
     # reads as calling until the grace has passed, so nothing rotates on a
     # half-populated state machine.
     assert all(row["calling"] for row in fleet)
+
+
+def _render_variables(hass: HomeAssistant, seed: dict) -> dict:
+    """Evaluate the blueprint's variables block in order, the way an automation
+    run does, so a template can be exercised with the ones it depends on
+    already filled in.
+    """
+    variables = dict(seed)
+    for name, template in _load(LOCKOUT).data["variables"].items():
+        if name in variables:
+            continue
+        variables[name] = Template(template, hass).async_render(variables)
+    return variables
+
+
+async def test_a_manual_run_with_nothing_to_resolve_says_so(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Triggering the automation by hand skips its conditions, so the guard
+    branch is the only thing between a manual run and a stand-down with nothing
+    to stand down. Both heads vote the same way here: no lockout exists.
+    """
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    climates, judges, demands = [], [], []
+    for room in HEADS:
+        device = device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id, identifiers={(DOMAIN, room)}
+        )
+        for domain, suffix, state in (
+            ("climate", "thermostat", "auto"),
+            ("sensor", "cool_hot_judge", "cooling"),
+            ("binary_sensor", "compressor_demand", "off"),
+        ):
+            registered = entity_registry.async_get_or_create(
+                domain,
+                DOMAIN,
+                f"{room}-{suffix}",
+                device_id=device.id,
+                suggested_object_id=f"{room}_{suffix}",
+            )
+            hass.states.async_set(registered.entity_id, state)
+            {"climate": climates, "sensor": judges, "binary_sensor": demands}[
+                domain
+            ].append(registered.entity_id)
+
+    variables = _render_variables(
+        hass,
+        {
+            "climate_entities": climates,
+            "judge_sensors": judges,
+            "demand_sensors": demands,
+            "release_grace_minutes": 0,
+            "cooldown_minutes": 30,
+            "relax_delay": "00:04:00",
+        },
+    )
+    assert variables["conflict"] is False
+
+    guard = _load(LOCKOUT).data["actions"][0]["choose"][0]
+    condition = guard["conditions"][0]["value_template"]
+    assert Template(condition, hass).async_render(variables) is True
+
+    message = guard["sequence"][0]["data"]["message"]
+    assert "do not disagree" in Template(message, hass).async_render(variables)


### PR DESCRIPTION
Three fixes to the multi-split lockout blueprint, all raised by @smdev0925 in #328 after running it.

**A manual run had nothing to say and did something odd.** Triggering an automation by hand skips its conditions, so a manual run fell through to the stand-down branch — logging that a side was standing down, then calling `climate.set_hvac_mode` on an empty entity list. A guard branch now sits first in the `choose:` and catches what the conditions would have caught: the heads do not disagree, somebody is still running, or there is nothing to stand down. It says which. The cooldown is deliberately left out — a manual run is someone asking for it now.

**The sensor picker asked for the wrong name.** It said "Cool/Heat Status sensors"; the entity is called **Cool Hot Judge** in Home Assistant, which is what someone filling the field in is actually looking at.

**And the demand picker was wrong about its default.** "Disabled by default — enable one per unit first" is true of Cool Hot Judge but not of Compressor Demand, which is enabled from the start (`CompressorBinarySensor` sets no `entity_registry_enabled_default`). As written it sent people hunting for a sensor they already had.

Covered by a test that renders the blueprint's variables in order and then the guard's own condition and message, so a broken template shows up here rather than for whoever imports it.