### PR TITLE
Route every first frame through the guard, and pin pywfrac 0.1.3

### DIFF
--- a/custom_components/mitsubishi_wf_rac/binary_sensor.py
+++ b/custom_components/mitsubishi_wf_rac/binary_sensor.py
@@ -60,7 +60,7 @@ class ProblemBinarySensor(WfRacEntity, BinarySensorEntity):
         """Initialize the binary sensor."""
         super().__init__(device)
         self._attr_unique_id = f"{DOMAIN}-{device.airco_id}-problem"
-        self._update_state()
+        self._apply_state()
 
     def _update_state(self) -> None:
         code = self._device.airco.ErrorCode
@@ -92,7 +92,7 @@ class CompressorBinarySensor(WfRacEntity, BinarySensorEntity):
         """Initialize the binary sensor."""
         super().__init__(device)
         self._attr_unique_id = f"{DOMAIN}-{device.airco_id}-compressor"
-        self._update_state()
+        self._apply_state()
 
     def _update_state(self) -> None:
         self._attr_is_on = self._device.airco.CompressorRunning
@@ -117,7 +117,7 @@ class ExternalControlBinarySensor(WfRacEntity, BinarySensorEntity):
         """Initialize the binary sensor."""
         super().__init__(device)
         self._attr_unique_id = f"{DOMAIN}-{device.airco_id}-external-control"
-        self._update_state()
+        self._apply_state()
 
     def _update_state(self) -> None:
         self._attr_is_on = self._device.foreign_activity
@@ -141,7 +141,7 @@ class ExternalTemperatureActiveBinarySensor(WfRacEntity, BinarySensorEntity):
         """Initialize the binary sensor."""
         super().__init__(device)
         self._attr_unique_id = f"{DOMAIN}-{device.airco_id}-external-temperature-active"
-        self._update_state()
+        self._apply_state()
 
     def _update_state(self) -> None:
         self._attr_is_on = self._device.external_temperature_applied
@@ -158,7 +158,7 @@ class OccupancyBinarySensor(WfRacEntity, BinarySensorEntity):
         """Initialize the binary sensor."""
         super().__init__(device)
         self._attr_unique_id = f"{DOMAIN}-{device.airco_id}-occupancy"
-        self._update_state()
+        self._apply_state()
 
     def _update_state(self) -> None:
         # Vacant == True means nobody is present.

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -32,7 +32,7 @@ from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .entity import WfRacEntity
 from .coordinator import Device
-from pywfrac import Aircon, AirconCommands, HomeLeaveModeSetting
+from pywfrac import AIRFLOW_UNKNOWN, Aircon, AirconCommands, HomeLeaveModeSetting
 from pywfrac.parser import (
     EXTERNAL_TEMPERATURE_MAX,
     EXTERNAL_TEMPERATURE_MIN,
@@ -153,7 +153,7 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
                 SUPPORT_FLAGS | ClimateEntityFeature.PRESET_MODE
             )
             self._attr_preset_modes = [PRESET_NONE, PRESET_AWAY]
-        self._update_state()
+        self._apply_state()
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
@@ -173,7 +173,7 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
         # state itself once this returns. (The source path above goes through
         # _set_external_temperature_override, whose write is harmless for the
         # same reason.)
-        self._update_state()
+        self._apply_state()
 
     @property
     def _external_temperature_source(self) -> str | None:
@@ -219,7 +219,7 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
         """Arm an override and immediately publish its integration-side state."""
         self._external_temperature_override = temperature
         self._device.set_external_temperature_override(temperature)
-        self._update_state()
+        self._apply_state()
         self.async_write_ha_state()
 
     def _set_external_temperature_from_source_state(self, state: State | None) -> None:
@@ -620,6 +620,12 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
             self._attr_current_temperature = airco.IndoorTemp + (
                 0.0 if self._device.external_temperature_applied else indoor_offset
             )
