### PR TITLE
Carry the unit's state in the operation-data request (#329)

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -211,13 +211,15 @@ async def create_device_from_entry(entry: ConfigEntry, hass: HomeAssistant) -> D
         CONF_AVAILABILITY_RETRY_LIMIT, AVAILABILITY_FAILURE_LIMIT_MIN
     )
     connection_method: str | None = entry.data.get(CONF_CONNECTION_METHOD)
-    carry_power_state: bool = bool(entry.data.get(CONF_CARRY_POWER_STATE, False))
+    # The stored key predates the fix and named only the power bit; the flag
+    # it sets now decides whether the whole state is carried.
+    carries_state: bool = bool(entry.data.get(CONF_CARRY_POWER_STATE, False))
     _device = Device(hass, entry, name, device, port, device_id, operator_id, airco_id,
                      swing_selects_enabled_default,
                      availability_failure_limit=availability_failure_limit,
                      firmware_update_check_enabled=firmware_update_check_enabled,
                      connection_method=connection_method,
-                     carry_power_state=carry_power_state)
+                     status_request_carries_state=carries_state)
     return _device
 
 

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -261,57 +261,6 @@ def registration_full_issue_id(entry_id: str) -> str:
     return f"too_many_devices_{entry_id}"
 
 
-class _ServiceDataParser(RacParser):
-    """RacParser whose operation-data request can carry the unit's own power
-    state back to it.
-
-    The request is built with no set-bits, which on the hardware this was
-    developed against changes nothing (see RacParser.status_request_to_byte).
-    On at least one module - firmType WCBN4612L, issue #329 - the zero in
-    command[2] is applied anyway and reads as "power off", so the unit stops
-    the second the request arrives and again every 60s after that.
-
-    Carrying the current power value together with its set-bit makes the frame
-    confirm the state instead of changing it. Measured against the two indoor
-    units here: result 0, full operation-data trailer, nothing altered, with
-    the unit running and with it switched off.
-
-    Off by default and switched on per device by _note_unit_stopped_on_request(),
-    because it costs something the empty frame does not: the state it carries
-    is up to a poll old, so on a unit that honours set-bits properly this turns
-    a read into a real power write. Which is why only "on" is ever carried, and
-    only while the unit is believed to be running: a confirmation that is wrong
-    can then only fail to change anything.
-    """
-
-    carry_power_state = False
-
-    @override
-    def status_request_to_byte(self, aircon_stat: AirconStat) -> bytearray:
-        stat_byte = super().status_request_to_byte(aircon_stat)
-        if self.carry_power_state and aircon_stat.Operation:
-            # Same encoding as command_to_byte(): bit 0 the value, bit 1 the
-            # set-bit that makes the value count. Only ever "on": the state
-            # this carries is as old as the last poll, and a stale "off" here
-            # is not a confirmation but a shutdown command for a unit somebody
-            # switched on in the meantime (#329). A unit believed off gets no
-            # request at all - see _power_state_is_safe_to_carry - so this is
-            # the second lock on the same door, not the first.
-            stat_byte[2] |= 3
-        # BETA DEBUG (#329) - remove before the final release. The whole
-        # question in that issue is what this frame contains, and reconstructing
-        # it from the base64 in the request log is a step nobody should have to
-        # take twice.
-        _LOGGER.debug(
-            "Operation-data request block: %s (carrying power state: %s, "
-            "unit is %s)",
-            bytes(stat_byte).hex(" "),
-            self.carry_power_state,
-            "on" if aircon_stat.Operation else "off",
-        )
-        return stat_byte
-
-
 class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instance-attributes
     """Device Class"""
 
@@ -333,7 +282,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             availability_failure_limit: int = AVAILABILITY_FAILURE_LIMIT_MIN,
             firmware_update_check_enabled: bool = False,
             connection_method: str | None = None,
-            carry_power_state: bool = False,
+            status_request_carries_state: bool = False,
     ) -> None:
         self._api = Repository(
             async_get_clientsession(hass),
@@ -344,11 +293,11 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             method=connection_method,
             cert_path=hass.config.path(AC_CERT_FILENAME),
         )
-        self._parser = _ServiceDataParser()
-        # Carried over from a previous run: a module that needs the power
-        # state has always needed it, and relearning costs the unit the same
-        # shutdowns every time (see _check_request_stopped_unit).
-        self._parser.carry_power_state = carry_power_state
+        self._parser = RacParser()
+        # Carried over from a previous run: a module that applies a frame it
+        # was not asked to apply has always done so, and relearning costs the
+        # unit the same disturbance every time.
+        self._parser.status_request_carries_state = status_request_carries_state
 
         # Protected state
         self._airco = Aircon()
