### PR TITLE
Read the unit before echoing its state back in the status action

### DIFF
--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -71,10 +71,12 @@ UPDATE_CONSOLIDATION_PERIOD = timedelta(milliseconds=500)
 FIRMWARE_CHECK_INTERVAL = timedelta(hours=24)
 
 # Operation data is requested for active operation-data entities and costs a
-# second request per poll. It stays on the local network and changes nothing on
-# the unit (see RacParser.status_request_to_byte) - but it is a setAirconStat,
-# so it takes the module's 60-second write lock all the same, and while we hold
-# that lock no one else can control the unit at all.
+# second request per poll. It stays on the local network, and on most modules
+# its block carries no set-bits (see RacParser.status_request_to_byte) - but it
+# is a setAirconStat, so it takes the module's 60-second write lock all the
+# same, and while we hold that lock no one else can control the unit at all.
+# On a module that needs its state carried (#329) the block is a full command
+# and the request really does write.
 #
 # The lock's deadline is `now + 60`, where `now` is the `timestamp` field of
 # the request that took it - the module has no RTC and reads its clock from
@@ -1080,8 +1082,8 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             new_airco = self._parser.translate_bytes(response["airconStat"])
         except (WfRacError, KeyError, TypeError, ValueError) as ex:
             _LOGGER.debug(
-                "Could not read [%s] before the operation-data request, "
-                "skipping this cycle: %s",
+                "Could not read [%s] before echoing its state back, "
+                "skipping the request: %s",
                 self.device_name,
                 ex,
             )
@@ -1099,16 +1101,18 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         task that deliberately swallows its errors.
         """
         await asyncio.sleep(self.service_data_offset.total_seconds())
-        # The state this is built from is almost irrelevant: a status request
-        # carries no set-bits, so the unit applies none of it (see
-        # RacParser.status_request_to_byte). Byte 5 is the one exception, since
-        # it has no set-bit to leave out - an active external temperature
-        # override rides along here, and that is the point: this is the frame
-        # that keeps it alive between commands. Note that this also makes the
-        # request a write in the strict sense, which is what the backdated
-        # timestamp below trades away part of the lock for. The offset stays
-        # because it is about spacing requests, not about what they contain -
-        # a second request too soon after the poll is what the module refuses.
+        # What this frame is built from matters on a carrying module and
+        # barely anywhere else: without the quirk the block holds no set-bits
+        # and the unit applies none of it (see
+        # RacParser.status_request_to_byte), with it the block is a full
+        # command. Byte 5 is written either way, having no set-bit to leave
+        # out - an active external temperature override rides along here, and
+        # that is the point: this is the frame that keeps it alive between
+        # commands. That also makes the request a write in the strict sense,
+        # which is what the backdated timestamp below trades away part of the
+        # lock for. The offset stays because it is about spacing requests, not
+        # about what they contain - a second request too soon after the poll is
+        # what the module refuses.
         if self._parser.status_request_carries_state and not await self._async_read_before_echo():
             return
         if not self._power_state_is_safe_to_carry():
@@ -1640,11 +1644,26 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
 
         Sent directly through set_airco() rather than async_queue_command():
         the latter coalesces this with any command queued in the same
-        window, and since this request's own block carries no set-bits (see
+        window, and on a module whose status request holds no set-bits (see
         RacParser.status_request_to_byte), a coalesced real command - e.g. a
         setpoint change - would go out in that same block without its
         set-bit and be silently ignored by the unit.
+
+        On a module that carries its state (#329) the block is a full command
+        instead, so the state it is built from is read fresh first, exactly as
+        the operation-data path does. Without that this action would write back
+        a setting up to a poll old and undo whatever was done at the unit since
+        - including switching a unit off that somebody just turned on.
         """
