### PR TITLE
Pin pywfrac 0.1.3

### DIFF
--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -13,7 +13,7 @@
     "pywfrac"
   ],
   "requirements": [
-    "pywfrac==0.1.2"
+    "pywfrac==0.1.3"
   ],
   "version": "2026.9.9-beta4",
   "zeroconf": [

--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -13,7 +13,7 @@
     "pywfrac"
   ],
   "requirements": [
-    "pywfrac==0.1.1"
+    "pywfrac==0.1.2"
   ],
   "version": "2026.9.9-beta4",
   "zeroconf": [


### PR DESCRIPTION
Two fixes from the protocol library.

**Credentials out of the debug log.** `Repository._post` logged the request and the response in the clear, including `operatorId` and `deviceId` — the two fields the module checks on a write. Debug logs are exactly what I ask people for in issues, so they were the wrong place for them. `airconId` and the host stay: they say which unit a line is about, which is the only thing that makes a log readable when two units are involved, and neither of them can be used to control anything on its own.

**An unreadable fan value no longer reads as the top fan step.** A fan nibble outside the known set decoded to `-1`, which is the one out-of-range value a list index accepts silently, so the entity reported `high` instead of showing the field as unknown. It also travelled into every outgoing frame: the encoder fell back to a cleared nibble, which the module reads back as a real fan step, so a command for any other field would have changed the fan as well. Both halves are fixed.

322 tests green, mypy clean.