### PR TITLE
Follow up the overshoot fix in the docs and the rest of the form

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,8 +304,8 @@ without one there is no room temperature for them to correct.
 | Target Temp. Offset | -5..5 °C | Calibrates the *setpoint sent to the unit* - see "Target Temp. Offset sign convention" below. Applies to every `hvac_mode` unless overridden by the two options below. |
 | Target Temp. Offset (Cooling) | -5..5 °C, unset by default | Overrides Target Temp. Offset for `cool` and `dry` mode. Leave unset to keep using Target Temp. Offset for those modes too. |
 | Target Temp. Offset (Heating) | -5..5 °C, unset by default | Overrides Target Temp. Offset for `heat` mode. Leave unset to keep using Target Temp. Offset for `heat` too. |
-| Cooling overshoot | -3..3 °C, in steps of 0.25 | How far past your setting the room actually goes before the unit stops. Set 22 °C, room settles at 21 °C: enter 1. Fractions are the point of this field, but only quarter degrees survive: the room temperature the unit is fed is carried in 0.25 °C steps, so 1.1 is rounded to 1 on the wire. Only shown, and only has an effect, while an Indoor temperature source is configured. |
-| Heating overshoot | -3..3 °C | The same for heating: how far above your setting the room ends up. Positive in both cases. |
+| Cooling overshoot | -3..3 °C, in steps of 0.25 | How far past your setting the room actually goes before the unit stops. Set 22 °C, room settles at 21 °C: enter 1. Quarter degrees are the finest step that reaches the unit - the room temperature it is fed is carried in 0.25 °C steps. Only shown, and only has an effect, while an Indoor temperature source is configured. |
+| Heating overshoot | -3..3 °C, in steps of 0.25 | The same for heating: how far above your setting the room ends up. Positive in both cases. |
 | Check for firmware updates | on/off, off by default | Creates the Firmware Update entity (see Update above) and periodically checks the manufacturer's `getFirmware` endpoint. The only outbound internet call this integration makes - leave off to stay fully local. |
 
 ### Target Temp. Offset sign convention

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -503,27 +503,43 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlowWithReload):
             return self.async_create_entry(title="", data=data)
 
         options = self.config_entry.options
-        offset_range_validator = vol.All(vol.Coerce(float), vol.Range(min=-5.0, max=5.0))
+
+        def degrees(limit: float, step: float) -> selector.NumberSelector:
+            """A correction in degrees, as a number box.
+
+            A bare float leaves the step to the browser, which is a whole
+            degree - and every field in this form is a correction that is read
+            in fractions of one. The step is what the value can still change
+            downstream, so each caller passes its own. Off-grid values already
+            stored keep loading either way: the selector holds the range, not
+            the step.
+            """
+            return selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=-limit,
+                    max=limit,
+                    step=step,
+                    mode=selector.NumberSelectorMode.BOX,
+                    unit_of_measurement=UnitOfTemperature.CELSIUS,
+                )
+            )
+
+        # Half a degree, because that is the setpoint's own resolution - and
+        # most units round that up to the next whole one anyway (see the
+        # field's description), so a finer step here would promise a precision
+        # the setpoint does not have.
+        offset_range_validator = degrees(5.0, 0.5)
         # Negative allowed, though overshooting is what everyone has measured
         # so far: a unit that stops short of the setting instead needs the
         # correction the other way, and there is no reason to make that
         # impossible before anyone has looked.
-        # A number box rather than a bare float: a plain float field leaves the
-        # step to the browser, which is a whole degree by default, and this
-        # correction is only ever read in fractions of one. 0.25 is the step
-        # because that is what the wire carries - the room temperature byte is
-        # round(T * 4) + 61 - so a finer figure is rounded away in the encoder
-        # and 0.1 quietly does nothing at all. Off-grid values that are already
-        # stored still load: the selector holds the range, not the step.
-        overshoot_validator = selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=-OVERSHOOT_MAX,
-                max=OVERSHOOT_MAX,
-                step=0.25,
-                mode=selector.NumberSelectorMode.BOX,
-                unit_of_measurement=UnitOfTemperature.CELSIUS,
-            )
-        )
+        # A quarter degree is where this one stops mattering: the room
+        # temperature byte it corrects is round(T * 4) + 61, and the source
+        # value entering that sum has already been snapped to the same grid
+        # (see AircoClimate._external_temperature_from_source_state), so a
+        # finer correction is rounded away for every reading rather than only
+        # for some.
+        overshoot_validator = degrees(OVERSHOOT_MAX, 0.25)
 
         source_fields: dict[Any, Any] = {
             # Keep this optional without a default: an omitted source must
@@ -598,11 +614,14 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlowWithReload):
             }
         )
 