+        # Named rather than left to index past the end of the list: the library
+        # says so itself when it could not read the unit's fan step, and a sixth
+        # fan mode here would otherwise turn that marker into a real one and
+        # lose the unknown state without a sound.
+        if airco.AirFlow == AIRFLOW_UNKNOWN:
+            raise IndexError("the unit reported a fan step pywfrac cannot read")
         self._attr_fan_mode = list(FAN_MODE_TRANSLATION.keys())[airco.AirFlow]
         self._attr_swing_mode = (
             SWING_3D_AUTO

--- a/custom_components/mitsubishi_wf_rac/entity.py
+++ b/custom_components/mitsubishi_wf_rac/entity.py
@@ -23,8 +23,8 @@ _LOGGER = logging.getLogger(__name__)
 class WfRacEntity(CoordinatorEntity[Device]):
     """Wires an entity to the shared Device coordinator.
 
-    Subclasses keep their existing _update_state() (called once at the end of
-    their own __init__ for the initial state, as before); this base class
+    Subclasses implement _update_state() and call _apply_state() once at the
+    end of their own __init__ for the initial state; this base class
     re-invokes it whenever the coordinator notifies listeners - either from
     its own poll or from Device.async_set_updated_data() right after a
     command completes.
@@ -82,11 +82,28 @@ class WfRacEntity(CoordinatorEntity[Device]):
         implementation."""
         raise NotImplementedError
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
+    def _apply_state(self) -> None:
+        """Read the current frame into this entity, or mark the device down.
+
+        Every read goes through here, the very first one included. A frame can
+        decode cleanly and still carry a value an entity cannot translate, and
+        letting that escape a constructor is not the same failure as letting it
+        escape a poll: the platform never finishes setting up, so the config
+        entry loads without a single one of its entities and only a traceback
+        to say why. The same value arriving one frame later merely takes the
+        device unavailable until it reads again.
+        """
         try:
             self._update_state()
         except (IndexError, KeyError, AttributeError, ValueError):
-            _LOGGER.warning("Could not update %s", self.entity_id)
+            # entity_id is only assigned once the entity is added, so on the
+            # first read the unique id is all there is to name it by.
+            _LOGGER.warning(
+                "Could not update %s", self.entity_id or self._attr_unique_id
+            )
             self._device.set_available(False)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._apply_state()
         self.async_write_ha_state()

--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -13,7 +13,7 @@
     "pywfrac"
   ],
   "requirements": [
-    "pywfrac==0.1.1"
+    "pywfrac==0.1.3"
   ],
   "version": "2026.9.9-beta4",
   "zeroconf": [

--- a/custom_components/mitsubishi_wf_rac/number.py
+++ b/custom_components/mitsubishi_wf_rac/number.py
@@ -94,7 +94,7 @@ class HomeLeaveModeNumber(WfRacEntity, NumberEntity):
         self._attr_unique_id = (
             f"{DOMAIN}-{self._device.airco_id}-home-leave-{mode}-{slug}-number"
         )
-        self._update_state()
+        self._apply_state()
 
     def _current_setting(self) -> HomeLeaveModeSetting | None:
         return (

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -12,7 +12,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import WfRacEntity
-from pywfrac import AirconCommands, HomeLeaveModeSetting
+from pywfrac import AIRFLOW_UNKNOWN, AirconCommands, HomeLeaveModeSetting
 from .coordinator import Device
 from .const import (
     DOMAIN,
@@ -194,9 +194,14 @@ class FanSpeedSelect(WfRacEntity, SelectEntity):
         self._attr_options = SUPPORTED_FAN_MODES
         self._attr_icon = "mdi:fan"
         self._attr_unique_id = f"{DOMAIN}-{self._device.airco_id}-fan-speed"
-        self._update_state()
+        self._apply_state()
 
     def _update_state(self) -> None:
+        # Same marker check as the climate entity's fan mode: the library
+        # reports an unreadable fan step by name, and a sixth option here
+        # would otherwise make it look like a real one.
+        if self._device.airco.AirFlow == AIRFLOW_UNKNOWN:
+            raise IndexError("the unit reported a fan step pywfrac cannot read")
         self.select_option(list(FAN_MODE_TRANSLATION.keys())[self._device.airco.AirFlow])
 
     def select_option(self, option: str) -> None:
@@ -237,7 +242,7 @@ class HomeLeaveModeSelect(WfRacEntity, SelectEntity):
             HOME_LEAVE_MODE_AWAY_HEAT,
         ]
         self._attr_unique_id = f"{DOMAIN}-{self._device.airco_id}-home-leave-mode"
-        self._update_state()
+        self._apply_state()
 
     def _update_state(self) -> None:
         airco = self._device.airco
@@ -312,7 +317,7 @@ class HomeLeaveAirFlowSelect(WfRacEntity, SelectEntity):
         self._attr_unique_id = (
             f"{DOMAIN}-{self._device.airco_id}-home-leave-{mode}-air-flow-select"
         )
-        self._update_state()
+        self._apply_state()
 
     def _current_setting(self) -> HomeLeaveModeSetting | None:
         return (

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -217,7 +217,7 @@ class DiagnosticsSensor(WfRacEntity, SensorEntity):
             "cool_hot_judge": "cool_hot_judge",
         }
         self._attr_translation_key = type_map.get(custom_type, custom_type)
-        self._update_state()
+        self._apply_state()
 
     def _update_state(self) -> None:
         if self._custom_type == CONF_OPERATOR_ID:
@@ -273,7 +273,7 @@ class TemperatureSensor(WfRacEntity, SensorEntity):
             "target_temperature": "target"
         }
         self._attr_translation_key = type_map.get(custom_type, custom_type)
-        self._update_state()
+        self._apply_state()
 
     def _update_state(self) -> None:
         if self._custom_type == ATTR_INSIDE_TEMPERATURE:
@@ -309,7 +309,7 @@ class EnergySensor(WfRacEntity, SensorEntity):
         """Initialize the sensor."""
         super().__init__(device)
         self._attr_unique_id = f"{DOMAIN}-{self._device.airco_id}-energy-sensor"
-        self._update_state()
+        self._apply_state()
 
     def _update_state(self) -> None:
         self._attr_native_value = self._device.airco.Electric
@@ -401,7 +401,7 @@ class EnergyTotalSensor(WfRacEntity, RestoreSensor):
             )
         )
 
