### PR TITLE
Tell the user what went wrong, and keep a reconfigure on its own unit

### DIFF
--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -121,7 +121,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             airco_id = await repository.get_airco_id()
-        except (WfRacError, KeyError, TypeError) as query_failed:
+        except (WfRacError, KeyError, TypeError, ValueError) as query_failed:
             # A discovery announcement has been seen carrying a port the module
             # does not serve. The port is fixed in the firmware and not
             # user-settable, so rather than failing on a value the device
@@ -148,7 +148,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             try:
                 airco_id = await repository.get_airco_id()
-            except (WfRacError, KeyError, TypeError) as retry_failed:
+            except (WfRacError, KeyError, TypeError, ValueError) as retry_failed:
                 raise CannotConnect(reason=str(retry_failed)) from retry_failed
             data[CONF_PORT] = DEFAULT_PORT
 
@@ -157,10 +157,20 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             raise CannotConnect(reason="unknown reason")
 
         _LOGGER.debug("Registering this controller on airco [%s]", airco_id)
-        result = await repository.update_account_info(airco_id, hass.config.time_zone)
-        if not result:
-            raise CannotConnect(reason="no answer to the registration request")
-        if int(result["result"]) == 2:
+        try:
+            result = await repository.update_account_info(airco_id, hass.config.time_zone)
+            if not result:
+                raise CannotConnect(reason="no answer to the registration request")
+            registration_result = int(result["result"])
+        except (WfRacError, KeyError, TypeError, ValueError) as register_failed:
+            # Same treatment as the query above: this is the second request of
+            # the two, and the module answers only one caller at a time, so a
+            # timeout here is an ordinary outcome and belongs in the form, not
+            # in "unexpected error". ValueError covers a body that is not the
+            # JSON we expect - what a wrong IP with some other HTTP service
+            # behind it returns.
+            raise CannotConnect(reason=str(register_failed)) from register_failed
+        if registration_result == 2:
             raise TooManyDevicesRegistered
 
         return data
@@ -365,6 +375,13 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 info = await self._async_register_airco(
                     self.hass, data, exclude_entry_id=reconfigure_entry.entry_id
                 )
+
+                # The address changed, the unit behind it must not: every
+                # entity's unique id is built from the airco id, so writing a
+                # different one here renames them all, orphans the originals
+                # and leaves discovery unable to recognise either unit.
+                await self.async_set_unique_id(info[CONF_AIRCO_ID].lower())
+                self._abort_if_unique_id_mismatch(reason="wrong_device")
 
                 new_data = {**reconfigure_entry.data, **data}
 

--- a/custom_components/mitsubishi_wf_rac/services.py
+++ b/custom_components/mitsubishi_wf_rac/services.py
@@ -28,6 +28,13 @@ from .const import (
     SERVICE_SET_VERTICAL_SWING_MODE,
 )
 
