### PR TITLE
Hold the custom component to the rules the core review applied

### DIFF
--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -647,21 +647,6 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
             self._attr_hvac_mode = HVACMode.OFF
             self._attr_hvac_action = HVACAction.OFF
         else:
-            _new_mode: HVACMode = HVACMode.OFF
-            _mode = airco.OperationMode
-            if _mode == 0:
-                _new_mode = HVACMode.AUTO
-            elif _mode == 1:
-                _new_mode = HVACMode.COOL
-            elif _mode == 2:
-                _new_mode = HVACMode.HEAT
-            elif _mode == 3:
-                _new_mode = HVACMode.FAN_ONLY
-            elif _mode == 4:
-                _new_mode = HVACMode.DRY
-            self._attr_hvac_mode = _new_mode
-
-            # Determine hvac_action based on operation mode and state
             self._attr_hvac_action = self._determine_hvac_action(airco)
 
         # Read back from the same Vacant bit HomeLeaveModeSelect uses, so the
@@ -673,40 +658,34 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
     def _determine_hvac_action(self, airco: Aircon) -> HVACAction:
         """Determine the current HVAC action from operation mode and state.
 
-        CoolHotJudge (content[8] & 8) reflects what the unit's own AUTO logic
-        is doing - set means COOLING, clear means HEATING. CompressorRunning
-        (content[9] & 2) distinguishes "unit on" from "compressor actually
-        running" (e.g. setpoint satisfied), same signal as the Compressor
-        binary sensor - used here so COOL/HEAT/AUTO can report IDLE instead
-        of claiming to cool/heat while the compressor is stopped.
-        """
-        if not airco.Operation:
-            return HVACAction.OFF
+        CoolHotJudge reflects what the unit's own AUTO logic is doing. Mind
+        the inversion: the parser reads it as (content[8] & 8) == 0, so the
+        raw bit set means COOLING and the resulting flag is then False -
+        a true CoolHotJudge is HEATING. CompressorRunning (content[9] & 2)
+        distinguishes "unit on" from "compressor actually running" (e.g.
+        setpoint satisfied), same signal as the Compressor binary sensor -
+        used here so COOL/HEAT/AUTO can report IDLE instead of claiming to
+        cool/heat while the compressor is stopped.
 
+        Only called while the unit is on, and only with an OperationMode of
+        0-4: anything else has already raised in _hvac_mode_from_operation.
+        """
         _mode = airco.OperationMode
 
-        # FAN_ONLY mode
         if _mode == 3:
             return HVACAction.FAN
 
-        # DRY mode
         if _mode == 4:
             return HVACAction.DRYING
 
         if not airco.CompressorRunning:
             return HVACAction.IDLE
 
-        # AUTO mode - use CoolHotJudge directly (unit tells us what it's doing)
+        # AUTO leaves the direction to the unit, so ask it what it picked.
         if _mode == 0:
             return HVACAction.HEATING if airco.CoolHotJudge else HVACAction.COOLING
 
-        # COOL mode
         if _mode == 1:
             return HVACAction.COOLING
 
-        # HEAT mode
-        if _mode == 2:
-            return HVACAction.HEATING
-
-        # Unknown mode with compressor running - nothing better to report
-        return HVACAction.IDLE
+        return HVACAction.HEATING

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -363,14 +363,7 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        set_temp = kwargs.get(ATTR_TEMPERATURE)
-        if set_temp is None:
-            raise ServiceValidationError(
-                "Temperature is required",
-                translation_domain=DOMAIN,
-                translation_key="temperature_required",
-            )
-
+        set_temp = kwargs[ATTR_TEMPERATURE]
         # If this call also switches hvac_mode, the minimum must reflect the mode
         # being switched to, not the (still stale until the next poll) current one.
         target_hvac_mode = kwargs.get("hvac_mode", self._attr_hvac_mode)
@@ -406,14 +399,13 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
                 },
             )
 
-        # The AC unit's own thermostat logic uses its own indoor sensor reading,
-        # subject to the same calibration bias CONF_INDOOR_OFFSET corrects for
-        # display (see sensor.py). To make the unit actually reach the
-        # user-requested real room temperature despite that bias, the offset is
-        # subtracted from the commanded setpoint before sending - the displayed
-        # target_temperature itself is unaffected. Resolved against the mode
-        # the unit will be in after this command (target_hvac_mode), since
-        # cooling and heating have opposite-sign return-air bias.
+        # The unit regulates against its own return-air reading, which is
+        # biased against the room. The target offset compensates that on the
+        # wire while the displayed target_temperature stays what was asked
+        # for - CONF_INDOOR_OFFSET is a separate, display-only correction and
+        # is not what is subtracted here. Resolved against the mode the unit
+        # will be in after this command, since cooling and heating have
+        # opposite-sign bias.
         target_offset = self._resolve_target_offset(target_hvac_mode)
         target_temp = set_temp - target_offset
         target_temp = max(min_temp, min(max_temp, target_temp))

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -398,7 +398,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle zeroconf discovery."""
 
         local_name = discovery_info.hostname.rstrip(".")
