### PR TITLE
Send a changed overshoot on the next carrier frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ without one there is no room temperature for them to correct.
 | Target Temp. Offset | -5..5 °C | Calibrates the *setpoint sent to the unit* - see "Target Temp. Offset sign convention" below. Applies to every `hvac_mode` unless overridden by the two options below. |
 | Target Temp. Offset (Cooling) | -5..5 °C, unset by default | Overrides Target Temp. Offset for `cool` and `dry` mode. Leave unset to keep using Target Temp. Offset for those modes too. |
 | Target Temp. Offset (Heating) | -5..5 °C, unset by default | Overrides Target Temp. Offset for `heat` mode. Leave unset to keep using Target Temp. Offset for `heat` too. |
-| Cooling overshoot | -3..3 °C | How far past your setting the room actually goes before the unit stops. Set 22 °C, room settles at 21 °C: enter 1. Only shown, and only has an effect, while an Indoor temperature source is configured. |
+| Cooling overshoot | -3..3 °C, in steps of 0.25 | How far past your setting the room actually goes before the unit stops. Set 22 °C, room settles at 21 °C: enter 1. Fractions are the point of this field, but only quarter degrees survive: the room temperature the unit is fed is carried in 0.25 °C steps, so 1.1 is rounded to 1 on the wire. Only shown, and only has an effect, while an Indoor temperature source is configured. |
 | Heating overshoot | -3..3 °C | The same for heating: how far above your setting the room ends up. Positive in both cases. |
 | Check for firmware updates | on/off, off by default | Creates the Firmware Update entity (see Update above) and periodically checks the manufacturer's `getFirmware` endpoint. The only outbound internet call this integration makes - leave off to stay fully local. |
 

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
     CONF_PORT,
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import section
@@ -507,8 +508,21 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlowWithReload):
         # so far: a unit that stops short of the setting instead needs the
         # correction the other way, and there is no reason to make that
         # impossible before anyone has looked.