+        # A tenth here, unlike the fields above: these two correct a reading on
+        # its way to being displayed, so nothing rounds them off afterwards.
+        sensor_offset_validator = degrees(15.0, 0.1)
         sensor_fields: dict[Any, Any] = {
             vol.Optional(
                 key,
                 default=options.get(key, 0.0),
-            ): vol.All(vol.Coerce(float), vol.Range(min=-15.0, max=15.0))
+            ): sensor_offset_validator
             for key in (CONF_INDOOR_OFFSET, CONF_OUTDOOR_OFFSET)
         }
 

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -443,10 +443,13 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
     def set_external_temperature_override(self, value: float | None) -> None:
         """Set the integration-side override state.
 
-        Used by the climate entity when restoring persisted state; the value
-        is re-armed into future commands without immediately issuing a new one.
-        Which is exactly why it counts as unapplied until a frame has carried
-        it: a restored value says what we intend to send, not what the unit
+        Used by the climate entity when restoring persisted state and whenever
+        the configured source reports. Arming asks for the operation-data frame
+        the value rides on (see _sync_external_temperature_carrier), since the
+        poll that would otherwise schedule one runs before the entities exist -
+        but that frame writes no setting of its own, so nothing here commands
+        the unit. Which is exactly why the value counts as unapplied until a
+        frame has carried it: it says what we intend to send, not what the unit
         currently regulates on.
 
         Nothing here says the unit has been told - see

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -92,7 +92,7 @@
             },
             "data_description": {
               "external_temperature_source": "The unit regulates on this sensor. Leave it empty to put the unit back on its own sensor. Unavailable or unknown states do the same on the next frame.",
-              "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. Starts at 1 because that is what the units measured so far need - check where your own room settles and adjust. If it stops short instead and never gets cold enough, enter a negative number.",
+              "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. Starts at 1 because that is what the units measured so far need - check where your own room settles and adjust. If it stops short instead and never gets cold enough, enter a negative number. Quarter degrees are the finest step that reaches the unit.",
               "overshoot_heat": "The same for heating: positive if the room ends up above your setting, negative if it stops short of it."
             }
           },

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -127,7 +127,7 @@
             },
             "data_description": {
               "external_temperature_source": "Das Gerät regelt auf diesen Sensor. Leer lassen, damit es wieder seinen eigenen benutzt; bei „unavailable“ oder „unknown“ geschieht dasselbe mit dem nächsten Frame.",
-              "overshoot_cool": "Wie weit der Raum über Ihre Einstellung hinausschießt, bevor das Gerät abschaltet. 22 °C eingestellt, Raum pendelt sich bei 21 °C ein: 1 eintragen. Startet bei 1, weil die bisher gemessenen Geräte das brauchen — prüfen Sie, wo Ihr Raum landet, und passen Sie an. Bleibt er stattdessen darüber und wird nie kalt genug, tragen Sie eine negative Zahl ein.",
+              "overshoot_cool": "Wie weit der Raum über Ihre Einstellung hinausschießt, bevor das Gerät abschaltet. 22 °C eingestellt, Raum pendelt sich bei 21 °C ein: 1 eintragen. Startet bei 1, weil die bisher gemessenen Geräte das brauchen — prüfen Sie, wo Ihr Raum landet, und passen Sie an. Bleibt er stattdessen darüber und wird nie kalt genug, tragen Sie eine negative Zahl ein. Viertelgrad ist der feinste Schritt, der beim Gerät ankommt.",
               "overshoot_heat": "Dasselbe fürs Heizen: positiv, wenn der Raum über Ihrer Einstellung landet, negativ, wenn er darunter bleibt."
             }
           },

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -127,7 +127,7 @@
             },
             "data_description": {
               "external_temperature_source": "The unit regulates on this sensor. Leave it empty to put the unit back on its own sensor. Unavailable or unknown states do the same on the next frame.",
-              "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. Starts at 1 because that is what the units measured so far need - check where your own room settles and adjust. If it stops short instead and never gets cold enough, enter a negative number.",
+              "overshoot_cool": "How far the room goes past your setting before the unit stops. Set 22 °C and the room settles at 21 °C: enter 1. Starts at 1 because that is what the units measured so far need - check where your own room settles and adjust. If it stops short instead and never gets cold enough, enter a negative number. Quarter degrees are the finest step that reaches the unit.",
               "overshoot_heat": "The same for heating: positive if the room ends up above your setting, negative if it stops short of it."
             }
           },


### PR DESCRIPTION
Follow-up to #344, which fixed the overshoot reaching the unit a poll late
and gave the field a 0.25 °C step. Four things that change came with it.

- **The docstring on `set_external_temperature_override()`** still said the
  value is re-armed "without immediately issuing a new one". Arming now asks
  for the operation-data frame it rides on, so that promise had to go - while
  the reason behind it stands: the frame carries no set-bits, so the value is
  still unapplied until the wire says otherwise.
- **The heating overshoot row in the README** kept the old range. Both fields
  share one selector, so they always shared the step. The cooling cell loses
  its worked example of a rounded-away value in the same pass; what the wire
  carries is the fact worth having there.
- **The quarter-degree limit now sits in the field's own description.** Nobody
  has the README open while filling that field in, and step arrows say what the
  step is without saying that a finer figure is dropped rather than refused.
  English and German; the other languages fall back.
- **The four remaining degree fields are number boxes too.** One section was
  mixing a box carrying its unit and step against bare floats the browser steps
  in whole degrees, in a form where a whole degree is never the interesting
  move. Each states the step it actually has: half a degree for the setpoint
  offsets (the setpoint's own resolution), a quarter for the overshoots, a
  tenth for the two display calibrations, which nothing rounds afterwards.

294 tests green, mypy clean.