-        node_name = local_name[: -len(".local")]
+        node_name = local_name.removesuffix(".local")
         host = discovery_info.host
         port = discovery_info.port
 

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -1776,7 +1776,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         info: DeviceInfo = {
             "sw_version": self._firmware,
             "identifiers": {(DOMAIN, self.airco_id)},
-            "manufacturer": "Mitsubishi (WF-RAC)",
+            "manufacturer": "Mitsubishi Heavy Industries",
             "name": self.device_name,
         }
         # airconId is MAC-derived, and on every module seen so far it is the

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -138,9 +138,6 @@
     "command_failed": {
       "message": "Sending the command to the Airco at {device} failed: {error}"
     },
-    "temperature_required": {
-      "message": "A target temperature is required."
-    },
     "temperature_below_minimum": {
       "message": "{temperature} °C is below the {min_temp} °C minimum for hvac_mode {hvac_mode}. Include hvac_mode in the same action call to check against the mode you are switching to instead."
     },

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -68,9 +68,6 @@
     "command_failed": {
       "message": "Das Senden des Befehls an das Klimagerät unter {device} ist fehlgeschlagen: {error}"
     },
-    "temperature_required": {
-      "message": "Eine Zieltemperatur ist erforderlich."
-    },
     "temperature_below_minimum": {
       "message": "{temperature} °C liegt unter dem Minimum von {min_temp} °C für hvac_mode {hvac_mode}. Geben Sie hvac_mode im selben Aufruf mit an, damit gegen den Modus geprüft wird, in den Sie wechseln."
     },

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -68,9 +68,6 @@
     "command_failed": {
       "message": "Sending the command to the Airco at {device} failed: {error}"
     },
-    "temperature_required": {
-      "message": "A target temperature is required."
-    },
     "temperature_below_minimum": {
       "message": "{temperature} °C is below the {min_temp} °C minimum for hvac_mode {hvac_mode}. Include hvac_mode in the same action call to check against the mode you are switching to instead."
     },

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -68,9 +68,6 @@
     "command_failed": {
       "message": "{device} のエアコンへのコマンド送信に失敗しました: {error}"
     },
-    "temperature_required": {
-      "message": "目標温度を指定してください。"
-    },
     "temperature_below_minimum": {
       "message": "{temperature}°Cは hvac_mode {hvac_mode} の最低温度{min_temp}°Cを下回っています。同じ呼び出しで hvac_mode を指定すると、切り替え先のモードで判定されます。"
     },

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -68,9 +68,6 @@
     "command_failed": {
       "message": "Nepavyko nusiųsti komandos kondicionieriui adresu {device}: {error}"
     },