@@ -1045,20 +994,18 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
     def _power_state_is_safe_to_carry(self) -> bool:
         """Whether an operation-data request may go out right now.
 
-        Only ever False on a unit that needs the power state carried (#329),
-        and only while we believe that unit is off. On such a module the field
-        is applied rather than ignored, so the request is a power write in all
-        but name - and the state it would write is as old as the last poll. A
-        unit switched on with the remote inside that window would be switched
-        straight back off by the very frame meant to confirm its state.
+        Only ever False on a unit whose request has to carry its state
+        (#329), and only while we believe that unit is off. On such a module
+        the block is applied rather than ignored, so the request is a write in
+        all but name.
 
-        Skipped rather than sent with the field left out: without the field
-        this module reads the zero in the block as "off" too, which is the
-        original fault. And a reading taken while the unit is off is worth
-        little anyway - the compressor is stopped and the valve is closed - so
-        nothing much is lost by waiting for the poll that finds it running.
+        Skipped rather than sent empty: without the state this module reads
+        the zeros as a command to clear the settings, which is the original
+        fault. And a reading taken while the unit is off is worth little
+        anyway - the compressor is stopped and the valve is closed - so
+        nothing is lost by waiting for the poll that finds it running.
         """
-        return not self._parser.carry_power_state or bool(
+        return not self._parser.status_request_carries_state or bool(
             self._airco is not None and self._airco.Operation
         )
 
@@ -1118,6 +1065,32 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             return timedelta(0)
         return SERVICE_DATA_STAMP_BACKDATE
 
+    async def _async_read_before_echo(self) -> bool:
+        """Read the unit's state immediately before sending it back.
+
+        A carrying request writes every field it contains, so anything changed
+        at the unit since the last poll would be undone by a state that old.
+        Reading here narrows that window from a poll cycle to one round trip.
+        Only the state is taken: availability, foreign-activity attribution and
+        the firmware fields belong to the poll, and running them from here
+        would attribute this read's own effects to somebody else.
+        """
+        try:
+            response = await self._api.get_aircon_stats(self._airco_id)
+            new_airco = self._parser.translate_bytes(response["airconStat"])
+        except (WfRacError, KeyError, TypeError, ValueError) as ex:
+            _LOGGER.debug(
+                "Could not read [%s] before the operation-data request, "
+                "skipping this cycle: %s",
+                self.device_name,
+                ex,
+            )
+            return False
+        self._carry_forward_home_leave_mode(new_airco)
+        self._carry_forward_service_data(new_airco)
+        self._airco = new_airco
+        return True
+
     async def _async_request_service_data(self, service_data_codes: tuple[int, ...]) -> None:
         """Ask the unit for operation-data segments, offset from the poll and
         retried once if the unit refuses it (see SERVICE_DATA_REQUEST_OFFSET).
@@ -1136,6 +1109,8 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         # timestamp below trades away part of the lock for. The offset stays
         # because it is about spacing requests, not about what they contain -
         # a second request too soon after the poll is what the module refuses.
+        if self._parser.status_request_carries_state and not await self._async_read_before_echo():
+            return
         if not self._power_state_is_safe_to_carry():
             # Re-checked after the sleep, not only when the request was
             # scheduled: the offset is up to half a minute, and the unit going
@@ -1401,7 +1376,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         at the unit, so somebody reached for the remote in the same second and
         this is not our doing.
         """
-        if not was_running or self._parser.carry_power_state:
+        if not was_running or self._parser.status_request_carries_state:
             return
         if self._airco is None or self._airco.Operation:
             self._stopped_on_request = 0
@@ -1427,7 +1402,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 STOPPED_ON_REQUEST_BEFORE_CARRYING,
             )
             return
-        self._parser.carry_power_state = True
+        self._parser.status_request_carries_state = True
         # Written down, not just remembered: this is a property of the module
         # in front of us, and a restart that forgot it would put the unit
         # through the same shutdowns again to learn the same thing.
@@ -1574,7 +1549,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 # other - which is why the narrower flag below is a separate
                 # one and not this same value read twice.
                 self._wrote_since_last_poll = True