-        overshoot_validator = vol.All(
-            vol.Coerce(float), vol.Range(min=-OVERSHOOT_MAX, max=OVERSHOOT_MAX)
+        # A number box rather than a bare float: a plain float field leaves the
+        # step to the browser, which is a whole degree by default, and this
+        # correction is only ever read in fractions of one. 0.25 is the step
+        # because that is what the wire carries - the room temperature byte is
+        # round(T * 4) + 61 - so a finer figure is rounded away in the encoder
+        # and 0.1 quietly does nothing at all. Off-grid values that are already
+        # stored still load: the selector holds the range, not the step.
+        overshoot_validator = selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=-OVERSHOOT_MAX,
+                max=OVERSHOOT_MAX,
+                step=0.25,
+                mode=selector.NumberSelectorMode.BOX,
+                unit_of_measurement=UnitOfTemperature.CELSIUS,
+            )
         )
 
         source_fields: dict[Any, Any] = {

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -526,6 +526,18 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 self._external_temperature_carrier = self.async_add_listener(
                     lambda: None, context=SERVICE_DATA_INDOOR_COIL_RAW
                 )
+                # Ask for the carrier frame now rather than waiting for a poll
+                # to schedule one. Only a poll calls this otherwise, and the
+                # poll that runs during setup happens before the entities
+                # exist - so nothing is subscribed for it and the request is
+                # skipped. An entry reload is exactly that path, and saving
+                # the options reloads the entry (OptionsFlowWithReload): a
+                # changed overshoot would sit unsent for a full poll interval
+                # on top of the offset, until some other frame happened to
+                # carry it. The spacing and in-flight guards inside still
+                # apply, so a source flapping in and out cannot turn this into
+                # a second request per cycle.
+                self._maybe_request_service_data()
             return
         self._release_external_temperature_carrier()
 

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -450,6 +450,32 @@ async def test_set_airco_explicitly_clears_external_temperature_override(device)
     assert raw[5] == 0xFF
 
 
+async def test_arming_an_override_asks_for_the_frame_that_carries_it(device, monkeypatch):
+    """The override has no frame of its own, and only a poll schedules the one
+    it rides on - while the poll during setup runs before any entity exists to
+    arm it. Saving the options reloads the entry, so without this a changed
+    overshoot would wait a whole poll interval to reach the unit.
+    """
+    _shorten_service_data_timing(monkeypatch)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device.set_airco = set_airco = AsyncMock()
+
+    device.set_external_temperature_override(18.7)
+    await asyncio.sleep(0.05)
+
+    set_airco.assert_awaited_once()
+    assert set_airco.await_args.kwargs["is_status_request"] is True
+
+    # A source reporting again is not a new arming: the carrier is already
+    # subscribed, so the new value rides the cadence like every other one.
+    set_airco.reset_mock()
+    device.set_external_temperature_override(19.0)
+    await asyncio.sleep(0.05)
+
+    set_airco.assert_not_awaited()
+
+
 async def test_external_temperature_applied_reads_the_echoed_byte(device):
     # The unit echoes an injected value back in byte 5 unchanged, so the byte
     # it reports matching one a recent frame carried is the whole question.


### PR DESCRIPTION
Two faults in the cooling and heating overshoot, reported against an
external temperature source: a changed value does not reach the unit until
something else sends a frame, and one decimal place appears to do nothing.

## The delay

The overshoot corrects the room temperature that goes to the unit. The
integration applies the correction when it builds a frame. Byte 5 has no
set-bit of its own, so the value can travel only on a frame that goes out
for a different reason. That frame is the operation-data request, and only
a poll asks for one.

A save in the options dialog reloads the entry, because the options flow is
an `OptionsFlowWithReload`. The poll during setup runs before the platforms
load. No entity subscribes to the request in that cycle, so
`_maybe_request_service_data()` skips it. The first frame that can carry the
new correction goes out one poll interval later, plus the request offset. A
change of mode sends a command immediately, and this is why a mode change
looks instant while the overshoot does not.

The carrier now asks for the frame when it subscribes. Both guards inside
`_maybe_request_service_data()` stay in front of the request: the in-flight
check and the minimum spacing. A source that drops out and comes back
therefore cannot cause a second request in the same cycle. The stamp moves
a request earlier in the cycle; it does not remove one.

## The decimal place

The overshoot field was a plain float in the schema. voluptuous-serialize
turns that into `{"type": "float", "valueMin": ..., "valueMax": ...}`, and
the field carries no step. The field is a number box now, and its step is
0.25 degC.

0.25 degC is the resolution of the wire. Byte 5 carries the room
temperature as `round(T * 4) + 61`. The integration does not refuse a
smaller correction; the encoder rounds it away. On a real unit at
192.168.0.67, with a room of 20.75 degC, an overshoot of 1.0 and an
overshoot of 1.1 both produce byte 140.

A stored value that is off the grid still loads.
`NumberSelector.__call__()` validates `min` and `max` only, and the source
states that user input is not rounded. The README now gives this limit.

## Testing

The gaps are wide, and they are in the commit message as well.

- No test ran. `requirements-dev.txt` needs Python 3.14. The machine has
  Python 3.12 and no `python3-venv` package. The new test in
  `tests/integration/test_coordinator.py` must pass in CI.
- No Home Assistant instance was available. To confirm the number box, I
  read voluptuous-serialize, `ha-selector-number` and
  `homeassistant/helpers/selector.py`. I did not see the field render.
- I read the state of a live unit and confirmed the arithmetic against its
  own values. I did not write to the unit. The new frame timing is
  therefore not measured on hardware.
- A full development environment for this project does not exist yet.

## One finding that is not fixed here

It is upstream, in pywfrac. For a status request while the unit is off or
in fan-only, `status_request_to_byte()` leaves byte 5 at `0xFF`, but
`external_temperature_raw_in_frame()` returns the encoded byte.
`set_airco()` records the second value as written, so
`external_temperature_applied` can report true for a byte that never went
out. Its own docstring states that this cannot happen in those modes.