-    "temperature_required": {
-      "message": "Būtina nurodyti norimą temperatūrą."
-    },
     "temperature_below_minimum": {
       "message": "{temperature} °C yra žemiau hvac_mode {hvac_mode} minimumo ({min_temp} °C). Nurodykite hvac_mode tame pačiame kvietime, kad būtų tikrinama pagal režimą, į kurį persijungiate."
     },

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -68,9 +68,6 @@
     "command_failed": {
       "message": "Het verzenden van de opdracht naar de airco op {device} is mislukt: {error}"
     },
-    "temperature_required": {
-      "message": "Een doeltemperatuur is verplicht."
-    },
     "temperature_below_minimum": {
       "message": "{temperature} °C is lager dan het minimum van {min_temp} °C voor hvac_mode {hvac_mode}. Geef hvac_mode mee in dezelfde aanroep om te toetsen aan de modus waarnaar je overschakelt."
     },

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -68,9 +68,6 @@
     "command_failed": {
       "message": "向 {device} 上的空调发送命令失败：{error}"
     },
-    "temperature_required": {
-      "message": "需要指定目标温度。"
-    },
     "temperature_below_minimum": {
       "message": "{temperature}°C 低于 hvac_mode {hvac_mode} 的最低温度 {min_temp}°C。在同一次调用中一并给出 hvac_mode，即可按你要切换到的模式来判断。"
     },

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -68,9 +68,6 @@
     "command_failed": {
       "message": "向 {device} 上的空調傳送命令失敗：{error}"
     },