+        if self._parser.status_request_carries_state and not await self._async_read_before_echo():
+            # A read failure is not a reason to send the old state anyway: on
+            # this module that is a write. The caller asked for a reading, so
+            # say that it did not happen rather than failing silently.
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="status_request_read_failed",
+                translation_placeholders={"device": self.device_name},
+            )
         await self.set_airco(
             {AirconCommands.HomeLeaveModeStatusRequest: True},
             is_status_request=True,

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -151,6 +151,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "Home Leave mode is only available while cooling or heating, not in {hvac_mode}. Switch the unit to cool or heat first, or use the Home Leave Mode select to name the direction."
+    },
+    "status_request_read_failed": {
+      "message": "Could not read the state of the Airco at {device}, so the status request was not sent."
     }
   },
   "entity": {

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -81,6 +81,9 @@
     },
     "external_temperature_source_configured": {
       "message": "Die Innentemperatur wird von der eingerichteten Quell-Entität bestimmt."
+    },
+    "status_request_read_failed": {
+      "message": "Der Zustand des Klimageräts {device} ließ sich nicht lesen, die Statusanfrage wurde deshalb nicht gesendet."
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -81,6 +81,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "Home Leave mode is only available while cooling or heating, not in {hvac_mode}. Switch the unit to cool or heat first, or use the Home Leave Mode select to name the direction."
+    },
+    "status_request_read_failed": {
+      "message": "Could not read the state of the Airco at {device}, so the status request was not sent."
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -81,6 +81,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "留守モードは冷房または暖房のときだけ使えます（現在は {hvac_mode}）。先に冷房か暖房へ切り替えるか、「留守モード」の選択エンティティで留守冷房・留守暖房を直接指定してください。"
+    },
+    "status_request_read_failed": {
+      "message": "エアコン {device} の状態を読み取れなかったため、ステータス要求は送信されませんでした。"
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -81,6 +81,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "Išvykimo režimas veikia tik vėsinant arba šildant, o ne režimu {hvac_mode}. Pirma perjunkite įrenginį į vėsinimą ar šildymą arba pasirinkite kryptį per „Išvykimo režimas“."
+    },
+    "status_request_read_failed": {
+      "message": "Nepavyko nuskaityti oro kondicionieriaus {device} būsenos, todėl būsenos užklausa nebuvo išsiųsta."
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -81,6 +81,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "Afwezigheidsmodus werkt alleen tijdens koelen of verwarmen, niet in {hvac_mode}. Zet de unit eerst op koelen of verwarmen, of kies de richting rechtstreeks met de selectie Afwezigheidsmodus."
+    },
+    "status_request_read_failed": {
+      "message": "De staat van de airco {device} kon niet worden gelezen, daarom is de statusaanvraag niet verstuurd."
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -81,6 +81,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "离家模式仅在制冷或制热时可用，当前为 {hvac_mode}。请先将设备切换到制冷或制热，或直接用“离家模式”选择项指定离家制冷 / 离家制热。"
+    },
+    "status_request_read_failed": {
+      "message": "无法读取空调 {device} 的状态，因此未发送状态请求。"
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -81,6 +81,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "離家模式僅在製冷或製熱時可用，目前為 {hvac_mode}。請先將設備切換到製冷或製熱，或直接用「離家模式」選擇項指定離家製冷／離家製熱。"
+    },
+    "status_request_read_failed": {
+      "message": "無法讀取空調 {device} 的狀態，因此未傳送狀態請求。"
     }
   },
   "issues": {

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -767,8 +767,8 @@ async def test_home_leave_mode_status_request_does_not_swallow_a_queued_command(
     async_queue_command(), so if it landed in the same consolidation window as
     a real command, both were merged into one AirconStat. to_base64() then
     saw HomeLeaveModeStatusRequest set and picked status_request_to_byte(),
-    which carries no set-bits at all - so the real command (here: a setpoint
-    change) went out unset and was silently ignored by the unit. Sending the
+    which on this module carries no set-bits at all - so the real command
+    (here: a setpoint change) went out unset and was silently ignored. Sending the
     status request directly through set_airco() keeps it out of that merge.
     """
     monkeypatch.setattr(coordinator_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
@@ -2229,6 +2229,59 @@ async def test_a_unit_switched_off_inside_the_offset_gets_no_request(
     await asyncio.sleep(0.1)
 
     set_airco.assert_not_awaited()
+
+
+async def test_the_home_leave_status_request_echoes_a_fresh_read(device):
+    """The Home Leave status request is a carrying frame too.
+
+    On an affected module RacParser encodes any status request as a full
+    command block, so this action writes every field it holds - and a state
+    left over from the last poll would undo whatever was done at the unit
+    since.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device._parser.status_request_carries_state = True
+    stale_fan = device.airco.AirFlow
+    device.set_airco = set_airco = AsyncMock()
+
+    # Somebody reaches for the remote between the poll and the action.
+    device._api.get_aircon_stats.return_value = _stats_response(FAN_SPEED_4_PAYLOAD)
+    await device.async_request_home_leave_mode_status()
+
+    set_airco.assert_awaited()
+    assert device.airco.AirFlow != stale_fan
+
+
+async def test_the_home_leave_status_request_does_not_send_a_state_it_could_not_read(
+    device,
+):
+    """Sending the old state anyway is a write on this module. The caller
+    asked for a reading, so the failure has to reach it."""
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device._parser.status_request_carries_state = True
+    device.set_airco = set_airco = AsyncMock()
+    device._api.get_aircon_stats.side_effect = WfRacError("boom")
+
+    with pytest.raises(HomeAssistantError):
+        await device.async_request_home_leave_mode_status()
+
+    set_airco.assert_not_awaited()
+
+
+async def test_a_plain_home_leave_status_request_reads_nothing_extra(device):
+    """Without the quirk the block holds no set-bits, so there is nothing to
+    echo and no reason to spend a second round trip."""
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device.set_airco = set_airco = AsyncMock()
+    device._api.get_aircon_stats.reset_mock()
+
+    await device.async_request_home_leave_mode_status()
+
+    set_airco.assert_awaited()
+    device._api.get_aircon_stats.assert_not_awaited()
 
 
 async def test_a_carrying_request_writes_the_settings_back_instead_of_zeros(device):


### PR DESCRIPTION
## What

`async_request_home_leave_mode_status()` went straight into `set_airco()` with no guard. On a module that carries its state (#329), `RacParser` encodes *any* status request as a full command block with set-bits — including this one — built from `self._airco`, which is up to a poll old.

Two ways that hurts, both the #329 damage through a second door:

- a setpoint changed at the remote since the last poll is written back
- a unit somebody just switched on is switched off again

The operation-data path has been guarded against exactly this since #361 (`_async_read_before_echo`). The action now uses the same guard, and raises instead of falling back on the state it already has — on this module, sending that state is a write, and the caller asked for a reading.

Unaffected modules are untouched: their block still holds no set-bits, so there is nothing to echo and no extra round trip.

## Also

Three comments claimed a status request carries no set-bits *at all*. True for every other module, not true here since the frame started carrying state — one of them sat two lines above the guard that exists because of it.

## Tests

Three new, verified against the unpatched code: the first two fail without the fix, the third pins that an unaffected module spends no extra request. 345 pass, mypy clean.