-                if not is_status_request or self._parser.carry_power_state:
+                if not is_status_request or self._parser.status_request_carries_state:
                     # A status request's block carries no set-bits, so nothing
                     # in it can explain a setting that moved - unless this is
                     # one of the units we carry the power state for (#329),

--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -15,7 +15,7 @@
   "requirements": [
     "pywfrac==0.1.3"
   ],
-  "version": "2026.9.9-beta5",
+  "version": "2026.9.9-beta6",
   "zeroconf": [
     "_beaver._tcp.local."
   ]

--- a/custom_components/mitsubishi_wf_rac/manifest.json
+++ b/custom_components/mitsubishi_wf_rac/manifest.json
@@ -13,7 +13,7 @@
     "pywfrac"
   ],
   "requirements": [
-    "pywfrac==0.1.3"
+    "pywfrac==0.1.4"
   ],
   "version": "2026.9.9-beta6",
   "zeroconf": [

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -332,9 +332,15 @@ class HomeLeaveAirFlowSelect(WfRacEntity, SelectEntity):
 
     def _update_state(self) -> None:
         setting = self._current_setting()
-        self._attr_current_option = (
-            HOME_LEAVE_AIRFLOW_OPTIONS[setting.AirFlow] if setting is not None else None
-        )
+        if setting is None:
+            self._attr_current_option = None
+            return
+        # Named rather than left to the list index, for the same reason as the
+        # fan speed select: a sixth option would make the marker look like a
+        # real fan step.
+        if setting.AirFlow == AIRFLOW_UNKNOWN:
+            raise IndexError("the unit reported a fan step pywfrac cannot read")
+        self._attr_current_option = HOME_LEAVE_AIRFLOW_OPTIONS[setting.AirFlow]
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,4 @@
 homeassistant>=2026.4.0
 pytest-homeassistant-custom-component
 mypy
-pywfrac==0.1.3
+pywfrac==0.1.4

--- a/requirements-floor.txt
+++ b/requirements-floor.txt
@@ -7,4 +7,4 @@
 # that the number we publish is the number the tests ran against.
 pytest-homeassistant-custom-component==0.13.325
 mypy
-pywfrac==0.1.3
+pywfrac==0.1.4

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -75,6 +75,7 @@ from homeassistant.util import dt as dt_util
 
 OFF_PAYLOAD, _ = LIVE_CAPTURES["off"]
 ON_COOL_PAYLOAD, _ = LIVE_CAPTURES["on_cool"]
+FAN_SPEED_4_PAYLOAD, _ = LIVE_CAPTURES["on_cool_fanspeed4"]
 ON_HEAT_PAYLOAD, _ = LIVE_CAPTURES["on_heat"]
 
 
@@ -2026,17 +2027,17 @@ async def test_a_unit_that_stops_on_our_request_twice_gets_its_power_state_carri
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
     assert device.airco.Operation is True
-    assert device._parser.carry_power_state is False
+    assert device._parser.status_request_carries_state is False
 
     # The unit answers our own request having switched itself off.
     device._api.send_airco_command = AsyncMock(return_value=OFF_PAYLOAD)
     await _run_service_data_request(device, monkeypatch)
-    assert device._parser.carry_power_state is False
+    assert device._parser.status_request_carries_state is False
 
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
     await _run_service_data_request(device, monkeypatch)
-    assert device._parser.carry_power_state is True
+    assert device._parser.status_request_carries_state is True
     # Written down, so the next start does not put the unit through the same
     # shutdowns to learn the same thing (#329, reported again after an update
     # had reset it).
@@ -2054,11 +2055,11 @@ async def test_a_learned_power_state_quirk_survives_a_restart(hass):
     device = Device(
         hass, entry, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id",
         "airco-id", swing_selects_enabled_default=True,
-        carry_power_state=bool(entry.data.get(CONF_CARRY_POWER_STATE, False)),
+        status_request_carries_state=bool(entry.data.get(CONF_CARRY_POWER_STATE, False)),
     )
     device._api = AsyncMock()
 
-    assert device._parser.carry_power_state is True
+    assert device._parser.status_request_carries_state is True
 
     await device.async_shutdown()
 
@@ -2083,7 +2084,7 @@ async def test_a_single_stop_during_our_request_is_not_enough(device, monkeypatc
     await device.update()
     await _run_service_data_request(device, monkeypatch)
 
-    assert device._parser.carry_power_state is False
+    assert device._parser.status_request_carries_state is False
 
 
 async def test_a_unit_started_by_remote_is_still_detected(device, monkeypatch):
@@ -2104,7 +2105,7 @@ async def test_a_unit_started_by_remote_is_still_detected(device, monkeypatch):
         await device.update()
         await _run_service_data_request(device, monkeypatch)
 
-    assert device._parser.carry_power_state is True
+    assert device._parser.status_request_carries_state is True
 
 
 async def test_a_unit_switched_off_at_the_unit_is_not_blamed_on_us(
@@ -2124,7 +2125,7 @@ async def test_a_unit_switched_off_at_the_unit_is_not_blamed_on_us(
     await device.update()
     await _run_service_data_request(device, monkeypatch)
 
-    assert device._parser.carry_power_state is False
+    assert device._parser.status_request_carries_state is False
 
 
 async def test_no_request_goes_out_while_a_carrying_unit_is_believed_off(
@@ -2138,7 +2139,7 @@ async def test_no_request_goes_out_while_a_carrying_unit_is_believed_off(
     """
     device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
     await device.update()
-    device._parser.carry_power_state = True
+    device._parser.status_request_carries_state = True
     device.set_airco = set_airco = AsyncMock()
 
     await _run_service_data_request(device, monkeypatch)
@@ -2153,16 +2154,65 @@ async def test_no_request_goes_out_while_a_carrying_unit_is_believed_off(
     set_airco.assert_awaited()
 
 
-async def test_a_unit_switched_off_inside_the_offset_gets_no_request(
-    device, monkeypatch
-):
-    """The check is repeated after the wait, not only when the request was
-    scheduled: the offset is up to half a minute, and the unit going off inside
-    it is exactly the window this protects.
+async def test_a_carrying_request_echoes_what_it_just_read(device, monkeypatch):
+    """The state is written back, so it has to be the unit's current one.
+
+    Anything changed at the unit since the last poll would otherwise be undone
+    by the very frame meant to read from it.
     """
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
-    device._parser.carry_power_state = True
+    device._parser.status_request_carries_state = True
+    stale_fan = device.airco.AirFlow
+    device.set_airco = AsyncMock()
+
+    monkeypatch.setattr(
+        coordinator_module, "SERVICE_DATA_REQUEST_OFFSET", timedelta(milliseconds=30)
+    )
+    monkeypatch.setattr(coordinator_module, "SERVICE_DATA_MIN_SPACING", timedelta(0))
+    monkeypatch.setattr(device, "async_contexts", lambda: {SERVICE_DATA_EEV_PULSES})
+    device._service_data_offset = timedelta(milliseconds=30)
+    device._maybe_request_service_data()
+
+    # Somebody reaches for the remote while the request waits out its offset.
+    device._api.get_aircon_stats.return_value = _stats_response(FAN_SPEED_4_PAYLOAD)
+    await asyncio.sleep(0.1)
+
+    device.set_airco.assert_awaited()
+    assert device.airco.AirFlow != stale_fan
+
+
+async def test_a_request_that_does_not_carry_state_reads_nothing_extra(
+    device, monkeypatch
+):
+    """A unit that ignores the empty block is not worth an extra request."""
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device.set_airco = AsyncMock()
+
+    monkeypatch.setattr(
+        coordinator_module, "SERVICE_DATA_REQUEST_OFFSET", timedelta(milliseconds=30)
+    )
+    monkeypatch.setattr(coordinator_module, "SERVICE_DATA_MIN_SPACING", timedelta(0))
+    monkeypatch.setattr(device, "async_contexts", lambda: {SERVICE_DATA_EEV_PULSES})
+    device._service_data_offset = timedelta(milliseconds=30)
+    device._api.get_aircon_stats.reset_mock()
+    device._maybe_request_service_data()
+    await asyncio.sleep(0.1)
+
+    device._api.get_aircon_stats.assert_not_awaited()
+
+
+async def test_a_unit_switched_off_inside_the_offset_gets_no_request(
+    device, monkeypatch
+):
+    """The read taken just before the echo decides, not the last poll: the
+    offset is up to half a minute, and the unit going off inside it is exactly
+    the window this protects.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device._parser.status_request_carries_state = True
     device.set_airco = set_airco = AsyncMock()
 
     monkeypatch.setattr(
@@ -2174,32 +2224,33 @@ async def test_a_unit_switched_off_inside_the_offset_gets_no_request(
     device._maybe_request_service_data()
 
     # ... and the unit goes off while the request is still waiting out its
-    # offset.
-    device._airco.Operation = False
+    # offset, which is what the read before the echo finds.
+    device._api.get_aircon_stats.return_value = _stats_response(OFF_PAYLOAD)
     await asyncio.sleep(0.1)
 
     set_airco.assert_not_awaited()
 
 
-async def test_carrying_the_power_state_sets_the_set_bit_with_the_value(device):
-    """Bit 0 is the value, bit 1 the set-bit that makes it count. Without the
-    set-bit the value is what a well-behaved unit ignores - and what the
-    affected one applies.
+async def test_a_carrying_request_writes_the_settings_back_instead_of_zeros(device):
+    """The empty block writes a zero into every field an affected module
+    applies; the carrying one writes the unit's own settings back instead.
     """
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
     stat = AirconStat.from_aircon(device.airco)
     stat.ServiceDataStatusRequest = (SERVICE_DATA_EEV_PULSES,)
 
-    assert device._parser.status_request_to_byte(stat)[2] == 0
+    empty = device._parser.status_request_to_byte(stat)
 
-    device._parser.carry_power_state = True
-    assert device._parser.status_request_to_byte(stat)[2] == 3
+    device._parser.status_request_carries_state = True
+    carried = device._parser.status_request_to_byte(stat)
 
-    # And "off" is never carried: that state is up to a poll old, so it is not
-    # a confirmation but a shutdown for a unit switched on in the meantime.
-    stat.Operation = False
-    assert device._parser.status_request_to_byte(stat)[2] == 0
+    # Power and mode, fan step, setpoint, and the horizontal vane: each of
+    # these is a setting the affected unit cleared on every request.
+    for index in (2, 3, 4, 12):
+        assert empty[index] == 0
+        assert carried[index] != 0
+    assert carried == device._parser.command_to_byte(stat)
 
 
 async def test_the_request_moves_back_towards_the_poll_while_it_keeps_landing(

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -425,6 +425,22 @@ async def test_fan_speed_select_recognises_an_unreadable_fan_step(platform_devic
     set_available.assert_not_called()
 
 
+async def test_home_leave_air_flow_select_recognises_an_unreadable_step(
+    platform_device,
+):
+    """Same marker as the fan speed select, one decode path further in."""
+    platform_device.airco.HomeLeaveModeForCooling = HomeLeaveModeSetting(
+        TempRule=35.0, TempSetting=33.0, AirFlow=AIRFLOW_UNKNOWN
+    )
+    set_available = MagicMock()
+    platform_device.set_available = set_available
+
+    entity = select.HomeLeaveAirFlowSelect(platform_device, "cooling")
+
+    assert entity.current_option is None
+    set_available.assert_not_called()
+
+
 async def test_the_climate_entity_is_the_device_itself(platform_device):
     """It carries the device's name and adds nothing of its own.
 


### PR DESCRIPTION
Replaces #360, which GitHub closed when its base branch was deleted on the merge of #359. Same branch, same commits, retargeted at `main`.

Needs `pywfrac 0.1.4`.

## What the log said

The empty request block assumes a module ignores a value that arrives without its set-bit. The module in #329 does not: it applies the zeros, and every value in the reporter's log follows from that.

| field | sent | what the unit made of it |
| --- | --- | --- |
| byte 4, setpoint | `0` | 0 °C, clamped up to the 10 °C heating floor |
| mode bits | `0` | auto |
| fan nibble | `0` | step 1 |
| vane bits | `0` | both to position 1 |

His Home Leave switch is off, so it was never Home Leave, and carrying only the power bit fixed one field of five.

## The fix

`RacParser.status_request_carries_state` builds the request from the state it is given instead, with every set-bit. That is the shape the manufacturer's own app uses for the one status request it makes: read the state, then send that same state straight back with the request in the trailer.

Carrying state turns the read into a real write, so the state has to be current - a fresh read goes out immediately before, narrowing the window from a poll cycle to one round trip. Only modules detected as needing it do either; the rest keep the empty frame and write nothing.

The parser subclass is gone with it, and the frame log moved into the library where the frame is built.

## Also

`HOME_LEAVE_AIRFLOW_OPTIONS[-1]` read as "4" for a nibble the library could not decode. The library answers with the marker now and the entity says unknown.

## What this cannot show

My own units ignore the empty frame, so the echo never runs here. Only the reporter can confirm it. If it does not help it comes out again - it has no other purpose.

342 tests, mypy clean, verified against the local library.
