### PR TITLE
Let the climate entity be the device

### DIFF
--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -138,10 +138,15 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
     _attr_preset_modes: list[str] | None = None
     _attr_preset_mode: str | None = None
     _attr_translation_key = "mitsubishi_wf_rac"
+    # The unit itself, so it carries the device's name and adds nothing of its
+    # own - the same shape every other platform here already uses. It displayed
+    # the device name before too, by copying it into _attr_name; the difference
+    # is that a renamed device now reaches it without a reload.
+    _attr_has_entity_name: bool = True
+    _attr_name: str | None = None
 
     def __init__(self, device: Device) -> None:
         super().__init__(device)
-        self._attr_name = device.device_name
         self._attr_unique_id = f"{DOMAIN}-{self._device.airco_id}-climate"
         # Away is the unit's own Home Leave mode, offered here as the preset a
         # thermostat card and a voice assistant already know how to ask for.

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -422,3 +422,16 @@ async def test_fan_speed_select_recognises_an_unreadable_fan_step(platform_devic
 
     assert fan.current_option is None
     set_available.assert_called_once_with(False)
+
+
+async def test_the_climate_entity_is_the_device_itself(platform_device):
+    """It carries the device's name and adds nothing of its own.
+
+    Every other platform here is already built this way. Climate used to copy
+    device_name into _attr_name instead, which displayed the same string but
+    only picked up a rename at the next reload.
+    """
+    entity = climate.AircoClimate(platform_device)
+
+    assert entity.has_entity_name is True
+    assert entity.name is None


### PR DESCRIPTION
Every other platform here already sets `has_entity_name` and leaves the name to
the device. Climate was the last one still copying `device_name` into
`_attr_name`, which showed the same string but only picked up a renamed entry at
the next reload.

Checked on a live instance before changing it: the climate entity already
displays exactly the device name, so this is a no-op for what people see.
Existing entity ids are unaffected — the registry keeps what it assigned.