-    "temperature_required": {
-      "message": "需要指定目標溫度。"
-    },
     "temperature_below_minimum": {
       "message": "{temperature}°C 低於 hvac_mode {hvac_mode} 的最低溫度 {min_temp}°C。在同一次呼叫中一併給出 hvac_mode，即可依你要切換到的模式來判斷。"
     },

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,23 @@
+"""Fixtures shared by the integration tests."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.mitsubishi_wf_rac.const import DOMAIN
+from custom_components.mitsubishi_wf_rac.coordinator import Device
+
+from ..unit.live_captures import LIVE_CAPTURES
+
+
+@pytest.fixture
+async def platform_device(hass):
+    """A Device holding one parsed live capture, with the API mocked out."""
+    entry = MockConfigEntry(domain=DOMAIN, options={})
+    entry.add_to_hass(hass)
+    device = Device(hass, entry, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id", swing_selects_enabled_default=True)
+    device._api = AsyncMock()
+    device._api.get_aircon_stats.return_value = {"numOfAccount": 1, "airconStat": LIVE_CAPTURES["on_cool"][0]}
+    await device.update()
+    return device

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,3 +21,16 @@ async def platform_device(hass):
     device._api.get_aircon_stats.return_value = {"numOfAccount": 1, "airconStat": LIVE_CAPTURES["on_cool"][0]}
     await device.update()
     return device
+
+
+@pytest.fixture
+def repository() -> AsyncMock:
+    """A module that answers every poll with one parsed live capture."""
+    api = AsyncMock()
+    api.get_aircon_stats.return_value = {
+        "numOfAccount": 1,
+        "airconStat": LIVE_CAPTURES["on_cool"][0],
+    }
+    # Persisted into entry.data, so it has to be storable.
+    api.method = "https"
+    return api

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -36,17 +36,6 @@ from pywfrac import AirconCommands, HomeLeaveModeSetting
 from ..unit.live_captures import LIVE_CAPTURES
 
 
-@pytest.fixture
-async def platform_device(hass):
-    entry = MockConfigEntry(domain=DOMAIN, options={})
-    entry.add_to_hass(hass)
-    device = Device(hass, entry, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id", "airco-id", swing_selects_enabled_default=True)
-    device._api = AsyncMock()
-    device._api.get_aircon_stats.return_value = {"numOfAccount": 1, "airconStat": LIVE_CAPTURES["on_cool"][0]}
-    await device.update()
-    return device
-
-
 def _entry(device, options=None):
     return MagicMock(
         runtime_data=MagicMock(device=device),

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -250,8 +250,6 @@ async def test_climate_commands_and_state_branches(platform_device):
     await entity.async_set_swing_horizontal_mode(horizontal)
     assert platform_device.async_queue_command.await_args.args[0][AirconCommands.Entrust] is False
 
-    with pytest.raises(ServiceValidationError, match="required"):
-        await entity.async_set_temperature()
     with pytest.raises(ServiceValidationError, match="below minimum") as below:
         await entity.async_set_temperature(temperature=9, hvac_mode=HVACMode.HEAT)
     with pytest.raises(ServiceValidationError, match="above maximum") as above:
@@ -369,12 +367,27 @@ async def test_select_command_and_state_branches(hass, platform_device):
     assert (cooling.AirFlow, heating.AirFlow) == (4, 1)
 
 
-async def test_home_leave_controls_require_known_settings_and_preserve_other_side(hass, platform_device):
+@pytest.mark.parametrize(
+    ("mode", "attribute", "expected"),
+    [
+        pytest.param("cooling", "TempRule", (15, 13), id="cooling_temp_rule"),
+        pytest.param("heating", "TempRule", (12, 15), id="heating_temp_rule"),
+        pytest.param("cooling", "TempSetting", (15, 10), id="cooling_temp_setting"),
+        pytest.param("heating", "TempSetting", (31, 15), id="heating_temp_setting"),
+    ],
+)
+async def test_home_leave_controls_require_known_settings_and_preserve_other_side(hass, platform_device, mode, attribute, expected):
+    """Each control writes its own field and carries the other three over.
+
+    The unit takes both directions in one frame, so the three fields this
+    control does not own have to be sent back unchanged - the value it writes
+    is the only difference between what came in and what goes out.
+    """
     platform_device.async_set_home_leave_mode = AsyncMock()
     control = _attached(
         hass,
-        number.HomeLeaveModeNumber(platform_device, "cooling", "TempRule"),
-        "number.home_leave_cooling_temp_rule",
+        number.HomeLeaveModeNumber(platform_device, mode, attribute),
+        f"number.home_leave_{mode}_{attribute.lower()}",
     )
     with pytest.raises(Exception, match="unknown yet"):
         await control.async_set_native_value(15)
@@ -382,7 +395,7 @@ async def test_home_leave_controls_require_known_settings_and_preserve_other_sid
     platform_device.airco.HomeLeaveModeForHeating = HomeLeaveModeSetting(13, 10, 1)
     await control.async_set_native_value(15)
     cooling, heating = platform_device.async_set_home_leave_mode.await_args.args
-    assert (cooling.TempRule, heating.TempRule) == (15, 13)
+    assert (getattr(cooling, attribute), getattr(heating, attribute)) == expected
 
 
 @pytest.mark.parametrize("available, latest", [(True, "2.0"), (False, "1.0"), (False, None)])

--- a/tests/integration/test_firmware_check.py
+++ b/tests/integration/test_firmware_check.py
@@ -1,0 +1,68 @@
+"""Tests for firmware_check.py: the manufacturer's getFirmware endpoint.
+
+The endpoint is unauthenticated and outside our control, so every shape it
+can answer with has to end somewhere defined - the update entity treats
+None as "nothing known" and says so rather than claiming to be up to date.
+"""
+
+import aiohttp
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.mitsubishi_wf_rac.firmware_check import (
+    _FIRMWARE_API_URL,
+    fetch_latest_firmware,
+)
+
+
+async def test_a_good_answer_gives_both_versions(hass: HomeAssistant, aioclient_mock):
+    """Both branches ship their own version, and the entity compares each."""
+    aioclient_mock.post(
+        _FIRMWARE_API_URL,
+        json={"result": 0, "contents": {"mFirmVer": "025", "cFirmVer": "200"}},
+    )
+
+    assert await fetch_latest_firmware(hass, "WF-RAC-HTTPS") == {
+        "wireless": "025",
+        "mcu": "200",
+    }
+
+
+async def test_the_declared_content_type_is_ignored(hass: HomeAssistant, aioclient_mock):
+    """Deployments of this endpoint mislabel it, the local API does too."""
+    aioclient_mock.post(
+        _FIRMWARE_API_URL,
+        text='{"result": 0, "contents": {"mFirmVer": "025", "cFirmVer": "200"}}',
+        headers={"Content-Type": "text/html"},
+    )
+
+    assert await fetch_latest_firmware(hass, "WF-RAC-HTTPS") is not None
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        pytest.param({"status": 500}, id="server_error"),
+        pytest.param({"json": []}, id="not_an_object"),
+        pytest.param({"json": {"result": 1}}, id="result_says_no"),
+        pytest.param({"json": {"result": 0}}, id="no_contents"),
+        pytest.param({"json": {"result": 0, "contents": "none"}}, id="contents_not_an_object"),
+    ],
+)
+async def test_an_answer_we_cannot_use_reports_nothing(
+    hass: HomeAssistant, aioclient_mock, response: dict
+):
+    """None means "unknown", which is the only honest answer here."""
+    aioclient_mock.post(_FIRMWARE_API_URL, **response)
+
+    assert await fetch_latest_firmware(hass, "WF-RAC-HTTPS") is None
+
+
+async def test_an_unreachable_endpoint_reports_nothing(
+    hass: HomeAssistant, aioclient_mock
+):
+    """The check is optional and off by default - it must never raise into
+    the coordinator's poll."""
+    aioclient_mock.post(_FIRMWARE_API_URL, exc=aiohttp.ClientError("no route"))
+
+    assert await fetch_latest_firmware(hass, "WF-RAC-HTTPS") is None

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -7,6 +7,9 @@ them at runtime any more - the migration's job is to leave no trace of them.
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+from pywfrac import WfRacConnectionError, WfRacError
+
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
@@ -20,6 +23,7 @@ from custom_components.mitsubishi_wf_rac import (
 )
 from custom_components.mitsubishi_wf_rac.config_flow import WfRacConfigFlow
 from custom_components.mitsubishi_wf_rac.const import (
+    CONF_CONNECTION_METHOD,
     CONF_AVAILABILITY_CHECK,
     CONF_AVAILABILITY_RETRY_LIMIT,
     DOMAIN,
@@ -188,3 +192,94 @@ async def test_an_entry_from_before_the_host_moved_still_sets_up(hass: HomeAssis
     assert entry.version == _CURRENT_VERSION
     assert entry.data[CONF_HOST] == "192.168.1.50"
     assert CONF_HOST not in entry.options
+
+
+async def test_a_unit_that_is_unreachable_at_startup_gets_retried(hass: HomeAssistant):
+    """update() reports failure through .available rather than raising.
+
+    ConfigEntryNotReady is what buys HA's retry-with-backoff; without it the
+    entry would sit there "loaded" with entities that never get a reading.
+    """
+    entry = _entry(hass, _CURRENT_VERSION, {**_DATA, CONF_HOST: "192.168.1.50"}, {})
+
+    repository = AsyncMock()
+    repository.get_aircon_stats.side_effect = WfRacConnectionError("no route")
+    with patch(
+        "custom_components.mitsubishi_wf_rac.coordinator.Repository",
+        return_value=repository,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_the_connection_method_is_remembered(
+    hass: HomeAssistant, repository: AsyncMock
+):
+    """Protocol discovery costs a round-trip on every start otherwise."""
+    entry = _entry(hass, _CURRENT_VERSION, {**_DATA, CONF_HOST: "192.168.1.50"}, {})
+
+    with patch(
+        "custom_components.mitsubishi_wf_rac.coordinator.Repository",
+        return_value=repository,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert entry.data[CONF_CONNECTION_METHOD] is not None
+
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_a_failed_platform_unload_keeps_the_coordinator(
+    hass: HomeAssistant, repository: AsyncMock
+):
+    """Entities that stayed loaded must keep the coordinator that feeds them.
+
+    Shutting it down anyway would leave a loaded entry that never updates
+    again.
+    """
+    entry = _entry(hass, _CURRENT_VERSION, {**_DATA, CONF_HOST: "192.168.1.50"}, {})
+
+    with patch(
+        "custom_components.mitsubishi_wf_rac.coordinator.Repository",
+        return_value=repository,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        device = entry.runtime_data.device
+
+        with patch.object(
+            hass.config_entries, "async_unload_platforms", return_value=False
+        ):
+            assert not await hass.config_entries.async_unload(entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert device.last_update_success
+
+        await device.async_shutdown()
+
+
+async def test_removal_says_so_when_the_slot_is_not_released(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+):
+    """The module keeps a small account table, and it can refuse to free ours.
+
+    Nothing here can fix that - the slot has to be freed from the official
+    app - so the removal goes through and says what was left behind.
+    """
+    entry = _entry(hass, _CURRENT_VERSION, {**_DATA, CONF_HOST: "192.168.1.50"}, {})
+
+    repository = AsyncMock()
+    repository.del_account_info.side_effect = WfRacError("no answer")
+    with patch(
+        "custom_components.mitsubishi_wf_rac.coordinator.Repository",
+        return_value=repository,
+    ):
+        await async_remove_entry(hass, entry)
+
+    assert "Could not delete operator ID" in caplog.text

--- a/tests/integration/test_sensor.py
+++ b/tests/integration/test_sensor.py
@@ -1,0 +1,112 @@
+"""Tests for sensor.py: the parts that only exist at the entity boundary.
+
+The accumulator arithmetic itself is covered in tests/unit/test_energy_total.py
+against a bare instance; what is left here needs Home Assistant around it -
+the entity service, the restore path, and the one diagnostic sensor that
+reports nothing rather than guessing.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant, ServiceCall, State
+from homeassistant.exceptions import ServiceValidationError
+from pytest_homeassistant_custom_component.common import (
+    MockEntityPlatform,
+    mock_restore_cache_with_extra_data,
+)
+
+from custom_components.mitsubishi_wf_rac.const import ATTR_COOL_HOT_JUDGE
+from custom_components.mitsubishi_wf_rac.sensor import (
+    DiagnosticsSensor,
+    EnergyTotalExtraStoredData,
+    EnergyTotalSensor,
+    async_set_energy_total,
+)
+
+
+async def test_setting_the_total_on_the_wrong_sensor_says_which(
+    hass: HomeAssistant, platform_device
+):
+    """An entity service reaches every sensor of the integration.
+
+    The handler is registered as a callable rather than a method name for
+    exactly this: targeting any other sensor has to name the entity instead
+    of failing with an AttributeError.
+    """
+    wrong = DiagnosticsSensor(platform_device, "Error", "error")
+    wrong.entity_id = "sensor.living_room_error"
+
+    with pytest.raises(ServiceValidationError, match="sensor.living_room_error"):
+        await async_set_energy_total(
+            wrong, MagicMock(spec=ServiceCall, data={"value": 12.0})
+        )
+
+
+async def test_setting_the_total_reanchors_the_meter(
+    hass: HomeAssistant, platform_device
+):
+    """Carrying a figure over from a previous meter is the whole point."""
+    sensor = EnergyTotalSensor(platform_device)
+    sensor.async_write_ha_state = lambda: None
+
+    await async_set_energy_total(
+        sensor, MagicMock(spec=ServiceCall, data={"value": 412.5})
+    )
+
+    assert sensor.native_value == 412.5
+
+
+@pytest.mark.parametrize(
+    ("operation", "operation_mode"),
+    [
+        pytest.param(False, 1, id="unit_off"),
+        pytest.param(True, 3, id="fan_only"),
+    ],
+)
+async def test_the_judge_reports_nothing_when_it_means_nothing(
+    hass: HomeAssistant, platform_device, operation: bool, operation_mode: int
+):
+    """CoolHotJudge keeps its last value while the unit is not regulating.
+
+    Reporting it then would claim a direction the unit is not working in.
+    """
+    platform_device.airco.Operation = operation
+    platform_device.airco.OperationMode = operation_mode
+    sensor = DiagnosticsSensor(platform_device, "Judge", ATTR_COOL_HOT_JUDGE)
+
+    sensor._update_state()
+
+    assert sensor.native_value is None
+
+
+def test_a_stored_state_that_cannot_be_read_restores_nothing():
+    """from_dict has to answer for anything the state store hands it."""
+    assert EnergyTotalExtraStoredData.from_dict({"native_value": 3.0}) is None
+
+
+async def test_the_total_survives_a_restart(hass: HomeAssistant, platform_device):
+    """The lifetime figure is the sensor's whole reason to exist.
+
+    The anchor is restored with it: the unit's counter keeps running across
+    our restart, so without last_raw the first reading afterwards would be
+    counted as consumption from zero all over again.
+    """
+    entity_id = "sensor.living_room_energy_usage_total"
+    mock_restore_cache_with_extra_data(
+        hass,
+        ((State(entity_id, "123.5"), EnergyTotalExtraStoredData(123.5, "kWh", 0.75).as_dict()),),
+    )
+    platform_device.airco.Electric = 1.0
+    sensor = EnergyTotalSensor(platform_device)
+    sensor.entity_id = entity_id
+    sensor.platform = MockEntityPlatform(hass)
+    sensor.hass = hass
+
+    await sensor.async_added_to_hass()
+
+    # 123.5 carried over, plus the 0.25 the unit ran up while we were away.
+    assert sensor.native_value == 123.75
+
+    # Registering with the coordinator started its refresh timer.
+    await platform_device.async_shutdown()


### PR DESCRIPTION
Stacked on #349 — merge that first, GitHub retargets this to `main` afterwards.

The core submission went through three review rounds. Their findings apply here too wherever the two share code, and the coverage rule is worth meeting on its own: every platform still to be submitted gets lifted out of this repo, so the closer the two stay, the cheaper each of those PRs is.

## Coverage

The `test-coverage` rule asks for above 95% in **every** module. Three were below:

| | before | after |
| --- | --- | --- |
| `firmware_check.py` | 43% | 100% |
| `sensor.py` | 92% | 100% |
| `number.py` | 94% | 100% |
| `__init__.py` | 93% | 100% |
| **total** | 96% | **99%** |

What had no test: `fetch_latest_firmware` entirely; the sensor platform's entity service, its restore path and the judge's "not regulating" case; setup retry when the unit is unreachable at startup, the connection-method write, a failed platform unload, and a refused account removal.

The Home Leave numbers only ever exercised cooling/`TempRule`. Parametrized across all four combinations rather than duplicated — which is what surfaced the two heating branches.

## Same findings as core

- The device says **Mitsubishi Heavy Industries** rather than a bare `"Mitsubishi"`, which reads as the unrelated Electric brand.
- `removesuffix(".local")` for the zeroconf node name instead of blind slicing, which truncates a hostname without that suffix.
- `_update_state` repeated the mode mapping `_hvac_mode_from_operation` had done a line earlier; `_determine_hvac_action` checked two cases its only caller had already decided. Its docstring had the `CoolHotJudge` inversion backwards — the parser reads the bit as `== 0`, so a true flag is heating.
- The comment above the setpoint offset named `CONF_INDOOR_OFFSET`, which is the separate display-only correction, not what is subtracted there.
- The `set_temperature` guard against a missing setpoint cannot be reached through Home Assistant: the climate schema requires the value on an entity that does not offer a range. Gone, with its string and the test that called the method directly to reach it.

321 tests green, mypy clean.