-        self._update_state()
+        self._apply_state()
         self.async_write_ha_state()
 
     def _update_state(self) -> None:
@@ -480,7 +480,7 @@ class ServiceDataSensor(WfRacEntity, SensorEntity):
         elif custom_type in (ATTR_INDOOR_COIL_TEMP, ATTR_INDOOR_COIL_OUTLET_TEMP):
             self._attr_device_class = SensorDeviceClass.TEMPERATURE
             self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
-        self._update_state()
+        self._apply_state()
 
     def _update_state(self) -> None:
         self._attr_native_value = getattr(self._device.airco, self._FIELD_BY_TYPE[self._custom_type])

--- a/custom_components/mitsubishi_wf_rac/update.py
+++ b/custom_components/mitsubishi_wf_rac/update.py
@@ -56,7 +56,7 @@ class FirmwareUpdateEntity(WfRacEntity, UpdateEntity):
     def __init__(self, device: Device) -> None:
         super().__init__(device)
         self._attr_unique_id = f"{DOMAIN}-{device.airco_id}-firmware-update"
-        self._update_state()
+        self._apply_state()
 
     def _update_state(self) -> None:
         self._attr_installed_version = self._device.wireless_firmware_version

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@
 homeassistant>=2025.12.0
 pytest-homeassistant-custom-component
 mypy
