### PR TITLE
Remember which module needs its power state carried

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_AIRCO_ID,
     CONF_AVAILABILITY_CHECK,
     CONF_AVAILABILITY_RETRY_LIMIT,
+    CONF_CARRY_POWER_STATE,
     CONF_CONNECTION_METHOD,
     CONF_FIRMWARE_UPDATE_CHECK,
     CONF_OPERATOR_ID, CONF_CREATE_SWING_MODE_SELECT,
@@ -212,11 +213,13 @@ async def create_device_from_entry(entry: ConfigEntry, hass: HomeAssistant) -> D
         CONF_AVAILABILITY_RETRY_LIMIT, AVAILABILITY_FAILURE_LIMIT_MIN
     )
     connection_method: str | None = entry.data.get(CONF_CONNECTION_METHOD)
+    carry_power_state: bool = bool(entry.data.get(CONF_CARRY_POWER_STATE, False))
     _device = Device(hass, entry, name, device, port, device_id, operator_id, airco_id,
                      swing_selects_enabled_default,
                      availability_failure_limit=availability_failure_limit,
                      firmware_update_check_enabled=firmware_update_check_enabled,
-                     connection_method=connection_method)
+                     connection_method=connection_method,
+                     carry_power_state=carry_power_state)
     return _device
 
 

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -39,6 +39,10 @@ CONF_FIRMWARE_UPDATE_CHECK = "firmware_update_check"
 # New entries must not write this key.
 CONF_CREATE_SWING_MODE_SELECT = "create_swing_mode_select"
 CONF_CONNECTION_METHOD = "connection_method"
+# Learned, not configured: set once a module has shown that it applies the
+# operation-data request's empty power field as "switch off" (see
+# Device._check_request_stopped_unit).
+CONF_CARRY_POWER_STATE = "carry_power_state"
 ATTR_DEVICE_ID = "device_id"
 ATTR_CONNECTED_ACCOUNTS = "connected_accounts"
 ATTR_UPDATED_BY = "updated_by"

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import (
     AC_CERT_FILENAME,
+    CONF_CARRY_POWER_STATE,
     CONF_EXTERNAL_TEMPERATURE_SOURCE,
     CONF_OVERSHOOT_COOL,
     CONF_OVERSHOOT_DRY,
@@ -327,6 +328,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             availability_failure_limit: int = AVAILABILITY_FAILURE_LIMIT_MIN,
             firmware_update_check_enabled: bool = False,
             connection_method: str | None = None,
+            carry_power_state: bool = False,
     ) -> None:
         self._api = Repository(
             async_get_clientsession(hass),
@@ -338,6 +340,10 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             cert_path=hass.config.path(AC_CERT_FILENAME),
         )
         self._parser = _ServiceDataParser()
+        # Carried over from a previous run: a module that needs the power
+        # state has always needed it, and relearning costs the unit the same
+        # shutdowns every time (see _check_request_stopped_unit).
+        self._parser.carry_power_state = carry_power_state
         self._hass = hass
 
         # Protected state
@@ -1425,6 +1431,14 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             )
             return
         self._parser.carry_power_state = True
+        # Written down, not just remembered: this is a property of the module
+        # in front of us, and a restart that forgot it would put the unit
+        # through the same shutdowns again to learn the same thing.
+        entry = self.config_entry
+        assert entry is not None  # always constructed with one - see options
+        self._hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_CARRY_POWER_STATE: True}
+        )
         _LOGGER.warning(
             "[%s] switched off in the same request in which we asked it for "
             "operation data. That request carries no settings, so this module "

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -19,6 +19,7 @@ from homeassistant.helpers import issue_registry as ir
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.mitsubishi_wf_rac.const import (
+    CONF_CARRY_POWER_STATE,
     CONF_OVERSHOOT_COOL,
     CONF_OVERSHOOT_DRY,
     CONF_OVERSHOOT_HEAT,
@@ -2048,6 +2049,8 @@ async def test_a_unit_that_stops_on_our_request_twice_gets_its_power_state_carri
     would be the wrong thing to gate on. Twice, because the signal cannot
     separate us from another client on the same network.
     """
+    # Registered, so the entry can actually be written to - see _set_options.
+    device.config_entry.add_to_hass(device.hass)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
     assert device.airco.Operation is True
@@ -2062,6 +2065,30 @@ async def test_a_unit_that_stops_on_our_request_twice_gets_its_power_state_carri
     await device.update()
     await _run_service_data_request(device, monkeypatch)
     assert device._parser.carry_power_state is True
+    # Written down, so the next start does not put the unit through the same
+    # shutdowns to learn the same thing (#329, reported again after an update
+    # had reset it).
+    assert device.config_entry.data[CONF_CARRY_POWER_STATE] is True
+
+
+async def test_a_learned_power_state_quirk_survives_a_restart(hass):
+    """A module that needs the power state has always needed it.
+
+    The flag used to live only in memory, so every restart and every reload
+    started the count from zero - and the unit paid for it again each time.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_CARRY_POWER_STATE: True})
+    entry.add_to_hass(hass)
+    device = Device(
+        hass, entry, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id",
+        "airco-id", swing_selects_enabled_default=True,
+        carry_power_state=bool(entry.data.get(CONF_CARRY_POWER_STATE, False)),
+    )
+    device._api = AsyncMock()
+
+    assert device._parser.carry_power_state is True
+
+    await device.async_shutdown()
 
 
 async def test_a_single_stop_during_our_request_is_not_enough(device, monkeypatch):


### PR DESCRIPTION
Fixes the report in #329 on `2026.9.9-beta4`.

Some modules apply the operation-data request's empty power field as "switch
off". The request only asks the unit for readings and carries no settings, so
on the hardware this was developed against it changes nothing — on those
modules it stops the unit, every 60 seconds, for as long as any operating-data
sensor is enabled. The integration notices that from the symptom (twice, so a
person reaching for the remote in the same second does not count) and from then
on carries the unit's own power state back to it, which confirms the state
instead of changing it.

**What it did not do was remember.** The flag lived on the parser instance and
nowhere else, so every restart and every reload started the count at zero and
the unit paid two more shutdowns to teach the same lesson again. On an
installation that meets this at all, updating the integration was enough to
bring the fault straight back.

That is exactly what the log in #329 shows, right after an update:

```
18:19:34  Operation-data request block: 00 00 00 00 00 ff … (carrying power state: False, unit is on)
18:19:35  [14b5cd001aa3] stopped during our operation-data request (1 of 2 before the request starts carrying the power state)
18:20:05  was changed at the unit itself: Operation True -> False, OperationMode 1 -> 0, PresetTemp 23.0 -> 10.0, …
```

Back at strike one, on a module that had already been through this.

## The change

The learned flag goes into `entry.data`, next to `connection_method` — learned
the same way, for the same reason: it is a property of the module in front of
us, not a setting. `create_device_from_entry` reads it back and hands it to the
parser before the first poll.

The threshold stays at two. One stop during our request can genuinely be
somebody switching the unit off in the second it lands; what changes is that
the cost is paid once per installation rather than once per restart.

## Tests

337 pass, mypy clean. Two cover this: that reaching the threshold writes the
flag to the entry, and that a device built from an entry carrying it starts
with the request already correct.
