### PR TITLE
Align with what core reviews for, and fix four defects it turned up

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -86,11 +86,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry, data=new_data, options=new_options, version=2
         )
     if entry.version == 2:
-        # This step used to write an "availability_retry" key that nothing ever
-        # reads, and to reset CONF_AVAILABILITY_RETRY_LIMIT back to 3 over any
-        # value the user had picked. Both are gone; the version bump is all that
-        # is left. Entries that already ran the old step get the stale key
-        # cleaned up by the v3 -> v4 step below.
+        # Nothing to change here any more; the v3 -> v4 step below clears
+        # what this step once wrote.
         hass.config_entries.async_update_entry(entry, version=3)
     if entry.version == 3:
         new_options = dict(entry.options)
@@ -252,10 +249,8 @@ async def async_remove_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEn
     """Handle removal of an entry."""
 
     temp_device = await create_device_from_entry(entry, hass)
-    # delete_account() catches its own errors and returns None on failure (see
-    # coordinator.py) rather than raising, so check the result instead of
-    # try/except - the previous try/except here could never actually trigger,
-    # and the "Deleted" log below used to fire unconditionally even on failure.
+    # delete_account() returns None on failure rather than raising, so the
+    # result is what says whether the slot was actually released.
     result = await temp_device.delete_account()
     if result is not None:
         _LOGGER.info(

--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -167,8 +167,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEnt
     # device that's unreachable at startup gets HA's automatic retry-with-backoff
     # rather than a silently "loaded" entry with no working entities.
     if not _device.available:
+        # No positional message: HomeAssistantError only renders the
+        # translation when it is constructed without one.
         raise ConfigEntryNotReady(
-            f"Could not reach device [{device}]",
             translation_domain=DOMAIN,
             translation_key="cannot_connect",
             translation_placeholders={"device": device},

--- a/custom_components/mitsubishi_wf_rac/binary_sensor.py
+++ b/custom_components/mitsubishi_wf_rac/binary_sensor.py
@@ -53,7 +53,6 @@ class ProblemBinarySensor(WfRacEntity, BinarySensorEntity):
 
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_has_entity_name = True
     _attr_translation_key = "problem"
 
     def __init__(self, device: Device) -> None:
@@ -88,7 +87,6 @@ class CompressorBinarySensor(WfRacEntity, BinarySensorEntity):
     a sibling unit while this reads off, so it is demand, not compressor state."""
 
     _attr_device_class = BinarySensorDeviceClass.RUNNING
-    _attr_has_entity_name = True
     _attr_translation_key = "compressor"
 
     def __init__(self, device: Device) -> None:
@@ -116,7 +114,6 @@ class ExternalControlBinarySensor(WfRacEntity, BinarySensorEntity):
     """
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_has_entity_name = True
     _attr_translation_key = "external_control"
 
     def __init__(self, device: Device) -> None:
@@ -143,7 +140,6 @@ class ExternalTemperatureActiveBinarySensor(WfRacEntity, BinarySensorEntity):
     """
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_has_entity_name = True
     _attr_translation_key = "external_temperature_active"
 
     def __init__(self, device: Device) -> None:
@@ -163,7 +159,6 @@ class OccupancyBinarySensor(WfRacEntity, BinarySensorEntity):
     """Reports the occupancy state of the unit (VacantProperty-capable models only)."""
 
     _attr_device_class = BinarySensorDeviceClass.OCCUPANCY
-    _attr_has_entity_name = True
     _attr_translation_key = "occupancy"
 
     def __init__(self, device: Device) -> None:

--- a/custom_components/mitsubishi_wf_rac/binary_sensor.py
+++ b/custom_components/mitsubishi_wf_rac/binary_sensor.py
@@ -134,9 +134,7 @@ class ExternalTemperatureActiveBinarySensor(WfRacEntity, BinarySensorEntity):
 
     Armed is not the same as in effect: nothing is written while the unit is
     off or in fan_only (see is_external_temperature_mode), and after a restart
-    the value waits for the next outgoing frame. Both cases used to be visible
-    only in the README, which is where people went looking after their
-    override appeared to do nothing.
+    the value waits for the next outgoing frame.
     """
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/custom_components/mitsubishi_wf_rac/binary_sensor.py
+++ b/custom_components/mitsubishi_wf_rac/binary_sensor.py
@@ -62,6 +62,9 @@ class ProblemBinarySensor(WfRacEntity, BinarySensorEntity):
         self._attr_unique_id = f"{DOMAIN}-{device.airco_id}-problem"
         self._apply_state()
 
+    def _mark_state_unknown(self) -> None:
+        self._attr_is_on = None
+
     def _update_state(self) -> None:
         code = self._device.airco.ErrorCode
         self._attr_is_on = code != "00"
@@ -94,6 +97,9 @@ class CompressorBinarySensor(WfRacEntity, BinarySensorEntity):
         self._attr_unique_id = f"{DOMAIN}-{device.airco_id}-compressor"
         self._apply_state()
 
+    def _mark_state_unknown(self) -> None:
+        self._attr_is_on = None
+
     def _update_state(self) -> None:
         self._attr_is_on = self._device.airco.CompressorRunning
 
@@ -119,6 +125,9 @@ class ExternalControlBinarySensor(WfRacEntity, BinarySensorEntity):
         self._attr_unique_id = f"{DOMAIN}-{device.airco_id}-external-control"
         self._apply_state()
 
+    def _mark_state_unknown(self) -> None:
+        self._attr_is_on = None
+
     def _update_state(self) -> None:
         self._attr_is_on = self._device.foreign_activity
 
@@ -143,6 +152,9 @@ class ExternalTemperatureActiveBinarySensor(WfRacEntity, BinarySensorEntity):
         self._attr_unique_id = f"{DOMAIN}-{device.airco_id}-external-temperature-active"
         self._apply_state()
 
+    def _mark_state_unknown(self) -> None:
+        self._attr_is_on = None
+
     def _update_state(self) -> None:
         self._attr_is_on = self._device.external_temperature_applied
 
@@ -159,6 +171,9 @@ class OccupancyBinarySensor(WfRacEntity, BinarySensorEntity):
         super().__init__(device)
         self._attr_unique_id = f"{DOMAIN}-{device.airco_id}-occupancy"
         self._apply_state()
+
+    def _mark_state_unknown(self) -> None:
+        self._attr_is_on = None
 
     def _update_state(self) -> None:
         # Vacant == True means nobody is present.

--- a/custom_components/mitsubishi_wf_rac/button.py
+++ b/custom_components/mitsubishi_wf_rac/button.py
@@ -37,6 +37,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
+# HACS only: it resets EnergyTotalSensor, so it goes wherever that goes.
 class EnergyTotalResetButton(WfRacEntity, ButtonEntity):
     """Resets the accumulated Energy Usage Total back to zero.
 

--- a/custom_components/mitsubishi_wf_rac/button.py
+++ b/custom_components/mitsubishi_wf_rac/button.py
@@ -63,5 +63,8 @@ class EnergyTotalResetButton(WfRacEntity, ButtonEntity):
             0.0,
         )
 
+    def _mark_state_unknown(self) -> None:
+        """A button carries no state, so there is nothing to drop."""
+
     def _update_state(self) -> None:
         """No state to reflect - the button has none."""

--- a/custom_components/mitsubishi_wf_rac/button.py
+++ b/custom_components/mitsubishi_wf_rac/button.py
@@ -49,7 +49,6 @@ class EnergyTotalResetButton(WfRacEntity, ButtonEntity):
 
     _attr_translation_key = "reset_energy_total"
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_has_entity_name = True
 
     def __init__(self, device: Device) -> None:
         """Initialize the button."""

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -59,13 +59,8 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-# Zero, not one, although this platform writes: the serialisation the module
-# needs already lives in the coordinator, which holds a send lock around the
-# request and spaces requests by MIN_TIME_BETWEEN_REQUESTS. A platform
-# semaphore on top of that only stops actions issued together - a scene, an
-# automation step that fans out - from reaching the coordinator's
-# consolidation window together, and those are exactly the ones worth
-# merging into a single frame.
+# Zero although this platform writes: the coordinator already serialises and
+# spaces every request.
 PARALLEL_UPDATES = 0
 
 # The modes whose setpoint the unit actually regulates on. Off and fan-only
@@ -135,10 +130,7 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
     _attr_preset_modes: list[str] | None = None
     _attr_preset_mode: str | None = None
     _attr_translation_key = "mitsubishi_wf_rac"
-    # The unit itself, so it carries the device's name and adds nothing of its
-    # own - the same shape every other platform here already uses. It displayed
-    # the device name before too, by copying it into _attr_name; the difference
-    # is that a renamed device now reaches it without a reload.
+    # The unit itself: it carries the device's name and adds nothing of its own.
     _attr_name: str | None = None
 
     def __init__(self, device: Device) -> None:

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -119,7 +119,6 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
     _attr_temperature_unit: str = UnitOfTemperature.CELSIUS
     _attr_hvac_modes: list[HVACMode] = SUPPORTED_HVAC_MODES
     _attr_fan_modes: list[str] = SUPPORTED_FAN_MODES
-    _attr_hvac_mode: HVACMode = HVACMode.OFF
     _attr_hvac_action: HVACAction | None = None
     _attr_fan_mode: str = FAN_AUTO
     _attr_swing_mode: str | None = SWING_VERTICAL_AUTO
@@ -358,7 +357,7 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
             max(self._max_temp_for_mode(mode) for mode in REGULATING_HVAC_MODES),
         )
 
-    def _writing_mode(self, hvac_mode: HVACMode) -> HVACMode:
+    def _writing_mode(self, hvac_mode: HVACMode | None) -> HVACMode:
         """The mode a setpoint for this hvac_mode is actually written in.
 
         A call naming a regulating mode switches to it. Off leaves the unit on
@@ -370,11 +369,13 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
             return hvac_mode
         return self._hvac_mode_from_operation
 
-    def _offset_for_target(self, hvac_mode: HVACMode) -> float:
+    def _offset_for_target(self, hvac_mode: HVACMode | None) -> float:
         """The target offset a setpoint for this mode is written with."""
         return self._resolve_target_offset(self._writing_mode(hvac_mode))
 
-    def _displayed_setpoint_range(self, hvac_mode: HVACMode) -> tuple[float, float]:
+    def _displayed_setpoint_range(
+        self, hvac_mode: HVACMode | None
+    ) -> tuple[float, float]:
         """The setpoint range in the numbers the card shows.
 
         The device is held to _setpoint_range_for_mode(); what the user sets
@@ -661,6 +662,9 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
                 AirFlow=air_flow_heating,
             ),
         )
+
+    def _mark_state_unknown(self) -> None:
+        self._attr_hvac_mode = None
 
     def _update_state(self) -> None:
         """Private update attributes"""

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -36,7 +36,6 @@ from pywfrac import AIRFLOW_UNKNOWN, Aircon, AirconCommands, HomeLeaveModeSettin
 from pywfrac.parser import (
     EXTERNAL_TEMPERATURE_MAX,
     EXTERNAL_TEMPERATURE_MIN,
-    is_external_temperature_mode,
 )
 from .const import (
     DOMAIN,
@@ -81,7 +80,7 @@ async def async_setup_entry(
 ) -> None:
     """Setup climate entities"""
     device: Device = entry.runtime_data.device
-    _LOGGER.info("Setup climate for: %s, %s", device.device_name, device.airco_id)
+    _LOGGER.debug("Setup climate for: %s, %s", device.device_name, device.airco_id)
     async_add_entities([AircoClimate(device)])
 
 
@@ -119,7 +118,6 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
     _attr_temperature_unit: str = UnitOfTemperature.CELSIUS
     _attr_hvac_modes: list[HVACMode] = SUPPORTED_HVAC_MODES
     _attr_fan_modes: list[str] = SUPPORTED_FAN_MODES
-    _attr_hvac_action: HVACAction | None = None
     _attr_fan_mode: str = FAN_AUTO
     _attr_swing_mode: str | None = SWING_VERTICAL_AUTO
     _attr_swing_modes: list[str] | None = SUPPORT_SWING_MODES
@@ -141,7 +139,6 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
     # own - the same shape every other platform here already uses. It displayed
     # the device name before too, by copying it into _attr_name; the difference
     # is that a renamed device now reaches it without a reload.
-    _attr_has_entity_name: bool = True
     _attr_name: str | None = None
 
     def __init__(self, device: Device) -> None:

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import section
+from homeassistant.data_entry_flow import AbortFlow, section
 from homeassistant.helpers import entity_registry as er, selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -248,6 +248,10 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         description_placeholders[key] = str(value)
                     else:
                         description_placeholders[key] = value
+            except AbortFlow:
+                # An abort is the flow working as intended - already
+                # configured, already in progress - not an unexpected error.
+                raise
             except Exception:  # pylint: disable=broad-except
                 # Intentionally broad: this is the outermost boundary of the config
                 # flow step, so any bug here should show the user a graceful
@@ -380,6 +384,10 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 description_placeholders.update(
                     {k: str(v) for k, v in placeholders.items()}
                 )
+            except AbortFlow:
+                # An abort is the flow working as intended - already
+                # configured, already in progress - not an unexpected error.
+                raise
             except Exception:  # pylint: disable=broad-except
                 # Same outermost boundary as _async_create_common: a bug here
                 # should surface as "unexpected_error", not crash the flow.

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -64,9 +64,9 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     # Assistant skips migration entirely once entry.version equals this, so a
     # new step that is not reflected here never runs.
     VERSION = 7
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
-    _discovery_info: dict[str, Any] = {}
     DOMAIN = DOMAIN
+    # Annotated, not assigned: a dict here would be shared by every flow.
+    _discovery_info: dict[str, Any]
 
     def is_matching(self, other_flow: "WfRacConfigFlow") -> bool:
         """Return True if two flows are attempting to configure the same device."""
@@ -156,11 +156,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not airco_id:
             raise CannotConnect(reason="unknown reason")
 
-        _LOGGER.info(
-            "Trying to register OperatorId[%s] on Airco[%s]",
-            data[CONF_OPERATOR_ID],
-            data[CONF_AIRCO_ID],
-        )
+        _LOGGER.debug("Registering this controller on airco [%s]", airco_id)
         result = await repository.update_account_info(airco_id, hass.config.time_zone)
         if not result:
             raise CannotConnect(reason="no answer to the registration request")
@@ -242,7 +238,6 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors, placeholders = error.get_errors_and_placeholders(
                     data_schema.schema
                 )
-                errors.update(errors)
                 for key, value in placeholders.items():
                     if isinstance(value, dict):
                         description_placeholders[key] = str(value)

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -440,11 +440,9 @@ class WfRacOptionsFlowHandler(config_entries.OptionsFlowWithReload):
 
     OptionsFlowWithReload rather than OptionsFlow: every option here is read
     once while the device is built (see create_device_from_entry), so a change
-    only takes effect after a reload. Letting the flow do that itself is what
-    replaced the entry update listener - HA deprecated combining a listener
-    with the config flow's own reloading methods (async_update_reload_and_abort
-    and _abort_if_unique_id_configured), which this flow uses, because the two
-    reload the entry twice and race each other.
+    only takes effect after a reload. An update listener must not be combined
+    with the flow's own reloading methods - the two reload the entry twice and
+    race each other.
     """
 
     def _own_entity_ids(self) -> list[str]:

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -1,7 +1,6 @@
 """Constants used by the mitsubishi-wf-rac component."""
 
 from datetime import timedelta
-from homeassistant.const import CONF_ICON, CONF_NAME, CONF_TYPE
 from homeassistant.components.climate.const import (
     HVACMode,
     ClimateEntityFeature,
@@ -18,7 +17,6 @@ DOMAIN = "mitsubishi_wf_rac"
 # WF-RAC branch). Used as the manual-setup default and as the fallback when a
 # discovery announcement carries something else.
 DEFAULT_PORT = 51443
-DEVICES = "wf-rac-devices"
 
 MIN_TIME_BETWEEN_UPDATES=timedelta(seconds=60)
 
@@ -95,20 +93,7 @@ CONF_OVERSHOOT_HEAT = "overshoot_heat"
 CONF_OVERSHOOT_DRY = "overshoot_dry"
 OVERSHOOT_MAX = 3.0
 
-SENSOR_TYPE_TEMPERATURE = "temperature"
 
-SENSOR_TYPES = {
-    ATTR_INSIDE_TEMPERATURE: {
-        CONF_NAME: "Inside Temperature",
-        CONF_ICON: "mdi:thermometer",
-        CONF_TYPE: SENSOR_TYPE_TEMPERATURE,
-    },
-    ATTR_OUTSIDE_TEMPERATURE: {
-        CONF_NAME: "Outside Temperature",
-        CONF_ICON: "mdi:thermometer",
-        CONF_TYPE: SENSOR_TYPE_TEMPERATURE,
-    },
-}
 
 # Heating uses the unit's own Heating TempSetting (10.0°C), which matches
 # HOME_LEAVE_TEMP_HEAT exactly. Cooling does not: the unit's Cooling
@@ -238,14 +223,6 @@ SUPPORTED_FAN_MODES = [
 ]
 
 
-OPERATION_LIST = {
-    # HVAC_MODE_OFF: "Off",
-    HVACMode.HEAT: "Heat",
-    HVACMode.COOL: "Cool",
-    HVACMode.AUTO: "Auto",
-    HVACMode.DRY: "Dry",
-    HVACMode.FAN_ONLY: "Fan",
-}
 
 
 # Optional certificate for the unit's HTTPS stack, looked up in the HA config

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.device_registry import (
     format_mac,
 )
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import (
     AC_CERT_FILENAME,
@@ -777,7 +778,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             return
         if not self._firm_type or not self._wireless_firmware_ver:
             return
-        now = datetime.now()
+        now = dt_util.utcnow()
         if (
             self._last_firmware_check is not None
             and now - self._last_firmware_check < FIRMWARE_CHECK_INTERVAL
@@ -870,8 +871,8 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
 
     def _note_foreign_write(self, evidence: str) -> None:
         if self._foreign_activity_since is None:
-            self._foreign_activity_since = datetime.now()
-        self._foreign_activity_until = datetime.now() + FOREIGN_ACTIVITY_BACKOFF
+            self._foreign_activity_since = dt_util.utcnow()
+        self._foreign_activity_until = dt_util.utcnow() + FOREIGN_ACTIVITY_BACKOFF
         _LOGGER.debug("Another client wrote to [%s]: %s", self.device_name, evidence)
 
     def _settings_snapshot(self) -> dict[str, Any] | None:
@@ -984,7 +985,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             return WRITE_LOCK_RETRY_DELAY.total_seconds()
         # The module compares whole seconds and refuses while `expires` still
         # equals the current one, so land on the far side of the lapse.
-        remaining = expires - datetime.now().timestamp() + 1
+        remaining = expires - dt_util.utcnow().timestamp() + 1
         return max(0.0, min(remaining, WRITE_LOCK_MAX_WAIT.total_seconds()))
 
     def _report_foreign_activity(self) -> None:
@@ -1042,7 +1043,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         are still standing down - see FOREIGN_ACTIVITY_BACKOFF."""
         return (
             self._foreign_activity_until is not None
-            and datetime.now() < self._foreign_activity_until
+            and dt_util.utcnow() < self._foreign_activity_until
         )
 
     def _power_state_is_safe_to_carry(self) -> bool:
@@ -1083,7 +1084,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             # A retry from the previous cycle is still in flight; piling a
             # second request on top is exactly the crowding this avoids.
             return
-        now = datetime.now()
+        now = dt_util.utcnow()
         if (
             self._last_service_data_request is not None
             and now - self._last_service_data_request < SERVICE_DATA_MIN_SPACING
@@ -1116,7 +1117,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         cycle.
         """
         if self._last_command_at is not None and (
-            datetime.now() - self._last_command_at < MIN_TIME_BETWEEN_UPDATES
+            dt_util.utcnow() - self._last_command_at < MIN_TIME_BETWEEN_UPDATES
         ):
             return timedelta(0)
         return SERVICE_DATA_STAMP_BACKDATE
@@ -1234,7 +1235,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         if self._airco is None:
             return
         self._settle_service_data_pause()
-        now = datetime.now()
+        now = dt_util.utcnow()
         if any(getattr(new_airco, name) is not None for name in SERVICE_DATA_FIELDS):
             self._last_service_data_response = now
             if self._service_data_expired:
@@ -1700,7 +1701,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         # A real, set-bit command: mark it so the next operation-data request
         # stamps honestly and renews this command's lock rather than trimming
         # it (see _service_data_stamp_backdate).
-        self._last_command_at = datetime.now()
+        self._last_command_at = dt_util.utcnow()
         try:
             await self.set_airco(params)
         except (WfRacError, KeyError, TypeError, ValueError) as ex:

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -349,7 +349,6 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         # state has always needed it, and relearning costs the unit the same
         # shutdowns every time (see _check_request_stopped_unit).
         self._parser.carry_power_state = carry_power_state
-        self._hass = hass
 
         # Protected state
         self._airco = Aircon()
@@ -782,7 +781,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         ):
             return
         self._last_firmware_check = now
-        self._hass.async_create_task(
+        self.hass.async_create_task(
             self._async_check_firmware_update(
                 self._firm_type, self._wireless_firmware_ver
             )
@@ -793,7 +792,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
     ) -> None:
         """Compare the locally-reported wireless firmware version against the
         manufacturer's latest for this firmType."""
-        latest = await fetch_latest_firmware(self._hass, firm_type)
+        latest = await fetch_latest_firmware(self.hass, firm_type)
         if latest is None or latest.get("wireless") is None:
             return
 
@@ -1094,7 +1093,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         # Background task, not a plain one: it spends most of its life asleep
         # waiting out the offset, and HA cancels background tasks at shutdown
         # instead of waiting for them.
-        self._service_data_task = self._hass.async_create_background_task(
+        self._service_data_task = self.hass.async_create_background_task(
             self._async_request_service_data(service_data_codes),
             name=f"{DOMAIN} service data request {self._airco_id}",
         )
@@ -1304,7 +1303,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         """Add account (operator id) from the airco"""
         try:
             result = await self._api.update_account_info(
-                self._airco_id, self._hass.config.time_zone
+                self._airco_id, self.hass.config.time_zone
             )
         except (WfRacError, KeyError, TypeError):
             _LOGGER.warning("Could not add account from airco %s", self._airco_id)
@@ -1433,7 +1432,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         # in front of us, and a restart that forgot it would put the unit
         # through the same shutdowns again to learn the same thing.
         entry = self.config_entry
-        self._hass.config_entries.async_update_entry(
+        self.hass.config_entries.async_update_entry(
             entry, data={**entry.data, CONF_CARRY_POWER_STATE: True}
         )
         _LOGGER.warning(
@@ -1446,7 +1445,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             self.device_name,
         )
         ir.async_create_issue(
-            self._hass,
+            self.hass,
             DOMAIN,
             request_stops_unit_issue_id(self.entry_id),
             is_fixable=False,
@@ -1457,7 +1456,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
 
     def _report_registration_full(self) -> None:
         ir.async_create_issue(
-            self._hass,
+            self.hass,
             DOMAIN,
             registration_full_issue_id(self.entry_id),
             is_fixable=False,
@@ -1468,7 +1467,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
 
     def _clear_registration_full_issue(self) -> None:
         ir.async_delete_issue(
-            self._hass, DOMAIN, registration_full_issue_id(self.entry_id)
+            self.hass, DOMAIN, registration_full_issue_id(self.entry_id)
         )
 
     async def set_airco(

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -315,6 +315,10 @@ class _ServiceDataParser(RacParser):
 class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instance-attributes
     """Device Class"""
 
+    # Narrowed from the base class's optional: this integration never builds a
+    # Device without one.
+    config_entry: ConfigEntry
+
     def __init__(  # pylint: disable=too-many-arguments
             self,
             hass: HomeAssistant,
@@ -430,19 +434,12 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
 
     @property
     def options(self) -> Mapping[str, Any]:
-        """Options of the config entry that owns this device.
-
-        DataUpdateCoordinator.config_entry is typed as optional because a
-        coordinator need not have one - this integration always constructs a
-        Device with one, passed to super().__init__() above.
-        """
-        assert self.config_entry is not None
+        """Options of the config entry that owns this device."""
         return self.config_entry.options
 
     @property
     def entry_id(self) -> str:
         """Id of the config entry that owns this device - see options above."""
-        assert self.config_entry is not None
         return self.config_entry.entry_id
 
     @property
@@ -1436,7 +1433,6 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         # in front of us, and a restart that forgot it would put the unit
         # through the same shutdowns again to learn the same thing.
         entry = self.config_entry
-        assert entry is not None  # always constructed with one - see options
         self._hass.config_entries.async_update_entry(
             entry, data={**entry.data, CONF_CARRY_POWER_STATE: True}
         )

--- a/custom_components/mitsubishi_wf_rac/diagnostics.py
+++ b/custom_components/mitsubishi_wf_rac/diagnostics.py
@@ -17,7 +17,6 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: MitsubishiWfRacConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    del hass
     device = entry.runtime_data.device
 
     diagnostics = {

--- a/custom_components/mitsubishi_wf_rac/diagnostics.py
+++ b/custom_components/mitsubishi_wf_rac/diagnostics.py
@@ -41,9 +41,8 @@ async def async_get_config_entry_diagnostics(
             "auto_heating": device.auto_heating,
             "port": device.port,
         },
-        # Refusals are logged at debug now (see Repository._report_result_code),
-        # so this is where a report shows whether the unit has been declining
-        # commands and how often.
+        # Refusals only reach the log at debug level, so this is where a
+        # report shows whether the unit has been declining commands.
         "result_codes": device.result_codes,
         "aircon": asdict(device.airco),
     }

--- a/custom_components/mitsubishi_wf_rac/entity.py
+++ b/custom_components/mitsubishi_wf_rac/entity.py
@@ -34,6 +34,7 @@ class WfRacEntity(CoordinatorEntity[Device]):
         super().__init__(device, context=context)
         self._device = device
         self._attr_device_info = device.device_info
+        self._state_unreadable = False
 
     @property
     def _hvac_mode_from_operation(self) -> HVACMode:
@@ -69,12 +70,23 @@ class WfRacEntity(CoordinatorEntity[Device]):
 
     @property
     def available(self) -> bool:
+        """Return whether the airco is currently reachable."""
         # Device tracks its own retry-tolerant availability (see
-        # Device._set_availability()), and entities follow that rather than the
-        # coordinator's last_update_success: an expected missed poll leaves the
-        # coordinator successful on purpose, so this is the only thing that
-        # decides whether entities go unavailable.
-        return self._device.available
+        # Device._set_availability()): an expected missed poll leaves the
+        # coordinator successful on purpose, so last_update_success alone
+        # would not hold the entity up. It still has to be honoured, though -
+        # an unexpected failure raises UpdateFailed and only shows there.
+        return super().available and self._device.available
+
+    def _mark_state_unknown(self) -> None:
+        """Drop the attributes that carry this entity's state.
+
+        Overridden per platform. Called when a frame arrives that the entity
+        cannot read: the unit answered and still takes commands, so it is not
+        unavailable - its state is merely unknown until a frame it can read
+        comes along.
+        """
+        raise NotImplementedError
 
     def _update_state(self) -> None:
         """Refresh entity state from the coordinator. Every concrete
@@ -83,25 +95,34 @@ class WfRacEntity(CoordinatorEntity[Device]):
         raise NotImplementedError
 
     def _apply_state(self) -> None:
-        """Read the current frame into this entity, or mark the device down.
+        """Read the current frame into this entity, or mark it unknown.
 
         Every read goes through here, the very first one included. A frame can
-        decode cleanly and still carry a value an entity cannot translate, and
-        letting that escape a constructor is not the same failure as letting it
-        escape a poll: the platform never finishes setting up, so the config
-        entry loads without a single one of its entities and only a traceback
-        to say why. The same value arriving one frame later merely takes the
-        device unavailable until it reads again.
+        decode cleanly and still carry a value this entity cannot translate,
+        and letting that escape a constructor is not the same failure as
+        letting it escape a poll: the platform never finishes setting up, so
+        the config entry loads with no entity at all and only a traceback to
+        say why. The same value arriving one frame later merely makes this
+        entity's state unknown.
         """
         try:
             self._update_state()
         except (IndexError, KeyError, AttributeError, ValueError):
-            # entity_id is only assigned once the entity is added, so on the
-            # first read the unique id is all there is to name it by.
-            _LOGGER.warning(
-                "Could not update %s", self.entity_id or self._attr_unique_id
-            )
-            self._device.set_available(False)
+            # Once, with the traceback: which field was missing is the whole
+            # diagnosis, and the condition holds until the unit sends
+            # something else - a line per poll would say nothing more.
+            if not self._state_unreadable:
+                # entity_id is only assigned once the entity is added, so on
+                # the first read the unique id is all there is to name it by.
+                _LOGGER.warning(
+                    "Could not update %s",
+                    self.entity_id or self._attr_unique_id,
+                    exc_info=True,
+                )
+            self._state_unreadable = True
+            self._mark_state_unknown()
+        else:
+            self._state_unreadable = False
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/mitsubishi_wf_rac/entity.py
+++ b/custom_components/mitsubishi_wf_rac/entity.py
@@ -30,6 +30,8 @@ class WfRacEntity(CoordinatorEntity[Device]):
     command completes.
     """
 
+    _attr_has_entity_name = True
+
     def __init__(self, device: Device, context: Any | None = None) -> None:
         super().__init__(device, context=context)
         self._device = device

--- a/custom_components/mitsubishi_wf_rac/entity.py
+++ b/custom_components/mitsubishi_wf_rac/entity.py
@@ -57,8 +57,7 @@ class WfRacEntity(CoordinatorEntity[Device]):
         is unset (None), which is what keeps single-target_offset installs
         unchanged. Lives on the base entity so the climate write path, the
         climate read-back path and the target temperature sensor can never
-        resolve a different offset for the same mode (see beta2: that
-        divergence is what caused the target_temperature re-send loop).
+        resolve a different offset for the same mode.
         """
         options = self._device.options
         base_offset = options.get(CONF_TARGET_OFFSET, 0.0)

--- a/custom_components/mitsubishi_wf_rac/firmware_check.py
+++ b/custom_components/mitsubishi_wf_rac/firmware_check.py
@@ -1,5 +1,8 @@
 """Cloud check for available WF-RAC wireless-module firmware updates.
 
+HACS only: an undocumented manufacturer endpoint reached with an imitated
+user agent. Not defensible in a core review, and not ported.
+
 Queries the manufacturer's `server/getFirmware` endpoint - unauthenticated,
 no account/Cognito token involved, same call the official app makes before
 showing "update available". Field names come from the app's own

--- a/custom_components/mitsubishi_wf_rac/icons.json
+++ b/custom_components/mitsubishi_wf_rac/icons.json
@@ -37,6 +37,31 @@
             "reset_energy_total": {
                 "default": "mdi:restart"
             }
+        },
+        "sensor": {
+            "connected_accounts": {
+                "default": "mdi:account-group"
+            },
+            "eev_pulses": {
+                "default": "mdi:pulse"
+            },
+            "eev_position": {
+                "default": "mdi:valve"
+            }
+        },
+        "select": {
+            "horizontal_swing": {
+                "default": "mdi:weather-dust"
+            },
+            "vertical_swing": {
+                "default": "mdi:weather-dust"
+            },
+            "fan_speed": {
+                "default": "mdi:fan"
+            },
+            "home_leave_mode": {
+                "default": "mdi:home-export-outline"
+            }
         }
     }
 }

--- a/custom_components/mitsubishi_wf_rac/number.py
+++ b/custom_components/mitsubishi_wf_rac/number.py
@@ -18,13 +18,8 @@ from pywfrac import HomeLeaveModeSetting
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-# Zero, not one, although this platform writes: the serialisation the module
-# needs already lives in the coordinator, which holds a send lock around the
-# request and spaces requests by MIN_TIME_BETWEEN_REQUESTS. A platform
-# semaphore on top of that only stops actions issued together - a scene, an
-# automation step that fans out - from reaching the coordinator's
-# consolidation window together, and those are exactly the ones worth
-# merging into a single frame.
+# Zero although this platform writes: the coordinator already serialises and
+# spaces every request.
 PARALLEL_UPDATES = 0
 
 # Same bounds as the temp_rule_*/temp_setting_* fields in services.yaml's

--- a/custom_components/mitsubishi_wf_rac/number.py
+++ b/custom_components/mitsubishi_wf_rac/number.py
@@ -103,6 +103,9 @@ class HomeLeaveModeNumber(WfRacEntity, NumberEntity):
             else self._device.airco.HomeLeaveModeForHeating
         )
 
+    def _mark_state_unknown(self) -> None:
+        self._attr_native_value = None
+
     def _update_state(self) -> None:
         # WfRacEntity.available reflects device connectivity, not per-value
         # readiness - a not-yet-requested Home Leave value just reads as

--- a/custom_components/mitsubishi_wf_rac/number.py
+++ b/custom_components/mitsubishi_wf_rac/number.py
@@ -73,9 +73,7 @@ class HomeLeaveModeNumber(WfRacEntity, NumberEntity):
     # diagnostic sensors. Disabled by default though, same as those sensors
     # were: a niche away-mode feature, not everyone with a HomeLeaveMode-
     # capable model wants six extra entities on their device page.
-    _attr_entity_category = None
     _attr_entity_registry_enabled_default = False
-    _attr_has_entity_name: bool = True
     _attr_device_class = NumberDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_native_min_value = HOME_LEAVE_TEMP_MIN

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -57,7 +57,7 @@ async def async_setup_entry(
     """Setup select entries"""
 
     device: Device = entry.runtime_data.device
-    _LOGGER.info("Setup Fan, Horizontal and Vertical Select: %s, %s", device.device_name, device.airco_id)
+    _LOGGER.debug("Setup selects for: %s, %s", device.device_name, device.airco_id)
     entities = [HorizontalSwingSelect(device), VerticalSwingSelect(device), FanSpeedSelect(device)]
 
     # Same VacantProperty capability gate as OccupancyBinarySensor in
@@ -81,7 +81,6 @@ class HorizontalSwingSelect(WfRacEntity, SelectEntity):
     """Select component to set the horizontal swing direction of the airco"""
 
     _attr_translation_key = "horizontal_swing"
-    _attr_has_entity_name: bool = True
 
     def __init__(self, device: Device) -> None:
         super().__init__(device)
@@ -139,7 +138,6 @@ class VerticalSwingSelect(WfRacEntity, SelectEntity):
     """Select component to set the vertical swing direction of the airco"""
 
     _attr_translation_key = "vertical_swing"
-    _attr_has_entity_name: bool = True
 
     def __init__(self, device: Device) -> None:
         super().__init__(device)
@@ -195,7 +193,6 @@ class FanSpeedSelect(WfRacEntity, SelectEntity):
     """Select component to set the fan speed of the airco"""
 
     _attr_translation_key = "fan_speed"
-    _attr_has_entity_name: bool = True
 
     def __init__(self, device: Device) -> None:
         super().__init__(device)
@@ -243,7 +240,6 @@ class HomeLeaveModeSelect(WfRacEntity, SelectEntity):
     """
 
     _attr_translation_key = "home_leave_mode"
-    _attr_has_entity_name: bool = True
     _attr_icon = "mdi:home-export-outline"
 
     def __init__(self, device: Device) -> None:
@@ -322,7 +318,6 @@ class HomeLeaveAirFlowSelect(WfRacEntity, SelectEntity):
     # niche away-mode feature, not everyone with a HomeLeaveMode-capable
     # model wants extra entities on their device page.
     _attr_entity_registry_enabled_default = False
-    _attr_has_entity_name: bool = True
 
     def __init__(self, device: Device, mode: str) -> None:
         super().__init__(device)

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -74,6 +74,9 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
+# HACS only: the climate entity already exposes horizontal swing, vertical
+# swing and fan speed. These three are a second, flatter control surface for
+# dashboards; core takes the climate entity alone.
 class HorizontalSwingSelect(WfRacEntity, SelectEntity):
     """Select component to set the horizontal swing direction of the airco"""
 

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -29,13 +29,8 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-# Zero, not one, although this platform writes: the serialisation the module
-# needs already lives in the coordinator, which holds a send lock around the
-# request and spaces requests by MIN_TIME_BETWEEN_REQUESTS. A platform
-# semaphore on top of that only stops actions issued together - a scene, an
-# automation step that fans out - from reaching the coordinator's
-# consolidation window together, and those are exactly the ones worth
-# merging into a single frame.
+# Zero although this platform writes: the coordinator already serialises and
+# spaces every request.
 PARALLEL_UPDATES = 0
 
 HOME_LEAVE_MODE_OFF = "off"

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -97,6 +97,9 @@ class HorizontalSwingSelect(WfRacEntity, SelectEntity):
             ]
         )
 
+    def _mark_state_unknown(self) -> None:
+        self._attr_current_option = None
+
     def _update_state(self) -> None:
         self.select_option(
             SWING_3D_AUTO
@@ -151,6 +154,9 @@ class VerticalSwingSelect(WfRacEntity, SelectEntity):
             ]
         )
 
+    def _mark_state_unknown(self) -> None:
+        self._attr_current_option = None
+
     def _update_state(self) -> None:
         self.select_option(
             SWING_3D_AUTO
@@ -195,6 +201,9 @@ class FanSpeedSelect(WfRacEntity, SelectEntity):
         self._attr_icon = "mdi:fan"
         self._attr_unique_id = f"{DOMAIN}-{self._device.airco_id}-fan-speed"
         self._apply_state()
+
+    def _mark_state_unknown(self) -> None:
+        self._attr_current_option = None
 
     def _update_state(self) -> None:
         # Same marker check as the climate entity's fan mode: the library
@@ -243,6 +252,9 @@ class HomeLeaveModeSelect(WfRacEntity, SelectEntity):
         ]
         self._attr_unique_id = f"{DOMAIN}-{self._device.airco_id}-home-leave-mode"
         self._apply_state()
+
+    def _mark_state_unknown(self) -> None:
+        self._attr_current_option = None
 
     def _update_state(self) -> None:
         airco = self._device.airco
@@ -325,6 +337,9 @@ class HomeLeaveAirFlowSelect(WfRacEntity, SelectEntity):
             if self._mode == "cooling"
             else self._device.airco.HomeLeaveModeForHeating
         )
+
+    def _mark_state_unknown(self) -> None:
+        self._attr_current_option = None
 
     def _update_state(self) -> None:
         setting = self._current_setting()

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -86,7 +86,6 @@ class HorizontalSwingSelect(WfRacEntity, SelectEntity):
         super().__init__(device)
         self._attr_entity_registry_enabled_default = device.swing_selects_enabled_default
         self._attr_options = SUPPORT_SWING_HORIZONTAL_MODES
-        self._attr_icon = "mdi:weather-dust"
         self._attr_unique_id = (
             f"{DOMAIN}-{self._device.airco_id}-horizontal-swing-direction"
         )
@@ -143,7 +142,6 @@ class VerticalSwingSelect(WfRacEntity, SelectEntity):
         super().__init__(device)
         self._attr_entity_registry_enabled_default = device.swing_selects_enabled_default
         self._attr_options = SUPPORT_SWING_MODES
-        self._attr_icon = "mdi:weather-dust"
         self._attr_unique_id = (
             f"{DOMAIN}-{self._device.airco_id}-vertical-swing-direction"
         )
@@ -198,7 +196,6 @@ class FanSpeedSelect(WfRacEntity, SelectEntity):
         super().__init__(device)
         self._attr_entity_registry_enabled_default = device.swing_selects_enabled_default
         self._attr_options = SUPPORTED_FAN_MODES
-        self._attr_icon = "mdi:fan"
         self._attr_unique_id = f"{DOMAIN}-{self._device.airco_id}-fan-speed"
         self._apply_state()
 
@@ -240,7 +237,6 @@ class HomeLeaveModeSelect(WfRacEntity, SelectEntity):
     """
 
     _attr_translation_key = "home_leave_mode"
-    _attr_icon = "mdi:home-export-outline"
 
     def __init__(self, device: Device) -> None:
         super().__init__(device)

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -219,6 +219,9 @@ class DiagnosticsSensor(WfRacEntity, SensorEntity):
         self._attr_translation_key = type_map.get(custom_type, custom_type)
         self._apply_state()
 
+    def _mark_state_unknown(self) -> None:
+        self._attr_native_value = None
+
     def _update_state(self) -> None:
         if self._custom_type == CONF_OPERATOR_ID:
             self._attr_native_value = self._device.operator_id
@@ -275,6 +278,9 @@ class TemperatureSensor(WfRacEntity, SensorEntity):
         self._attr_translation_key = type_map.get(custom_type, custom_type)
         self._apply_state()
 
+    def _mark_state_unknown(self) -> None:
+        self._attr_native_value = None
+
     def _update_state(self) -> None:
         if self._custom_type == ATTR_INSIDE_TEMPERATURE:
             indoor_offset = self._device.options.get(CONF_INDOOR_OFFSET, 0.0)
@@ -310,6 +316,9 @@ class EnergySensor(WfRacEntity, SensorEntity):
         super().__init__(device)
         self._attr_unique_id = f"{DOMAIN}-{self._device.airco_id}-energy-sensor"
         self._apply_state()
+
+    def _mark_state_unknown(self) -> None:
+        self._attr_native_value = None
 
     def _update_state(self) -> None:
         self._attr_native_value = self._device.airco.Electric
@@ -404,6 +413,9 @@ class EnergyTotalSensor(WfRacEntity, RestoreSensor):
         self._apply_state()
         self.async_write_ha_state()
 
+    def _mark_state_unknown(self) -> None:
+        self._attr_native_value = None
+
     def _update_state(self) -> None:
         raw = self._device.airco.Electric
         if raw is None:
@@ -481,6 +493,9 @@ class ServiceDataSensor(WfRacEntity, SensorEntity):
             self._attr_device_class = SensorDeviceClass.TEMPERATURE
             self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._apply_state()
+
+    def _mark_state_unknown(self) -> None:
+        self._attr_native_value = None
 
     def _update_state(self) -> None:
         self._attr_native_value = getattr(self._device.airco, self._FIELD_BY_TYPE[self._custom_type])

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -86,30 +86,30 @@ async def async_setup_entry(
 
     _LOGGER.debug("Setup sensors for: %s, %s", device.device_name, device.airco_id)
     entities = [
-        TemperatureSensor(device, "Indoor", ATTR_INSIDE_TEMPERATURE),
-        TemperatureSensor(device, "Outdoor", ATTR_OUTSIDE_TEMPERATURE),
-        TemperatureSensor(device, "Target", ATTR_TARGET_TEMPERATURE, False),
+        TemperatureSensor(device, ATTR_INSIDE_TEMPERATURE),
+        TemperatureSensor(device, ATTR_OUTSIDE_TEMPERATURE),
+        TemperatureSensor(device, ATTR_TARGET_TEMPERATURE, False),
         # The `enable` flag decides entity_registry_enabled_default: on for
         # readings that say something about the unit, off for the internal
         # plumbing (ids, session, addressing) that only matters when
         # diagnosing a connection problem. All of these come out of the
         # regular poll, so enabling one costs no extra request.
-        DiagnosticsSensor(device, "Airco ID", CONF_AIRCO_ID),
-        DiagnosticsSensor(device, "Operator ID", CONF_OPERATOR_ID),
-        DiagnosticsSensor(device, "Device ID", ATTR_DEVICE_ID),
-        DiagnosticsSensor(device, "IP", CONF_HOST),
-        DiagnosticsSensor(device, "Accounts", ATTR_CONNECTED_ACCOUNTS),
-        DiagnosticsSensor(device, "Error", CONF_ERROR, True),
-        DiagnosticsSensor(device, "Updated By", ATTR_UPDATED_BY, True),
-        DiagnosticsSensor(device, "Account Expires", ATTR_ACCOUNT_EXPIRES),
+        DiagnosticsSensor(device, CONF_AIRCO_ID),
+        DiagnosticsSensor(device, CONF_OPERATOR_ID),
+        DiagnosticsSensor(device, ATTR_DEVICE_ID),
+        DiagnosticsSensor(device, CONF_HOST),
+        DiagnosticsSensor(device, ATTR_CONNECTED_ACCOUNTS),
+        DiagnosticsSensor(device, CONF_ERROR, True),
+        DiagnosticsSensor(device, ATTR_UPDATED_BY, True),
+        DiagnosticsSensor(device, ATTR_ACCOUNT_EXPIRES),
         # Off by default: mirrors the unit's own "LED ON" display-light
         # setting (see wf-rac-module-reference.md §2.8), which nobody has
         # switched off on either test unit - a constant 1 is the default,
         # not a broken read.
-        DiagnosticsSensor(device, "LED Status", ATTR_LED_STATUS),
-        DiagnosticsSensor(device, "Auto Heating", ATTR_AUTO_HEATING, True),
-        DiagnosticsSensor(device, "Model Nr", ATTR_MODEL_NR),
-        DiagnosticsSensor(device, "Cool Hot Judge", ATTR_COOL_HOT_JUDGE),
+        DiagnosticsSensor(device, ATTR_LED_STATUS),
+        DiagnosticsSensor(device, ATTR_AUTO_HEATING, True),
+        DiagnosticsSensor(device, ATTR_MODEL_NR),
+        DiagnosticsSensor(device, ATTR_COOL_HOT_JUDGE),
     ]
     if device.airco.Electric is not None:
         entities.append(EnergySensor(device))
@@ -186,37 +186,16 @@ class DiagnosticsSensor(WfRacEntity, SensorEntity):
     _attr_entity_category: EntityCategory | None = EntityCategory.DIAGNOSTIC
 
     def __init__(
-        self, device: Device, name: str, custom_type: str, enable: bool = False
+        self, device: Device, custom_type: str, enable: bool = False
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device)
         self._attr_entity_registry_enabled_default = enable
         self._custom_type = custom_type
-        self._attr_native_unit_of_measurement = (
-            "Accounts" if custom_type == ATTR_CONNECTED_ACCOUNTS else None
-        )
-        self._attr_icon = (
-            "mdi:account-group" if custom_type == ATTR_CONNECTED_ACCOUNTS else None
-        )
         self._attr_unique_id = (
             f"{DOMAIN}-{self._device.airco_id}-{self._custom_type}-sensor"
         )
-        # Map custom_type to translation key
-        type_map = {
-            "airco_id": "airco_id",
-            "operator_id": "operator_id",
-            "device_id": "device_id",
-            "host": "host",
-            "connected_accounts": "connected_accounts",
-            "error": "error",
-            "updated_by": "updated_by",
-            "account_expires": "account_expires",
-            "led_status": "led_status",
-            "auto_heating": "auto_heating",
-            "model_nr": "model_nr",
-            "cool_hot_judge": "cool_hot_judge",
-        }
-        self._attr_translation_key = type_map.get(custom_type, custom_type)
+        self._attr_translation_key = custom_type
         self._apply_state()
 
     def _mark_state_unknown(self) -> None:
@@ -260,7 +239,15 @@ class TemperatureSensor(WfRacEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, device: Device, name: str, custom_type: str, enable: bool = True) -> None:
+    _TRANSLATION_KEYS = {
+        "inside_temperature": "indoor",
+        "outside_temperature": "outdoor",
+        "target_temperature": "target",
+    }
+
+    def __init__(
+        self, device: Device, custom_type: str, enable: bool = True
+    ) -> None:
         """Initialize the sensor."""
         super().__init__(device)
         self._custom_type = custom_type
@@ -268,13 +255,7 @@ class TemperatureSensor(WfRacEntity, SensorEntity):
         self._attr_unique_id = (
             f"{DOMAIN}-{self._device.airco_id}-{self._custom_type}-sensor"
         )
-        # Map custom_type to translation key
-        type_map = {
-            "inside_temperature": "indoor",
-            "outside_temperature": "outdoor",
-            "target_temperature": "target"
-        }
-        self._attr_translation_key = type_map.get(custom_type, custom_type)
+        self._attr_translation_key = self._TRANSLATION_KEYS[custom_type]
         self._apply_state()
 
     def _mark_state_unknown(self) -> None:
@@ -484,10 +465,8 @@ class ServiceDataSensor(WfRacEntity, SensorEntity):
             self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         elif custom_type == ATTR_EEV_PULSES:
             self._attr_native_unit_of_measurement = "pulses"
-            self._attr_icon = "mdi:pulse"
         elif custom_type == ATTR_EEV_POSITION:
             self._attr_native_unit_of_measurement = PERCENTAGE
-            self._attr_icon = "mdi:valve"
         elif custom_type in (ATTR_INDOOR_COIL_TEMP, ATTR_INDOOR_COIL_OUTLET_TEMP):
             self._attr_device_class = SensorDeviceClass.TEMPERATURE
             self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -84,7 +84,7 @@ async def async_setup_entry(
 
     device: Device = entry.runtime_data.device
 
-    _LOGGER.info("Setup: %s, %s", device.device_name, device.airco_id)
+    _LOGGER.debug("Setup sensors for: %s, %s", device.device_name, device.airco_id)
     entities = [
         TemperatureSensor(device, "Indoor", ATTR_INSIDE_TEMPERATURE),
         TemperatureSensor(device, "Outdoor", ATTR_OUTSIDE_TEMPERATURE),
@@ -184,7 +184,6 @@ class DiagnosticsSensor(WfRacEntity, SensorEntity):
     """Representation of a Sensor."""
 
     _attr_entity_category: EntityCategory | None = EntityCategory.DIAGNOSTIC
-    _attr_has_entity_name: bool = True
 
     def __init__(
         self, device: Device, name: str, custom_type: str, enable: bool = False
@@ -260,7 +259,6 @@ class TemperatureSensor(WfRacEntity, SensorEntity):
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_has_entity_name: bool = True
 
     def __init__(self, device: Device, name: str, custom_type: str, enable: bool = True) -> None:
         """Initialize the sensor."""
@@ -310,7 +308,6 @@ class EnergySensor(WfRacEntity, SensorEntity):
     _attr_native_unit_of_measurement: str | None = UnitOfEnergy.KILO_WATT_HOUR
     _attr_device_class: SensorDeviceClass | None = SensorDeviceClass.ENERGY
     _attr_state_class: SensorStateClass | None = SensorStateClass.TOTAL_INCREASING
-    _attr_has_entity_name: bool = True
 
     def __init__(self, device: Device) -> None:
         """Initialize the sensor."""
@@ -371,7 +368,6 @@ class EnergyTotalSensor(WfRacEntity, RestoreSensor):
     _attr_native_unit_of_measurement: str | None = UnitOfEnergy.KILO_WATT_HOUR
     _attr_device_class: SensorDeviceClass | None = SensorDeviceClass.ENERGY
     _attr_state_class: SensorStateClass | None = SensorStateClass.TOTAL_INCREASING
-    _attr_has_entity_name: bool = True
     _attr_suggested_display_precision: int | None = 2
 
     def __init__(self, device: Device) -> None:
@@ -447,7 +443,6 @@ class ServiceDataSensor(WfRacEntity, SensorEntity):
     only those segments.
     """
 
-    _attr_has_entity_name = True
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -196,6 +196,9 @@ class DiagnosticsSensor(WfRacEntity, SensorEntity):
             f"{DOMAIN}-{self._device.airco_id}-{self._custom_type}-sensor"
         )
         self._attr_translation_key = custom_type
+        if custom_type == ATTR_COOL_HOT_JUDGE:
+            self._attr_device_class = SensorDeviceClass.ENUM
+            self._attr_options = ["cooling", "heating"]
         self._apply_state()
 
     def _mark_state_unknown(self) -> None:

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -158,6 +158,7 @@ async def async_set_energy_total(entity: SensorEntity, call: ServiceCall) -> Non
     await entity.async_set_total(call.data["value"])
 
 
+# HACS only: removes entities only earlier HACS releases ever created.
 def _async_remove_home_leave_mode_sensors(hass: HomeAssistant, device: Device) -> None:
     """Drop the former Home Leave Mode diagnostic sensors from the entity
     registry.
@@ -349,6 +350,9 @@ class EnergyTotalExtraStoredData(SensorExtraStoredData):
         )
 
 
+# HACS only: a resetting counter is expressed with TOTAL_INCREASING and the
+# utility_meter helper in core; this accumulates it in the integration and
+# takes a settable total, which core does not do.
 class EnergyTotalSensor(WfRacEntity, RestoreSensor):
     """Lifetime energy total, accumulated from the unit's per-run counter.
 

--- a/custom_components/mitsubishi_wf_rac/services.py
+++ b/custom_components/mitsubishi_wf_rac/services.py
@@ -21,6 +21,8 @@ from homeassistant.helpers.service import async_register_platform_entity_service
 from pywfrac.parser import EXTERNAL_TEMPERATURE_MAX, EXTERNAL_TEMPERATURE_MIN
 
 from .const import (
+    SUPPORT_SWING_HORIZONTAL_MODES,
+    SUPPORT_SWING_MODES,
     DOMAIN,
     SERVICE_REQUEST_HOME_LEAVE_MODE_STATUS,
     SERVICE_SET_ENERGY_TOTAL,
@@ -39,13 +41,16 @@ def async_setup_services(hass: HomeAssistant) -> None:
     # is a cycle, by the time async_setup runs it is not.
     from .sensor import async_set_energy_total  # noqa: PLC0415  pylint: disable=import-outside-toplevel
 
+    # HACS only: climate.set_swing_mode and climate.set_swing_horizontal_mode
+    # already do this, and binding func= directly skips the base class's own
+    # mode validation - hence vol.In here, which it would otherwise do.
     async_register_platform_entity_service(
         hass,
         DOMAIN,
         SERVICE_SET_HORIZONTAL_SWING_MODE,
         entity_domain=Platform.CLIMATE,
         func="async_set_swing_horizontal_mode",
-        schema={vol.Required("swing_mode"): cv.string},
+        schema={vol.Required("swing_mode"): vol.In(SUPPORT_SWING_HORIZONTAL_MODES)},
     )
 
     async_register_platform_entity_service(
@@ -54,7 +59,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_SET_VERTICAL_SWING_MODE,
         entity_domain=Platform.CLIMATE,
         func="async_set_swing_mode",
-        schema={vol.Required("swing_mode"): cv.string},
+        schema={vol.Required("swing_mode"): vol.In(SUPPORT_SWING_MODES)},
     )
 
     # HomeLeaveMode (Tag 248, capability index 7) - deliberately actions, not

--- a/custom_components/mitsubishi_wf_rac/services.py
+++ b/custom_components/mitsubishi_wf_rac/services.py
@@ -15,7 +15,6 @@ import voluptuous as vol
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import async_register_platform_entity_service
 
 from pywfrac.parser import EXTERNAL_TEMPERATURE_MAX, EXTERNAL_TEMPERATURE_MIN

--- a/custom_components/mitsubishi_wf_rac/services.py
+++ b/custom_components/mitsubishi_wf_rac/services.py
@@ -1,12 +1,9 @@
 """Entity service actions of the WF-RAC integration.
 
-Registered from async_setup rather than from the platforms themselves: with
-the platform-level API the actions only existed once a config entry had
-finished setting up its climate/sensor platform, so a device that was
-unreachable at startup left the actions missing from the UI and from any
-automation that referenced them. Registering here makes them independent of
-that - the entities a call resolves to are still restricted to this
-integration's own, the helper takes care of that.
+Registered from async_setup, not from the platforms: an action registered by
+a platform is missing from the UI and from automations until a config entry
+finishes setting that platform up, which a device unreachable at startup
+never does. Calls still resolve only to this integration's entities.
 """
 
 from __future__ import annotations

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -198,7 +198,11 @@
         "name": "Model Nr"
       },
       "cool_hot_judge": {
-        "name": "Cool Hot Judge"
+        "name": "Cool Hot Judge",
+        "state": {
+          "cooling": "Cooling",
+          "heating": "Heating"
+        }
       },
       "energy_usage": {
         "name": "Energy Usage (current run)"

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -174,91 +174,91 @@
         "name": "Device ID"
       },
       "host": {
-        "name": "IP"
+        "name": "IP address"
       },
       "connected_accounts": {
-        "name": "Accounts"
+        "name": "Connected accounts"
       },
       "error": {
         "name": "Error"
       },
       "updated_by": {
-        "name": "Updated By"
+        "name": "Updated by"
       },
       "account_expires": {
-        "name": "Account Expires"
+        "name": "Account expires"
       },
       "led_status": {
-        "name": "LED Status"
+        "name": "LED status"
       },
       "auto_heating": {
-        "name": "Auto Heating"
+        "name": "Auto heating"
       },
       "model_nr": {
-        "name": "Model Nr"
+        "name": "Model number"
       },
       "cool_hot_judge": {
-        "name": "Cool Hot Judge",
+        "name": "Cool hot judge",
         "state": {
           "cooling": "Cooling",
           "heating": "Heating"
         }
       },
       "energy_usage": {
-        "name": "Energy Usage (current run)"
+        "name": "Energy usage (current run)"
       },
       "energy_usage_total": {
-        "name": "Energy Usage Total"
+        "name": "Energy usage total"
       },
       "compressor_frequency": {
-        "name": "Compressor Frequency"
+        "name": "Compressor frequency"
       },
       "compressor_frequency_raw": {
-        "name": "Compressor Frequency (raw)"
+        "name": "Compressor frequency (raw)"
       },
       "operating_current": {
-        "name": "Operating Current"
+        "name": "Operating current"
       },
       "operating_current_raw": {
-        "name": "Operating Current (raw)"
+        "name": "Operating current (raw)"
       },
       "hot_gas_temp": {
-        "name": "Hot Gas Temperature"
+        "name": "Hot gas temperature"
       },
       "hot_gas_temp_raw": {
-        "name": "Hot Gas Temperature (raw)"
+        "name": "Hot gas temperature (raw)"
       },
       "eev_pulses": {
-        "name": "EEV Pulses"
+        "name": "EEV pulses"
       },
       "eev_position": {
-        "name": "EEV Position"
+        "name": "EEV position"
       },
       "indoor_coil_temp": {
-        "name": "Indoor Coil Temperature"
+        "name": "Indoor coil temperature"
       },
       "indoor_coil_outlet_temp": {
-        "name": "Indoor Coil Outlet Temperature"
+        "name": "Indoor coil outlet temperature"
       },
       "indoor_coil_raw": {
-        "name": "Indoor Coil Temperature (raw)"
+        "name": "Indoor coil temperature (raw)"
       },
       "indoor_coil_outlet_raw": {
-        "name": "Indoor Coil Outlet Temperature (raw)"
+        "name": "Indoor coil outlet temperature (raw)"
       },
       "outdoor_coil_raw": {
-        "name": "Outdoor Coil Temperature (raw)"
+        "name": "Outdoor coil temperature (raw)"
       },
       "discharge_superheat_raw": {
-        "name": "Discharge Superheat (raw)"
+        "name": "Discharge superheat (raw)"
       },
       "protection_raw": {
-        "name": "Protection Number (raw)"
+        "name": "Protection number (raw)"
       }
     },
     "update": {
       "firmware_update": {
-        "name": "Firmware Update"
+        "name": "Firmware update"
       }
     },
     "climate": {
@@ -301,7 +301,7 @@
     },
     "select": {
       "horizontal_swing": {
-        "name": "Horizontal Swing Direction",
+        "name": "Horizontal swing direction",
         "state": {
           "left_right_auto": "Left/Right Auto",
           "left_left": "Left-Left",
@@ -315,7 +315,7 @@
         }
       },
       "vertical_swing": {
-        "name": "Vertical Swing Direction",
+        "name": "Vertical swing direction",
         "state": {
           "up_down_auto": "Up/Down Auto",
           "highest": "Highest",
@@ -326,7 +326,7 @@
         }
       },
       "fan_speed": {
-        "name": "Fan Speed",
+        "name": "Fan speed",
         "state": {
           "auto": "Auto",
           "quiet": "Quiet",
@@ -336,7 +336,7 @@
         }
       },
       "home_leave_mode": {
-        "name": "Home Leave Mode",
+        "name": "Home Leave mode",
         "state": {
           "off": "Off",
           "away_cool": "Away Cooling",
@@ -344,7 +344,7 @@
         }
       },
       "home_leave_cooling_air_flow": {
-        "name": "Home Leave Cooling Air Flow",
+        "name": "Home Leave cooling air flow",
         "state": {
           "auto": "Auto",
           "1": "1",
@@ -354,7 +354,7 @@
         }
       },
       "home_leave_heating_air_flow": {
-        "name": "Home Leave Heating Air Flow",
+        "name": "Home Leave heating air flow",
         "state": {
           "auto": "Auto",
           "1": "1",
@@ -366,16 +366,16 @@
     },
     "number": {
       "home_leave_cooling_temp_rule": {
-        "name": "Home Leave Cooling Outdoor Temp. Threshold"
+        "name": "Home Leave cooling outdoor temperature threshold"
       },
       "home_leave_cooling_temp_setting": {
-        "name": "Home Leave Cooling Target Room Temp."
+        "name": "Home Leave cooling target room temperature"
       },
       "home_leave_heating_temp_rule": {
-        "name": "Home Leave Heating Outdoor Temp. Threshold"
+        "name": "Home Leave heating outdoor temperature threshold"
       },
       "home_leave_heating_temp_setting": {
-        "name": "Home Leave Heating Target Room Temp."
+        "name": "Home Leave heating target room temperature"
       }
     },
     "binary_sensor": {
@@ -386,10 +386,10 @@
         "name": "Presence"
       },
       "compressor": {
-        "name": "Compressor Demand"
+        "name": "Compressor demand"
       },
       "external_control": {
-        "name": "External Control"
+        "name": "External control"
       },
       "external_temperature_active": {
         "name": "Indoor temperature override"
@@ -397,7 +397,7 @@
     },
     "button": {
       "reset_energy_total": {
-        "name": "Reset Energy Usage Total"
+        "name": "Reset energy usage total"
       }
     }
   }

--- a/custom_components/mitsubishi_wf_rac/switch.py
+++ b/custom_components/mitsubishi_wf_rac/switch.py
@@ -19,13 +19,8 @@ from .coordinator import Device
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-# Zero, not one, although this platform writes: the serialisation the module
-# needs already lives in the coordinator, which holds a send lock around the
-# request and spaces requests by MIN_TIME_BETWEEN_REQUESTS. A platform
-# semaphore on top of that only stops actions issued together - a scene, an
-# automation step that fans out - from reaching the coordinator's
-# consolidation window together, and those are exactly the ones worth
-# merging into a single frame.
+# Zero although this platform writes: the coordinator already serialises and
+# spaces every request.
 PARALLEL_UPDATES = 0
 
 

--- a/custom_components/mitsubishi_wf_rac/switch.py
+++ b/custom_components/mitsubishi_wf_rac/switch.py
@@ -1,4 +1,9 @@
-"""for switch integration."""
+"""Registry cleanup for switches this integration no longer creates.
+
+HACS only: the platform adds no entities. It exists to drop two switches
+that earlier HACS releases created, and core never published either, so
+nothing here is ported.
+"""
 # pylint: disable = too-few-public-methods
 
 from __future__ import annotations

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -315,7 +315,11 @@
         "name": "Model Nr"
       },
       "cool_hot_judge": {
-        "name": "Cool Hot Judge"
+        "name": "Cool Hot Judge",
+        "state": {
+          "cooling": "Cooling",
+          "heating": "Heating"
+        }
       },
       "energy_usage": {
         "name": "Energy Usage (current run)"

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -194,7 +194,7 @@
     },
     "select": {
       "horizontal_swing": {
-        "name": "Horizontal Swing Direction",
+        "name": "Horizontal swing direction",
         "state": {
           "left_right_auto": "Left/Right Auto",
           "left_left": "Left-Left",
@@ -208,7 +208,7 @@
         }
       },
       "vertical_swing": {
-        "name": "Vertical Swing Direction",
+        "name": "Vertical swing direction",
         "state": {
           "up_down_auto": "Up/Down Auto",
           "highest": "Highest",
@@ -219,7 +219,7 @@
         }
       },
       "fan_speed": {
-        "name": "Fan Speed",
+        "name": "Fan speed",
         "state": {
           "auto": "Auto",
           "quiet": "Quiet",
@@ -229,7 +229,7 @@
         }
       },
       "home_leave_mode": {
-        "name": "Home Leave Mode",
+        "name": "Home Leave mode",
         "state": {
           "off": "Off",
           "away_cool": "Away Cooling",
@@ -237,7 +237,7 @@
         }
       },
       "home_leave_cooling_air_flow": {
-        "name": "Home Leave Cooling Air Flow",
+        "name": "Home Leave cooling air flow",
         "state": {
           "auto": "Auto",
           "1": "1",
@@ -247,7 +247,7 @@
         }
       },
       "home_leave_heating_air_flow": {
-        "name": "Home Leave Heating Air Flow",
+        "name": "Home Leave heating air flow",
         "state": {
           "auto": "Auto",
           "1": "1",
@@ -259,16 +259,16 @@
     },
     "number": {
       "home_leave_cooling_temp_rule": {
-        "name": "Home Leave Cooling Outdoor Temp. Threshold"
+        "name": "Home Leave cooling outdoor temperature threshold"
       },
       "home_leave_cooling_temp_setting": {
-        "name": "Home Leave Cooling Target Room Temp."
+        "name": "Home Leave cooling target room temperature"
       },
       "home_leave_heating_temp_rule": {
-        "name": "Home Leave Heating Outdoor Temp. Threshold"
+        "name": "Home Leave heating outdoor temperature threshold"
       },
       "home_leave_heating_temp_setting": {
-        "name": "Home Leave Heating Target Room Temp."
+        "name": "Home Leave heating target room temperature"
       }
     },
     "sensor": {
@@ -291,86 +291,86 @@
         "name": "Device ID"
       },
       "host": {
-        "name": "IP"
+        "name": "IP address"
       },
       "connected_accounts": {
-        "name": "Accounts"
+        "name": "Connected accounts"
       },
       "error": {
         "name": "Error"
       },
       "updated_by": {
-        "name": "Updated By"
+        "name": "Updated by"
       },
       "account_expires": {
-        "name": "Account Expires"
+        "name": "Account expires"
       },
       "led_status": {
-        "name": "LED Status"
+        "name": "LED status"
       },
       "auto_heating": {
-        "name": "Auto Heating"
+        "name": "Auto heating"
       },
       "model_nr": {
-        "name": "Model Nr"
+        "name": "Model number"
       },
       "cool_hot_judge": {
-        "name": "Cool Hot Judge",
+        "name": "Cool hot judge",
         "state": {
           "cooling": "Cooling",
           "heating": "Heating"
         }
       },
       "energy_usage": {
-        "name": "Energy Usage (current run)"
+        "name": "Energy usage (current run)"
       },
       "energy_usage_total": {
-        "name": "Energy Usage Total"
+        "name": "Energy usage total"
       },
       "compressor_frequency": {
-        "name": "Compressor Frequency"
+        "name": "Compressor frequency"
       },
       "compressor_frequency_raw": {
-        "name": "Compressor Frequency (raw)"
+        "name": "Compressor frequency (raw)"
       },
       "operating_current": {
-        "name": "Operating Current"
+        "name": "Operating current"
       },
       "operating_current_raw": {
-        "name": "Operating Current (raw)"
+        "name": "Operating current (raw)"
       },
       "hot_gas_temp": {
-        "name": "Hot Gas Temperature"
+        "name": "Hot gas temperature"
       },
       "hot_gas_temp_raw": {
-        "name": "Hot Gas Temperature (raw)"
+        "name": "Hot gas temperature (raw)"
       },
       "eev_pulses": {
-        "name": "EEV Pulses"
+        "name": "EEV pulses"
       },
       "eev_position": {
-        "name": "EEV Position"
+        "name": "EEV position"
       },
       "indoor_coil_temp": {
-        "name": "Indoor Coil Temperature"
+        "name": "Indoor coil temperature"
       },
       "indoor_coil_outlet_temp": {
-        "name": "Indoor Coil Outlet Temperature"
+        "name": "Indoor coil outlet temperature"
       },
       "indoor_coil_raw": {
-        "name": "Indoor Coil Temperature (raw)"
+        "name": "Indoor coil temperature (raw)"
       },
       "indoor_coil_outlet_raw": {
-        "name": "Indoor Coil Outlet Temperature (raw)"
+        "name": "Indoor coil outlet temperature (raw)"
       },
       "outdoor_coil_raw": {
-        "name": "Outdoor Coil Temperature (raw)"
+        "name": "Outdoor coil temperature (raw)"
       },
       "discharge_superheat_raw": {
-        "name": "Discharge Superheat (raw)"
+        "name": "Discharge superheat (raw)"
       },
       "protection_raw": {
-        "name": "Protection Number (raw)"
+        "name": "Protection number (raw)"
       }
     },
     "binary_sensor": {
@@ -381,10 +381,10 @@
         "name": "Presence"
       },
       "compressor": {
-        "name": "Compressor Demand"
+        "name": "Compressor demand"
       },
       "external_control": {
-        "name": "External Control"
+        "name": "External control"
       },
       "external_temperature_active": {
         "name": "Indoor temperature override"
@@ -393,12 +393,12 @@
     "switch": {},
     "update": {
       "firmware_update": {
-        "name": "Firmware Update"
+        "name": "Firmware update"
       }
     },
     "button": {
       "reset_energy_total": {
-        "name": "Reset Energy Usage Total"
+        "name": "Reset energy usage total"
       }
     }
   }

--- a/custom_components/mitsubishi_wf_rac/update.py
+++ b/custom_components/mitsubishi_wf_rac/update.py
@@ -49,7 +49,6 @@ class FirmwareUpdateEntity(WfRacEntity, UpdateEntity):
     itself while switched off, so triggering an install isn't offered here.
     """
 
-    _attr_has_entity_name = True
     _attr_translation_key = "firmware_update"
     _attr_device_class = UpdateDeviceClass.FIRMWARE
     # Reports only; installing is the module's own business (see the class

--- a/custom_components/mitsubishi_wf_rac/update.py
+++ b/custom_components/mitsubishi_wf_rac/update.py
@@ -1,4 +1,8 @@
-"""for update integration (firmware-update-available indicator)."""
+"""for update integration (firmware-update-available indicator).
+
+HACS only: it reports what firmware_check.py finds, so it goes wherever
+that goes.
+"""
 # pylint: disable = too-few-public-methods
 
 from __future__ import annotations

--- a/custom_components/mitsubishi_wf_rac/update.py
+++ b/custom_components/mitsubishi_wf_rac/update.py
@@ -58,6 +58,10 @@ class FirmwareUpdateEntity(WfRacEntity, UpdateEntity):
         self._attr_unique_id = f"{DOMAIN}-{device.airco_id}-firmware-update"
         self._apply_state()
 
+    def _mark_state_unknown(self) -> None:
+        self._attr_installed_version = None
+        self._attr_latest_version = None
+
     def _update_state(self) -> None:
         self._attr_installed_version = self._device.wireless_firmware_version
         latest = self._device.latest_wireless_firmware_version

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -787,9 +787,12 @@ async def test_unknown_fan_step_leaves_the_entity_constructed(device, monkeypatc
 
     # Constructing must not raise: the platform would never finish setting up
     # and the entry would load without a climate entity at all.
-    AircoClimate(device)
+    entity = AircoClimate(device)
 
-    set_available.assert_called_once_with(False)
+    # The unit answered and still takes commands, so only this entity's state
+    # is unknown - the device stays as available as it was.
+    assert entity.hvac_mode is None
+    set_available.assert_not_called()
 
 
 async def test_unknown_fan_step_is_recognised_by_name(device, monkeypatch):

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -229,7 +229,7 @@ async def test_round_trip_symmetry_survives_unit_being_off(device):
 
 # --- the Target sensor agrees with the climate entity ---------------------
 #
-# TemperatureSensor("Target") shows the same setpoint as the climate entity,
+# The target temperature sensor shows the same setpoint as the climate entity,
 # derived from the same PresetTemp, so it has to resolve the offset the same
 # way. Adding only the global CONF_TARGET_OFFSET there made the two disagree
 # by the difference as soon as a per-mode override was configured.
@@ -254,7 +254,7 @@ async def test_target_sensor_matches_climate_entity(device, hvac_mode, override_
     device.airco.OperationMode = HVAC_TRANSLATION[hvac_mode]
 
     climate = AircoClimate(device)
-    sensor = TemperatureSensor(device, "Target", ATTR_TARGET_TEMPERATURE, False)
+    sensor = TemperatureSensor(device, ATTR_TARGET_TEMPERATURE, False)
     climate._update_state()
     sensor._update_state()
 

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -115,7 +115,6 @@ async def test_target_offset_zero_is_identity(device):
     assert entity._attr_target_temperature == 23
 
 
-# --- per-mode target_offset resolver ------------------------------------
 #
 # CONF_TARGET_OFFSET_COOL/_HEAT are optional per-mode overrides that must
 # fall back to the single CONF_TARGET_OFFSET when unset (None, not 0.0),
@@ -169,7 +168,6 @@ async def test_resolve_target_offset_ignores_overrides_for_other_modes(device, h
     assert entity._resolve_target_offset(hvac_mode) == 1.0
 
 
-# --- round-trip symmetry across modes ------------------------------------
 #
 # Regression guard for the 2026.9.1-beta2 fix: the write path (subtract) and
 # the read-back path (add) must resolve the *same* offset for the same mode,
@@ -227,7 +225,6 @@ async def test_round_trip_symmetry_survives_unit_being_off(device):
     assert entity._attr_target_temperature == 21
 
 
-# --- the Target sensor agrees with the climate entity ---------------------
 #
 # The target temperature sensor shows the same setpoint as the climate entity,
 # derived from the same PresetTemp, so it has to resolve the offset the same
@@ -772,7 +769,6 @@ async def test_set_preset_none_restores_a_normal_setpoint(device):
     assert sent == {AirconCommands.PresetTemp: NORMAL_TEMP}
 
 
-# --- an unreadable fan step ---------------------------------------------
 #
 # pywfrac 0.1.3 reports a fan nibble it cannot decode as AIRFLOW_UNKNOWN,
 # one past the end of FAN_MODE_TRANSLATION. Up to 0.1.1 the same nibble
@@ -813,7 +809,6 @@ async def test_unknown_fan_step_is_recognised_by_name(device, monkeypatch):
         AircoClimate(device)._update_state()
 
 
-# --- the offset moves the range, not the value behind the user's back -----
 #
 # The device is held to its own range; what the user sets and reads back is
 # that value plus the target offset. Advertising the device's range and

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -61,9 +61,6 @@ def bypass_entry_setup():
         yield
 
 
-# --- user flow --------------------------------------------------------
-
-
 async def test_user_flow_shows_form_with_no_input(hass: HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -112,8 +109,6 @@ async def test_user_flow_invalid_host_shows_error(hass: HomeAssistant):
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"host": "invalid_host"}
     repo.get_airco_id.assert_not_awaited()
-
-
 
 
 async def test_user_flow_host_already_configured_shows_error(hass: HomeAssistant):
@@ -258,9 +253,6 @@ async def test_user_flow_reuses_operator_and_device_id_from_existing_entry(hass:
     assert result["data"][CONF_DEVICE_ID] == "shared-device-id"
 
 
-# --- reconfigure flow ---------------------------------------------------
-
-
 def _existing_entry(
     hass: HomeAssistant, name="Living Room AC", host="192.168.1.50", port=51443
 ):
@@ -370,9 +362,6 @@ async def test_reconfigure_flow_cannot_connect_shows_error(hass: HomeAssistant):
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
     assert entry.data["host"] == "192.168.1.50"
-
-
-# --- zeroconf discovery -------------------------------------------------
 
 
 def _zeroconf_info(host="192.168.1.50", port=51443, hostname="ac-living-room.local."):
@@ -493,9 +482,6 @@ async def test_zeroconf_discovery_confirm_port_can_be_overridden(hass: HomeAssis
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"]["port"] == 51443
-
-
-# --- options flow --------------------------------------------------------
 
 
 _OPTION_SECTIONS = {
@@ -989,9 +975,6 @@ async def test_options_form_fields_all_have_a_label(hass: HomeAssistant):
     }
 
 
-# --- WfRacConfigFlow.is_matching() / _name ------------------------------
-
-
 def test_is_matching_compares_unique_ids():
     from custom_components.mitsubishi_wf_rac.config_flow import WfRacConfigFlow
 
@@ -1015,8 +998,6 @@ def test_is_matching_without_unique_id_never_matches():
     flow_b.context = {}
 
     assert flow_a.is_matching(flow_b) is False
-
-
 
 
 async def test_a_rediscovery_refreshes_the_address_but_not_the_port(hass: HomeAssistant):

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -152,9 +152,6 @@ async def device(hass):
     await dev.async_shutdown()
 
 
-# --- update() -------------------------------------------------------------
-
-
 async def test_update_success_marks_available_and_parses_state(device):
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     assert await device.update() is True
@@ -291,9 +288,6 @@ async def test_update_malformed_stat_marks_unavailable(device):
     }
     await device.update()
     assert device.available is False
-
-
-# --- set_airco(): diff is merged with current state, not just the params -
 
 
 async def test_set_airco_merges_params_with_current_state(device):
@@ -609,7 +603,6 @@ async def test_set_airco_fetches_state_first_if_unset(device):
     assert device.airco is not None
 
 
-# --- set_airco()'s lock: a call must never snapshot stale state while ----
 # another set_airco() call is still in flight (see conversation - this is
 # the actual fix for the fan/temperature command collision bug).
 
@@ -654,9 +647,6 @@ async def test_set_airco_lock_prevents_stale_snapshot_race(device):
     # been built from the first call's already-committed result.
     assert device.airco.AirFlow == 3
     assert device.airco.PresetTemp == 24.0
-
-
-# --- async_queue_command(): coalesces calls within the consolidation window
 
 
 async def test_async_queue_command_coalesces_into_one_send(device, monkeypatch):
@@ -802,9 +792,6 @@ async def test_home_leave_mode_status_request_does_not_swallow_a_queued_command(
     assert any(block[4] & 0x80 for block in blocks)
 
 
-# --- misc: properties, delete_account(), availability retry, coordinator -
-
-
 async def test_properties_reflect_constructor_args(device):
     assert device.device_name == "Test AC"
     assert device.host == "127.0.0.1"
@@ -940,10 +927,6 @@ async def test_availability_recovers_and_resets_the_failure_count(hass):
     assert dev.available is False
 
 
-
-# --- firmware update check (firmware_check.py) ----------------------------
-
-
 def _stats_response_with_firmware(payload: str, firm_type: str, wireless_ver: str) -> dict:
     return {
         **_stats_response(payload),
@@ -1034,9 +1017,6 @@ async def test_update_firmware_check_failure_leaves_state_unknown(device, monkey
 
     assert device.firmware_update_available is None
     assert device.latest_wireless_firmware_version is None
-
-
-# --- operation-data request (rac_parser.SERVICE_DATA_CODES) ----------------
 
 
 async def test_update_does_not_request_service_data_without_active_entities(device, monkeypatch):
@@ -1538,9 +1518,6 @@ async def test_add_account_returns_none_on_api_error(device):
     assert await device.add_account() is None
 
 
-# --- add_account() / registration-full repair issue -----------------------
-
-
 def _issue(device):
     return ir.async_get(device._hass).async_get_issue(
         DOMAIN, coordinator_module.registration_full_issue_id(device.config_entry.entry_id)
@@ -1884,9 +1861,6 @@ async def test_async_update_data_counts_timeouts_as_connection_failures(
     ]
 
 
-# --- service data is carried between polls, but not forever ---------------
-
-
 async def test_service_data_is_carried_forward_between_polls(device):
     device._airco.CompressorFrequency = 40.0
     device._last_service_data_response = dt_util.utcnow()
@@ -2015,9 +1989,6 @@ async def test_service_data_that_never_arrived_stays_quiet_until_it_is_due(
     device._carry_forward_service_data(Aircon())
 
     assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
-
-
-# --- a unit that stops when asked for readings (#329) ----------------------
 
 
 async def _run_service_data_request(device, monkeypatch, ceiling_ms: int = 1):

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -965,7 +965,7 @@ async def test_update_detects_available_firmware_update(device, monkeypatch):
     await device.update()
     await device.hass.async_block_till_done()
 
-    fetch.assert_awaited_once_with(device._hass, "WF-RAC-HTTPS")
+    fetch.assert_awaited_once_with(device.hass, "WF-RAC-HTTPS")
     assert device.wireless_firmware_version == "025"
     assert device.latest_wireless_firmware_version == "026"
     assert device.firmware_update_available is True
@@ -1519,7 +1519,7 @@ async def test_add_account_returns_none_on_api_error(device):
 
 
 def _issue(device):
-    return ir.async_get(device._hass).async_get_issue(
+    return ir.async_get(device.hass).async_get_issue(
         DOMAIN, coordinator_module.registration_full_issue_id(device.config_entry.entry_id)
     )
 

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -71,6 +71,7 @@ from pywfrac.repository import (
 )
 
 from ..unit.live_captures import LIVE_CAPTURES
+from homeassistant.util import dt as dt_util
 
 OFF_PAYLOAD, _ = LIVE_CAPTURES["off"]
 ON_COOL_PAYLOAD, _ = LIVE_CAPTURES["on_cool"]
@@ -1197,7 +1198,7 @@ async def test_operation_data_backdates_its_timestamp_to_shorten_the_lock(
         coordinator_module.SERVICE_DATA_STAMP_BACKDATE.total_seconds()
     )
 
-    device._last_service_data_request = datetime.now() - one_poll
+    device._last_service_data_request = dt_util.utcnow() - one_poll
     await device.update()
     await asyncio.sleep(0.05)
 
@@ -1207,7 +1208,7 @@ async def test_operation_data_backdates_its_timestamp_to_shorten_the_lock(
         == expected_offset
     )
 
-    device._last_service_data_request = datetime.now() - one_poll
+    device._last_service_data_request = dt_util.utcnow() - one_poll
     await device.update()
     await asyncio.sleep(0.05)
 
@@ -1225,10 +1226,10 @@ async def test_service_data_stamps_honestly_right_after_our_own_command(device):
         == coordinator_module.SERVICE_DATA_STAMP_BACKDATE
     )
 
-    device._last_command_at = datetime.now()
+    device._last_command_at = dt_util.utcnow()
     assert device._service_data_stamp_backdate() == timedelta(0)
 
-    device._last_command_at = datetime.now() - 2 * coordinator_module.MIN_TIME_BETWEEN_UPDATES
+    device._last_command_at = dt_util.utcnow() - 2 * coordinator_module.MIN_TIME_BETWEEN_UPDATES
     assert (
         device._service_data_stamp_backdate()
         == coordinator_module.SERVICE_DATA_STAMP_BACKDATE
@@ -1260,7 +1261,7 @@ async def test_a_refused_write_waits_out_the_lock_that_refused_it(device):
     """
     # Someone else took the lock 40 seconds ago: 20 of its 60 are left.
     device._api.get_aircon_stats.return_value = _stats_response_with_expires(
-        OFF_PAYLOAD, int(datetime.now().timestamp()) - 40 + 60
+        OFF_PAYLOAD, int(dt_util.utcnow().timestamp()) - 40 + 60
     )
 
     delay = await device._async_write_lock_delay()
@@ -1274,7 +1275,7 @@ async def test_a_refused_write_is_never_held_longer_than_a_lock_can_run(device):
     running. No reason to leave a service call hanging on it.
     """
     device._api.get_aircon_stats.return_value = _stats_response_with_expires(
-        OFF_PAYLOAD, int(datetime.now().timestamp()) + 3_600
+        OFF_PAYLOAD, int(dt_util.utcnow().timestamp()) + 3_600
     )
 
     delay = await device._async_write_lock_delay()
@@ -1287,7 +1288,7 @@ async def test_a_refused_write_retries_at_once_when_the_lock_has_lapsed(device):
     else - the MCU, most likely - and nothing is gained by waiting.
     """
     device._api.get_aircon_stats.return_value = _stats_response_with_expires(
-        OFF_PAYLOAD, int(datetime.now().timestamp()) - 30
+        OFF_PAYLOAD, int(dt_util.utcnow().timestamp()) - 30
     )
 
     assert await device._async_write_lock_delay() == 0.0
@@ -1334,7 +1335,7 @@ async def test_no_service_data_request_while_another_client_is_active(device, mo
     _shorten_service_data_timing(monkeypatch)
     _activate_service_data_contexts(device, monkeypatch)
     device.set_airco = set_airco = AsyncMock()
-    device._foreign_activity_until = datetime.now() + timedelta(minutes=3)
+    device._foreign_activity_until = dt_util.utcnow() + timedelta(minutes=3)
 
     device._maybe_request_service_data()
     await asyncio.sleep(0.05)
@@ -1351,20 +1352,20 @@ async def test_operation_data_survives_the_pause_instead_of_expiring(device):
     device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
     await device.update()
     device._airco.CompressorFrequency = 42
-    device._last_service_data_response = datetime.now()
+    device._last_service_data_response = dt_util.utcnow()
 
     # Well past MAX_AGE, but the whole time was spent standing down - the
     # state _detect_foreign_activity() leaves behind when it trips.
-    device._foreign_activity_since = datetime.now() - 2 * SERVICE_DATA_MAX_AGE
-    device._foreign_activity_until = datetime.now() + timedelta(minutes=3)
-    device._last_service_data_response = datetime.now() - 2 * SERVICE_DATA_MAX_AGE
+    device._foreign_activity_since = dt_util.utcnow() - 2 * SERVICE_DATA_MAX_AGE
+    device._foreign_activity_until = dt_util.utcnow() + timedelta(minutes=3)
+    device._last_service_data_response = dt_util.utcnow() - 2 * SERVICE_DATA_MAX_AGE
     await device.update()
     assert device.airco.CompressorFrequency == 42
     assert device._service_data_expired is False
 
     # ...and once it lapses, the age restarts from the resume rather than
     # expiring the readings on the very next poll.
-    device._foreign_activity_until = datetime.now() - timedelta(seconds=1)
+    device._foreign_activity_until = dt_util.utcnow() - timedelta(seconds=1)
     await device.update()
     assert device.airco.CompressorFrequency == 42
     assert device._service_data_expired is False
@@ -1375,7 +1376,7 @@ async def test_operation_data_still_expires_when_the_unit_goes_quiet(device):
     device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
     await device.update()
     device._airco.CompressorFrequency = 42
-    device._last_service_data_response = datetime.now() - 2 * SERVICE_DATA_MAX_AGE
+    device._last_service_data_response = dt_util.utcnow() - 2 * SERVICE_DATA_MAX_AGE
 
     await device.update()
 
@@ -1387,7 +1388,7 @@ async def test_service_data_resumes_once_the_backoff_lapses(device, monkeypatch)
     _shorten_service_data_timing(monkeypatch)
     _activate_service_data_contexts(device, monkeypatch)
     device.set_airco = set_airco = AsyncMock()
-    device._foreign_activity_until = datetime.now() - timedelta(seconds=1)
+    device._foreign_activity_until = dt_util.utcnow() - timedelta(seconds=1)
 
     device._maybe_request_service_data()
     await asyncio.sleep(0.05)
@@ -1742,7 +1743,7 @@ async def test_service_data_survives_a_poll_that_answered_early(device, monkeypa
     _shorten_service_data_timing(monkeypatch)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     device._api.send_airco_command = AsyncMock(side_effect=_echo_send_airco_command)
-    device._last_service_data_request = datetime.now() - (
+    device._last_service_data_request = dt_util.utcnow() - (
         coordinator_module.SERVICE_DATA_REQUEST_INTERVAL - timedelta(milliseconds=100)
     )
 
@@ -1888,7 +1889,7 @@ async def test_async_update_data_counts_timeouts_as_connection_failures(
 
 async def test_service_data_is_carried_forward_between_polls(device):
     device._airco.CompressorFrequency = 40.0
-    device._last_service_data_response = datetime.now()
+    device._last_service_data_response = dt_util.utcnow()
     new_airco = Aircon()
 
     device._carry_forward_service_data(new_airco)
@@ -1900,7 +1901,7 @@ async def test_raw_service_data_is_carried_forward_between_polls(device):
     device._airco.CompressorFrequencyRaw = 0x10C8
     device._airco.OperatingCurrentRaw = 0x04
     device._airco.HotGasTempRaw = 0x15
-    device._last_service_data_response = datetime.now()
+    device._last_service_data_response = dt_util.utcnow()
     new_airco = Aircon()
 
     device._carry_forward_service_data(new_airco)
@@ -1919,7 +1920,7 @@ async def test_unconvertible_coil_reading_is_not_carried_forward(device):
     """
     device._airco.IndoorCoilTemp = 37.5
     device._airco.IndoorCoilRaw = 119
-    device._last_service_data_response = datetime.now()
+    device._last_service_data_response = dt_util.utcnow()
     new_airco = Aircon()
     new_airco.IndoorCoilRaw = 252  # arrived, but off the end of the table
 
@@ -1935,7 +1936,7 @@ async def test_missing_coil_segment_is_still_carried_forward(device):
     """
     device._airco.IndoorCoilTemp = 21.5
     device._airco.IndoorCoilRaw = 88
-    device._last_service_data_response = datetime.now()
+    device._last_service_data_response = dt_util.utcnow()
     new_airco = Aircon()
     new_airco.CompressorFrequency = 40.0  # some other segment did arrive
 
@@ -1950,7 +1951,7 @@ async def test_service_data_expires_when_nothing_fresh_arrives(device):
     reporting a frozen value that looks live.
     """
     device._airco.CompressorFrequency = 40.0
-    device._last_service_data_response = datetime.now() - (
+    device._last_service_data_response = dt_util.utcnow() - (
         coordinator_module.SERVICE_DATA_MAX_AGE + timedelta(seconds=1)
     )
     new_airco = Aircon()
@@ -1963,7 +1964,7 @@ async def test_service_data_expires_when_nothing_fresh_arrives(device):
 async def test_fresh_service_data_restarts_the_clock(device):
     device._airco.CompressorFrequency = 40.0
     device._airco.HotGasTemp = 50.0
-    device._last_service_data_response = datetime.now() - (
+    device._last_service_data_response = dt_util.utcnow() - (
         coordinator_module.SERVICE_DATA_MAX_AGE + timedelta(seconds=1)
     )
     new_airco = Aircon()
@@ -1982,7 +1983,7 @@ async def test_expiring_service_data_warns_once_and_reports_the_recovery(
     """The refusals themselves are routine; running out of values is not."""
     caplog.set_level("DEBUG", logger=coordinator_module.__name__)
     device._airco.CompressorFrequency = 40.0
-    device._last_service_data_response = datetime.now() - (
+    device._last_service_data_response = dt_util.utcnow() - (
         coordinator_module.SERVICE_DATA_MAX_AGE + timedelta(seconds=1)
     )
 
@@ -2009,7 +2010,7 @@ async def test_service_data_that_never_arrived_stays_quiet_until_it_is_due(
 ):
     """A unit asked for the first time has nothing to lose yet."""
     caplog.set_level("DEBUG", logger=coordinator_module.__name__)
-    device._last_service_data_request = datetime.now()
+    device._last_service_data_request = dt_util.utcnow()
 
     device._carry_forward_service_data(Aircon())
 

--- a/tests/integration/test_entity.py
+++ b/tests/integration/test_entity.py
@@ -57,17 +57,22 @@ async def test_coordinator_contexts_include_only_contextual_entities(device):
     contextless_entity._call_on_remove_callbacks()
 
 
-async def test_base_entity_marks_device_unavailable_when_state_update_fails(device, monkeypatch):
+async def test_an_unreadable_frame_marks_the_entity_unknown_not_the_device(
+    device, monkeypatch
+):
+    """The unit answered and still takes commands, so it is not unavailable."""
     entity = WfRacEntity(device)
     entity._update_state = MagicMock(side_effect=ValueError)
+    entity._mark_state_unknown = MagicMock()
     entity.async_write_ha_state = lambda: None
     set_available = MagicMock()
     monkeypatch.setattr(device, "set_available", set_available)
 
-    assert entity.available is device.available
     entity._handle_coordinator_update()
 
-    set_available.assert_called_once_with(False)
+    entity._mark_state_unknown.assert_called_once_with()
+    set_available.assert_not_called()
+    assert entity.available is device.available
 
 
 async def test_apply_state_swallows_a_first_read_that_fails(device, monkeypatch):
@@ -81,12 +86,11 @@ async def test_apply_state_swallows_a_first_read_that_fails(device, monkeypatch)
     entity = WfRacEntity(device)
     entity._attr_unique_id = "airco-id-something"
     entity._update_state = MagicMock(side_effect=IndexError)
-    set_available = MagicMock()
-    monkeypatch.setattr(device, "set_available", set_available)
+    entity._mark_state_unknown = MagicMock()
 
     entity._apply_state()
 
-    set_available.assert_called_once_with(False)
+    entity._mark_state_unknown.assert_called_once_with()
 
 
 async def test_apply_state_names_the_entity_by_unique_id_before_it_is_added(
@@ -96,8 +100,30 @@ async def test_apply_state_names_the_entity_by_unique_id_before_it_is_added(
     entity = WfRacEntity(device)
     entity._attr_unique_id = "airco-id-fan-speed"
     entity._update_state = MagicMock(side_effect=IndexError)
-    monkeypatch.setattr(device, "set_available", MagicMock())
+    entity._mark_state_unknown = MagicMock()
 
     entity._apply_state()
 
     assert "airco-id-fan-speed" in caplog.text
+
+
+async def test_an_unreadable_frame_is_logged_once_and_the_entity_recovers(
+    device, caplog
+):
+    """The condition holds until the unit sends something else."""
+    entity = WfRacEntity(device)
+    entity._attr_unique_id = "airco-id-fan-speed"
+    entity._mark_state_unknown = MagicMock()
+    entity._update_state = MagicMock(side_effect=IndexError)
+
+    entity._apply_state()
+    entity._apply_state()
+
+    assert caplog.text.count("Could not update") == 1
+
+    entity._update_state = MagicMock()
+    entity._apply_state()
+    entity._update_state = MagicMock(side_effect=IndexError)
+    entity._apply_state()
+
+    assert caplog.text.count("Could not update") == 2

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -34,6 +34,7 @@ from custom_components.mitsubishi_wf_rac.coordinator import Device
 from pywfrac import AIRFLOW_UNKNOWN, AirconCommands, HomeLeaveModeSetting
 
 from ..unit.live_captures import LIVE_CAPTURES
+from homeassistant.util import dt as dt_util
 
 
 def _entry(device, options=None):
@@ -170,11 +171,11 @@ async def test_external_control_sensor_follows_the_backoff(platform_device):
     entity = binary_sensor.ExternalControlBinarySensor(platform_device)
     assert entity.is_on is False
 
-    platform_device._foreign_activity_until = datetime.now() + timedelta(minutes=3)
+    platform_device._foreign_activity_until = dt_util.utcnow() + timedelta(minutes=3)
     entity._update_state()
     assert entity.is_on is True
 
-    platform_device._foreign_activity_until = datetime.now() - timedelta(seconds=1)
+    platform_device._foreign_activity_until = dt_util.utcnow() - timedelta(seconds=1)
     entity._update_state()
     assert entity.is_on is False
 
@@ -421,7 +422,7 @@ async def test_fan_speed_select_recognises_an_unreadable_fan_step(platform_devic
     fan = select.FanSpeedSelect(platform_device)
 
     assert fan.current_option is None
-    set_available.assert_called_once_with(False)
+    set_available.assert_not_called()
 
 
 async def test_the_climate_entity_is_the_device_itself(platform_device):

--- a/tests/integration/test_sensor.py
+++ b/tests/integration/test_sensor.py
@@ -34,7 +34,7 @@ async def test_setting_the_total_on_the_wrong_sensor_says_which(
     exactly this: targeting any other sensor has to name the entity instead
     of failing with an AttributeError.
     """
-    wrong = DiagnosticsSensor(platform_device, "Error", "error")
+    wrong = DiagnosticsSensor(platform_device, "error")
     wrong.entity_id = "sensor.living_room_error"
 
     with pytest.raises(ServiceValidationError, match="sensor.living_room_error"):
@@ -73,7 +73,7 @@ async def test_the_judge_reports_nothing_when_it_means_nothing(
     """
     platform_device.airco.Operation = operation
     platform_device.airco.OperationMode = operation_mode
-    sensor = DiagnosticsSensor(platform_device, "Judge", ATTR_COOL_HOT_JUDGE)
+    sensor = DiagnosticsSensor(platform_device, ATTR_COOL_HOT_JUDGE)
 
     sensor._update_state()
 


### PR DESCRIPTION
Home Assistant core's own reviewer instructions were run over the whole component to prepare the follow-up core PRs. Four of the findings are real defects here and are fixed regardless of core.

## Defects

- The `cannot_connect` translation never rendered. `HomeAssistantError` only generates the message when it is built without a positional one, and setup passed an f-string alongside the translation key.
- `AbortFlow` was swallowed by the config flow's outermost handler. It subclasses `HomeAssistantError`, so `already_configured` surfaced as "unexpected error" and the form came back - which is exactly what the unique id exists to prevent.
- An unreadable frame took the whole device offline. One unrecognised fan nibble made every entity on the unit unavailable, and a genuine bug in any `_update_state()` disappeared the same way. Entities mark their own state unknown instead, and the warning is logged once with its traceback rather than every poll.
- Interval arithmetic ran on naive local wall-clock time in nine places. At a DST fall-back that pins `foreign_activity` on for an hour and stalls the operation-data cycle.

## Alignment

- The surfaces that stay here rather than move to core are marked `HACS only`: the empty switch platform, the three selects that duplicate climate attributes, the registry cleanup, `firmware_check.py` and the update entity, `EnergyTotalSensor` with its button and action, and the two swing actions. Those two also gained the mode validation that binding `func=` directly had skipped - an unknown mode surfaced as a raw `KeyError`.
- Dead constants, a self-updating errors dict and `CONNECTION_CLASS` removed; `has_entity_name` set once on the shared base entity instead of in nineteen classes; the coordinator narrows `config_entry` by type instead of asserting three times.
- Icons moved to `icons.json`, `Cool Hot Judge` became a proper enum sensor, and the English entity names are sentence case.
- Comments cut back to what is not obvious: the `PARALLEL_UPDATES` paragraph was repeated verbatim in four platforms, and roughly twenty comments explained what the code used to look like.

339 tests, mypy clean.