-pywfrac==0.1.1
+pywfrac==0.1.3

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -24,6 +24,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.restore_state import RestoredExtraData
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.mitsubishi_wf_rac import climate as climate_module
 from custom_components.mitsubishi_wf_rac.climate import AircoClimate
 from custom_components.mitsubishi_wf_rac.sensor import TemperatureSensor
 from custom_components.mitsubishi_wf_rac.const import (
@@ -35,13 +36,14 @@ from custom_components.mitsubishi_wf_rac.const import (
     CONF_TARGET_OFFSET_COOL,
     CONF_TARGET_OFFSET_HEAT,
     DOMAIN,
+    FAN_MODE_TRANSLATION,
     HOME_LEAVE_TEMP_COOL,
     HOME_LEAVE_TEMP_HEAT,
     HVAC_TRANSLATION,
     NORMAL_TEMP,
 )
 from custom_components.mitsubishi_wf_rac.coordinator import Device
-from pywfrac import AirconCommands
+from pywfrac import AIRFLOW_UNKNOWN, AirconCommands
 from pywfrac.parser import (
     SERVICE_DATA_INDOOR_COIL_RAW,
 )
@@ -768,3 +770,41 @@ async def test_set_preset_none_restores_a_normal_setpoint(device):
 
     sent = device.async_queue_command.call_args.args[0]
     assert sent == {AirconCommands.PresetTemp: NORMAL_TEMP}
+
+
+# --- an unreadable fan step ---------------------------------------------
+#
+# pywfrac 0.1.3 reports a fan nibble it cannot decode as AIRFLOW_UNKNOWN,
+# one past the end of FAN_MODE_TRANSLATION. Up to 0.1.1 the same nibble
+# arrived as -1 and the list index quietly returned the last mode, so the
+# pin is what makes this reachable at all.
+
+
+async def test_unknown_fan_step_leaves_the_entity_constructed(device, monkeypatch):
+    device.airco.AirFlow = AIRFLOW_UNKNOWN
+    set_available = MagicMock()
+    monkeypatch.setattr(device, "set_available", set_available)
+
+    # Constructing must not raise: the platform would never finish setting up
+    # and the entry would load without a climate entity at all.
+    AircoClimate(device)
+
+    set_available.assert_called_once_with(False)
+
+
+async def test_unknown_fan_step_is_recognised_by_name(device, monkeypatch):
+    """Not left to the list index: a sixth fan mode would swallow the marker.
+
+    AIRFLOW_UNKNOWN is one past the end of today's five modes, so indexing
+    happens to raise. Add a mode and it stops - the marker would read as a
+    real fan step and the unknown state would disappear without a sound.
+    """
+    monkeypatch.setattr(
+        climate_module,
+        "FAN_MODE_TRANSLATION",
+        {**FAN_MODE_TRANSLATION, "sixth": 5},
+    )
+    device.airco.AirFlow = AIRFLOW_UNKNOWN
+
+    with pytest.raises(IndexError):
+        AircoClimate(device)._update_state()

--- a/tests/integration/test_entity.py
+++ b/tests/integration/test_entity.py
@@ -68,3 +68,36 @@ async def test_base_entity_marks_device_unavailable_when_state_update_fails(devi
     entity._handle_coordinator_update()
 
     set_available.assert_called_once_with(False)
+
+
+async def test_apply_state_swallows_a_first_read_that_fails(device, monkeypatch):
+    """A constructor read must fail like a poll, not like a setup error.
+
+    Before this, every platform called _update_state() straight from its
+    __init__. A frame that decodes cleanly can still carry a value an entity
+    cannot translate, and there the exception took the whole platform down:
+    the config entry loaded without a single entity of that kind.
+    """
+    entity = WfRacEntity(device)
+    entity._attr_unique_id = "airco-id-something"
+    entity._update_state = MagicMock(side_effect=IndexError)
+    set_available = MagicMock()
+    monkeypatch.setattr(device, "set_available", set_available)
+
+    entity._apply_state()
+
+    set_available.assert_called_once_with(False)
+
+
+async def test_apply_state_names_the_entity_by_unique_id_before_it_is_added(
+    device, monkeypatch, caplog
+):
+    """entity_id is only assigned on add, so the first read has nothing else."""
+    entity = WfRacEntity(device)
+    entity._attr_unique_id = "airco-id-fan-speed"
+    entity._update_state = MagicMock(side_effect=IndexError)
+    monkeypatch.setattr(device, "set_available", MagicMock())
+
+    entity._apply_state()
+
+    assert "airco-id-fan-speed" in caplog.text

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -31,7 +31,7 @@ from custom_components.mitsubishi_wf_rac.const import (
     SWING_MODE_TRANSLATION,
 )
 from custom_components.mitsubishi_wf_rac.coordinator import Device
-from pywfrac import AirconCommands, HomeLeaveModeSetting
+from pywfrac import AIRFLOW_UNKNOWN, AirconCommands, HomeLeaveModeSetting
 
 from ..unit.live_captures import LIVE_CAPTURES
 
@@ -406,3 +406,19 @@ async def test_update_version_states(platform_device, available, latest):
     entity = update.FirmwareUpdateEntity(platform_device)
     assert entity.installed_version == "1.0"
     assert entity.latest_version == (latest if available else "1.0")
+
+
+async def test_fan_speed_select_recognises_an_unreadable_fan_step(platform_device, monkeypatch):
+    """Same marker as the climate entity's fan mode, same first-read guard.
+
+    FanSpeedSelect indexes FAN_MODE_TRANSLATION from its own __init__, so an
+    AIRFLOW_UNKNOWN nibble used to take the whole select platform with it.
+    """
+    platform_device.airco.AirFlow = AIRFLOW_UNKNOWN
+    set_available = MagicMock()
+    monkeypatch.setattr(platform_device, "set_available", set_available)
+
+    fan = select.FanSpeedSelect(platform_device)
+
+    assert fan.current_option is None
+    set_available.assert_called_once_with(False)


### PR DESCRIPTION
Every platform read its first frame straight from its own constructor, outside
the guard every later read goes through. A frame can decode cleanly and still
carry a value an entity cannot translate, and an exception there is not the
same failure as one in a poll: the platform never finishes setting up, so the
config entry loads without a single entity of that kind and nothing but a
traceback to say why.

`_update_state()` is now reached solely through `WfRacEntity._apply_state()` —
the same guard `_handle_coordinator_update()` has always applied, minus the
`async_write_ha_state()` an entity that has not been added yet must not do.
That covers 18 call sites, including `_set_external_temperature_override()`,
which is reached from `async_added_to_hass()` on both branches and so runs
*before* the initial read at the end of that method.

## Why now

`pywfrac 0.1.3` is what makes this reachable. Up to `0.1.1` a fan nibble the
library could not decode arrived as `-1`, and `list(FAN_MODE_TRANSLATION.keys())[-1]`
quietly returned the last mode. From `0.1.2` it arrives as `AIRFLOW_UNKNOWN`,
one past the end, and raises — in a constructor, so the climate entity or the
whole select platform simply would not appear.

The climate entity and the fan speed select recognise the marker by name
rather than leaning on that overflow: a sixth fan mode would otherwise turn it
into a real step and lose the unknown state without a sound. `0.1.3` also
names the field when a command carries a fan value it cannot encode, which
until now surfaced as `Failed to encode aircon state: 5`.

## The pin

This replaces #352, which changed `manifest.json` alone. `requirements-dev.txt`
pins `pywfrac` as well, so the tests there ran against `0.1.1` and never
exercised the version being pinned. Both move together here.

## Not covered

`HomeLeaveAirFlowSelect` indexes the same way, but `HomeLeaveModeSetting.AirFlow`
still comes from `find_match()` and returns `-1` for an unreadable byte, which
reads back as `"4"` rather than raising. Unchanged by the pin, so it is left
for its own fix.

## Tests

327 pass, mypy clean. The five new ones fail without the change.