+# Home Leave thresholds go on the wire as int(value * 2) in a single byte and
+# come back as raw / 2, so this is the whole range the unit can hold and hand
+# back unchanged. Unbounded, a mistyped 200 was masked to 144 and written as
+# 72 °C without a word (services.yaml's selectors are narrower still, but a
+# selector is a UI hint and validates nothing).
+_home_leave_temperature = vol.All(vol.Coerce(float), vol.Range(min=0, max=127.5))
+
 
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
@@ -77,16 +84,16 @@ def async_setup_services(hass: HomeAssistant) -> None:
         entity_domain=Platform.CLIMATE,
         func="async_set_home_leave_mode",
         schema={
-            vol.Required("temp_rule_cooling"): vol.Coerce(float),
-            vol.Required("temp_setting_cooling"): vol.Coerce(float),
+            vol.Required("temp_rule_cooling"): _home_leave_temperature,
+            vol.Required("temp_setting_cooling"): _home_leave_temperature,
             # The select selector in services.yaml submits its value as a
             # string ("0".."4") - coerce before checking range so both that
             # and a programmatic int call work.
             vol.Required("air_flow_cooling"): vol.All(
                 vol.Coerce(int), vol.In([0, 1, 2, 3, 4])
             ),
-            vol.Required("temp_rule_heating"): vol.Coerce(float),
-            vol.Required("temp_setting_heating"): vol.Coerce(float),
+            vol.Required("temp_rule_heating"): _home_leave_temperature,
+            vol.Required("temp_setting_heating"): _home_leave_temperature,
             vol.Required("air_flow_heating"): vol.All(
                 vol.Coerce(int), vol.In([0, 1, 2, 3, 4])
             ),
@@ -101,7 +108,12 @@ def async_setup_services(hass: HomeAssistant) -> None:
         func="async_set_external_temperature",
         schema={
             vol.Optional("temperature"): vol.Any(
-                vol.Range(min=EXTERNAL_TEMPERATURE_MIN, max=EXTERNAL_TEMPERATURE_MAX),
+                vol.All(
+                    vol.Coerce(float),
+                    vol.Range(
+                        min=EXTERNAL_TEMPERATURE_MIN, max=EXTERNAL_TEMPERATURE_MAX
+                    ),
+                ),
                 None,
             ),
         },

--- a/custom_components/mitsubishi_wf_rac/services.yaml
+++ b/custom_components/mitsubishi_wf_rac/services.yaml
@@ -147,7 +147,7 @@ set_home_leave_mode:
       example: 0
       selector:
         number:
-          min: -20
+          min: 0
           max: 30
           step: 0.5
           unit_of_measurement: "°C"

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -48,7 +48,8 @@
     "abort": {
       "existing_instance_updated": "Updated existing configuration.",
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "wrong_device": "This is a different air conditioner than the one this entry was set up for. Point it back at the original unit, or add the other one as its own entry."
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "Vorhandene Konfiguration aktualisiert.",
       "already_configured": "Klima ist bereits konfiguriert",
-      "reconfigure_successful": "Neukonfiguration erfolgreich"
+      "reconfigure_successful": "Neukonfiguration erfolgreich",
+      "wrong_device": "Hinter dieser Adresse antwortet ein anderes Klimagerät als das, für das dieser Eintrag angelegt wurde. Trage wieder die Adresse des ursprünglichen Geräts ein, oder lege für das andere einen eigenen Eintrag an."
     },
     "step": {
       "user": {

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "Updated existing configuration.",
       "already_configured": "Airco is already configured",
-      "reconfigure_successful": "Re-configuration was successful"
+      "reconfigure_successful": "Re-configuration was successful",
+      "wrong_device": "This is a different air conditioner than the one this entry was set up for. Point it back at the original unit, or add the other one as its own entry."
     },
     "step": {
       "user": {

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "既存の設定が更新されました。",
       "already_configured": "エアコンは既に設定されています。",
-      "reconfigure_successful": "再設定が完了しました"
+      "reconfigure_successful": "再設定が完了しました",
+      "wrong_device": "このアドレスでは、このエントリーを作成したときとは別のエアコンが応答しています。元の機器のアドレスに戻すか、別の機器として新しいエントリーを追加してください。"
     },
     "step": {
       "user": {

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "Esami nustatymai atnaujinti.",
       "already_configured": "Kondicionierius jau nustatytas",
-      "reconfigure_successful": "Perkonfigūravimas sėkmingas"
+      "reconfigure_successful": "Perkonfigūravimas sėkmingas",
+      "wrong_device": "Šiuo adresu atsiliepia kitas oro kondicionierius nei tas, kuriam buvo sukurtas šis įrašas. Įveskite pradinio įrenginio adresą arba pridėkite kitą įrenginį kaip atskirą įrašą."
     },
     "step": {
       "user": {

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "Huidige configuratie is geüpdatet.",
       "already_configured": "Airco is al geconfigureerd",
-      "reconfigure_successful": "Herconfiguratie geslaagd"
+      "reconfigure_successful": "Herconfiguratie geslaagd",
+      "wrong_device": "Op dit adres antwoordt een andere airco dan die waarvoor deze invoer is aangemaakt. Vul weer het adres van het oorspronkelijke apparaat in, of voeg het andere toe als eigen invoer."
     },
     "step": {
       "user": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "已更新现有配置。",
       "already_configured": "空调已配置",
-      "reconfigure_successful": "重新配置成功"
+      "reconfigure_successful": "重新配置成功",
+      "wrong_device": "此地址上响应的空调与创建此条目时的设备不同。请改回原设备的地址，或将另一台设备添加为独立条目。"
     },
     "step": {
       "user": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "已更新現有配置。",
       "already_configured": "空調已配置",
-      "reconfigure_successful": "重新配置成功"
+      "reconfigure_successful": "重新配置成功",
+      "wrong_device": "此位址上回應的空調與建立此項目時的裝置不同。請改回原裝置的位址，或將另一台裝置新增為獨立項目。"
     },
     "step": {
       "user": {

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -198,6 +198,60 @@ async def test_user_flow_update_account_info_falsy_is_cannot_connect(hass: HomeA
     assert result["errors"] == {"base": "cannot_connect"}
 
 
+async def test_user_flow_registration_failure_is_cannot_connect(hass: HomeAssistant):
+    """The registration request is the second of the two, and the module
+    answers one caller at a time - a timeout there is an ordinary outcome,
+    not an unexpected error."""
+    repo = _mock_repository()
+    repo.update_account_info.side_effect = WfRacError("timeout")
+    with _patch_repository(repo):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "192.168.1.50", "port": 51443}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_unreadable_registration_answer_is_cannot_connect(
+    hass: HomeAssistant,
+):
+    """Whatever answered is not a WF-RAC module."""
+    repo = _mock_repository()
+    repo.update_account_info.return_value = {"result": "not a number"}
+    with _patch_repository(repo):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "192.168.1.50", "port": 51443}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_non_json_answer_is_cannot_connect(hass: HomeAssistant):
+    """Typing the address of some other HTTP service in the house is a
+    connection problem from where the user stands. The library lets
+    json.loads' ValueError through, so the flow has to catch it."""
+    repo = _mock_repository()
+    repo.get_airco_id.side_effect = ValueError("Expecting value: line 1 column 1")
+    with _patch_repository(repo):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "192.168.1.50", "port": 51443}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
 async def test_user_flow_too_many_devices_shows_error(hass: HomeAssistant):
     repo = _mock_repository(update_result=2)
     with _patch_repository(repo):
@@ -258,7 +312,10 @@ def _existing_entry(
 ):
     entry = MockConfigEntry(
         domain=DOMAIN,
-        version=6,
+        version=7,
+        # Every entry carries the unit's own id as its unique id since the v7
+        # migration - a reconfigure compares against it.
+        unique_id="airco-1",
         data={
             "name": name,
             "host": host,
@@ -324,6 +381,27 @@ async def test_reconfigure_flow_allows_resubmitting_the_same_host(hass: HomeAssi
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+
+
+async def test_reconfigure_flow_rejects_a_different_unit(hass: HomeAssistant):
+    """A typo can point the entry at a second air conditioner. Every entity's
+    unique id is built from the airco id, so following it would rename them
+    all, orphan the originals, and leave discovery unable to place either
+    unit."""
+    entry = _existing_entry(hass, host="192.168.1.50")
+
+    repo = _mock_repository(airco_id="airco-2")
+    with _patch_repository(repo):
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "192.168.1.99", "port": 51443},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_device"
+    assert entry.data["host"] == "192.168.1.50"
+    assert entry.data[CONF_AIRCO_ID] == "airco-1"
 
 
 async def test_reconfigure_flow_rejects_another_entrys_host(hass: HomeAssistant):

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -10,6 +10,9 @@ longer depend on a platform having come up.
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+import voluptuous as vol
+
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
@@ -48,6 +51,64 @@ async def test_actions_exist_without_a_working_device(hass: HomeAssistant):
 
     for action in _ACTIONS:
         assert hass.services.has_service(DOMAIN, action), action
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["temp_rule_cooling", "temp_setting_cooling", "temp_rule_heating", "temp_setting_heating"],
+)
+async def test_set_home_leave_mode_rejects_a_temperature_the_unit_cannot_hold(
+    hass: HomeAssistant, field: str
+):
+    """The thresholds go out as int(value * 2) in a single byte. Unchecked, a
+    mistyped 200 was masked to 144 and written back as 72 °C without a word.
+    """
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    data = {
+        "temp_rule_cooling": 35.0,
+        "temp_setting_cooling": 33.0,
+        "air_flow_cooling": 0,
+        "temp_rule_heating": 5.0,
+        "temp_setting_heating": 10.0,
+        "air_flow_heating": 0,
+    }
+    data[field] = 200.0
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_HOME_LEAVE_MODE,
+            {**data, "entity_id": "climate.not_here"},
+            blocking=True,
+        )
+
+
+async def test_set_external_temperature_takes_a_numeric_string(hass: HomeAssistant):
+    """Every other numeric field in this file coerces first; this one went
+    straight to vol.Range, where a string is not orderable against a float -
+    so a templated value, which renders as a string, was rejected.
+    """
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    # Passes validation; there is no entity to run it against, which the
+    # service layer reports as a warning rather than raising.
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_EXTERNAL_TEMPERATURE,
+        {"temperature": "21.5", "entity_id": "climate.not_here"},
+        blocking=True,
+    )
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_EXTERNAL_TEMPERATURE,
+            {"temperature": "99", "entity_id": "climate.not_here"},
+            blocking=True,
+        )
 
 
 async def test_options_flow_reloads_itself(hass: HomeAssistant):


### PR DESCRIPTION
Three defects the second review pass turned up, all in the setup surface.

## The registration request had no error handling

Only `get_airco_id()` sat in a targeted `except`. `update_account_info()` — the second of the two requests, and the likelier one to time out, since the module answers one caller at a time — fell through to the flow's outermost handler, so a plain unreachable module produced *"unexpected error, check the log"* instead of the `cannot_connect` message written for it.

Same for a reply that is not the JSON we expect, which is what a wrong address with some other HTTP service behind it returns: `pywfrac` calls `json.loads()` inside a `try` that only catches `TimeoutError`/`ClientConnectionError`, so a `JSONDecodeError` arrives here — and `ValueError` was in neither `except` clause.

## A reconfigure never checked which unit answered

Every entity's unique id is built from the airco id. A typo in the reconfigure dialog that lands on the second air conditioner in the house wrote *that* unit's id into `entry.data` while `entry.unique_id` stayed on the first: every entity id changes, the originals are orphaned in the registry, history breaks, and a later discovery of either unit no longer matches the entry. `_abort_if_unique_id_mismatch` now stops it. `quality_scale.yaml` has listed `reconfiguration-flow: done` all along.

## `set_home_leave_mode` accepted anything

The four temperature fields carried only `vol.Coerce(float)` while the airflow fields were properly bounded. The values go on the wire as `int(value * 2)` in a single byte, and `pywfrac` masks with `& 0xFF` rather than refusing: `200` instead of `20.0` was written back as **72 °C** silently. Bounded now to what the byte can hold and hand back unchanged (0–127.5).

While there: `services.yaml` offered `min: -20` for the heating rule, but the unit reads that field back unsigned, so -20 returns as 108. The selector now stops where the round trip does. `set_external_temperature` gained the `vol.Coerce(float)` every other numeric field in the file already had — a templated value renders as a string and was rejected by `vol.Range` alone.

## Tests

Eight new, all verified against the unpatched code — the whole set fails without these changes. 351 pass, mypy clean.