### PR TITLE
The second review pass: nine defects, and the style the reviewers flagged

### DIFF
--- a/custom_components/mitsubishi_wf_rac/binary_sensor.py
+++ b/custom_components/mitsubishi_wf_rac/binary_sensor.py
@@ -2,7 +2,6 @@
 # pylint: disable = too-few-public-methods
 
 from __future__ import annotations
-import logging
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -18,7 +17,6 @@ from .coordinator import Device
 from pywfrac import describe_error_code
 from .const import DOMAIN
 
-_LOGGER = logging.getLogger(__name__)
 # Read-only as far as the device is concerned: the coordinator does the
 # polling, and nothing on this platform sends a request of its own.
 PARALLEL_UPDATES = 0
@@ -63,17 +61,19 @@ class ProblemBinarySensor(WfRacEntity, BinarySensorEntity):
 
     def _mark_state_unknown(self) -> None:
         self._attr_is_on = None
+        # The code goes with the state. Left behind it would keep answering
+        # state_attr() with the last fault this entity read, while the entity
+        # itself says it does not know.
+        self._attr_extra_state_attributes = {}
 
     def _update_state(self) -> None:
         code = self._device.airco.ErrorCode
         self._attr_is_on = code != "00"
         attrs: dict[str, str] = {"error_code": code}
-        # Deliberately no key at all (rather than a guessed/empty value) for
-        # codes describe_error_code() doesn't recognize.
-        # NB this still reports is_on for an M<n> code, which is a protective
-        # stop the unit recovered from rather than a fault it is displaying -
-        # arguably not a "problem". Left as it was for now; changing it would
-        # alter what existing automations see.
+        # No key at all, rather than a guessed or empty value, for codes
+        # describe_error_code() does not recognize. An M<n> code reads as a
+        # problem too, though it is a protective stop the unit recovered from:
+        # narrowing that would change what existing automations see.
         description = describe_error_code(code)
         if description is not None:
             attrs["error_description"] = description

--- a/custom_components/mitsubishi_wf_rac/button.py
+++ b/custom_components/mitsubishi_wf_rac/button.py
@@ -2,7 +2,6 @@
 # pylint: disable = too-few-public-methods
 
 from __future__ import annotations
-import logging
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.const import EntityCategory
@@ -15,7 +14,6 @@ from .entity import WfRacEntity
 from .coordinator import Device
 from .const import DOMAIN, SIGNAL_SET_ENERGY_TOTAL
 
-_LOGGER = logging.getLogger(__name__)
 # Read-only as far as the device is concerned: the coordinator does the
 # polling, and nothing on this platform sends a request of its own.
 PARALLEL_UPDATES = 0

--- a/custom_components/mitsubishi_wf_rac/climate.py
+++ b/custom_components/mitsubishi_wf_rac/climate.py
@@ -113,7 +113,7 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
     _attr_temperature_unit: str = UnitOfTemperature.CELSIUS
     _attr_hvac_modes: list[HVACMode] = SUPPORTED_HVAC_MODES
     _attr_fan_modes: list[str] = SUPPORTED_FAN_MODES
-    _attr_fan_mode: str = FAN_AUTO
+    _attr_fan_mode: str | None = FAN_AUTO
     _attr_swing_mode: str | None = SWING_VERTICAL_AUTO
     _attr_swing_modes: list[str] | None = SUPPORT_SWING_MODES
     _attr_swing_horizontal_mode: str | None = SWING_HORIZONTAL_AUTO
@@ -162,10 +162,8 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
                     self.hass, source, self._handle_external_temperature_source_change
                 )
             )
-        # No async_write_ha_state() of its own here: the platform writes the
-        # state itself once this returns. (The source path above goes through
-        # _set_external_temperature_override, whose write is harmless for the
-        # same reason.)
+        # No async_write_ha_state() here: the platform writes the state itself
+        # once this returns.
         self._apply_state()
 
     @property
@@ -368,20 +366,16 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
         """The setpoint range in the numbers the card shows.
 
         The device is held to _setpoint_range_for_mode(); what the user sets
-        and reads back is that value plus the target offset, so the bounds move
-        with it. Advertising the device's own range instead let a setpoint at
-        the edge pass validation, get clamped on the wire and come back one
-        offset away from what was asked for - with a +1 offset, a requested 16
-        became 15, was clamped back to 16 and displayed as 17.
+        and reads back is that value plus the target offset, so the bounds have
+        to move with it, or a setpoint at the edge passes validation and comes
+        back one offset away from what was asked for.
 
         For a mode with no range of its own the shift happens per mode and the
-        union comes after, because each mode carries its own offset. Shifting
-        the union by one mode's offset instead would reject a setpoint that is
-        legal in the mode the call switches to - and Home Assistant reads
-        min_temp/max_temp and rejects on its own before the entity ever sees
-        the call, so there is no second chance to get it right. That pre-check
-        still measures a mode-switching call against the mode the unit is in
-        right now, which no integration can help.
+        union comes after, because each mode carries its own offset. Home
+        Assistant reads min_temp/max_temp and rejects on its own before the
+        entity sees the call, so a union shifted by one mode's offset would
+        reject a setpoint that is legal in the mode the call switches to, with
+        no second chance to correct it.
         """
         if hvac_mode in REGULATING_HVAC_MODES:
             offset = self._resolve_target_offset(hvac_mode)
@@ -422,7 +416,6 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
         # rejection and a fix.
         if set_temp < min_temp:
             raise ServiceValidationError(
-                f"Temperature {set_temp} is below minimum {min_temp}",
                 translation_domain=DOMAIN,
                 translation_key="temperature_below_minimum",
                 translation_placeholders={
@@ -434,7 +427,6 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
 
         if set_temp > max_temp:
             raise ServiceValidationError(
-                f"Temperature {set_temp} is above maximum {max_temp}",
                 translation_domain=DOMAIN,
                 translation_key="temperature_above_maximum",
                 translation_placeholders={
@@ -555,7 +547,6 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
             # Two writers would make the service result immediately temporary
             # and leave users guessing which one controls the unit.
             raise ServiceValidationError(
-                "External temperature is controlled by the configured source entity",
                 translation_domain=DOMAIN,
                 translation_key="external_temperature_source_configured",
             )
@@ -600,7 +591,6 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
             away_temp = HOME_LEAVE_TEMP_HEAT
         else:
             raise ServiceValidationError(
-                f"Home Leave mode needs cooling or heating, not {self._attr_hvac_mode}",
                 translation_domain=DOMAIN,
                 translation_key="preset_away_needs_cool_or_heat",
                 translation_placeholders={"hvac_mode": str(self._attr_hvac_mode)},
@@ -617,7 +607,6 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
     def _require_home_leave_mode_capability(self) -> None:
         if not self._device.airco.Capabilities.home_leave_mode:
             raise ServiceValidationError(
-                "This model does not report the HomeLeaveMode capability",
                 translation_domain=DOMAIN,
                 translation_key="home_leave_mode_not_supported",
             )
@@ -653,7 +642,18 @@ class AircoClimate(WfRacEntity, ClimateEntity, RestoreEntity):
         )
 
     def _mark_state_unknown(self) -> None:
+        # All of it, not just hvac_mode: _update_state() writes the setpoint
+        # and the room reading before it reaches the fields that can fail, so
+        # leaving the rest in place would show a freshly updated temperature
+        # and a stale action next to a state the entity itself calls unknown.
         self._attr_hvac_mode = None
+        self._attr_hvac_action = None
+        self._attr_target_temperature = None
+        self._attr_current_temperature = None
+        self._attr_fan_mode = None
+        self._attr_swing_mode = None
+        self._attr_swing_horizontal_mode = None
+        self._attr_preset_mode = None
 
     def _update_state(self) -> None:
         """Private update attributes"""

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -91,11 +91,17 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data: dict[str, Any],
             exclude_entry_id: str | None = None,
             allow_port_fallback: bool = False,
+            expected_airco_id: str | None = None,
     ) -> dict[str, Any]:
         """Validate the user input allows us to connect, and register with the airco device.
 
         allow_port_fallback belongs to discovery only: a port the module
         announced may be wrong, a port a person typed is their decision.
+
+        expected_airco_id aborts before the registration request when some
+        other unit answers - registering takes one of the few account slots
+        the module has, and a reconfigure that lands on the wrong address has
+        no business spending one.
         """
         if len(data[CONF_HOST]) < 3:
             raise InvalidHost
@@ -155,21 +161,27 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         data[CONF_AIRCO_ID] = airco_id
         if not airco_id:
             raise CannotConnect(reason="unknown reason")
+        if (
+            expected_airco_id is not None
+            and airco_id.lower() != expected_airco_id.lower()
+        ):
+            raise AbortFlow("wrong_device")
 
         _LOGGER.debug("Registering this controller on airco [%s]", airco_id)
         try:
-            result = await repository.update_account_info(airco_id, hass.config.time_zone)
-            if not result:
-                raise CannotConnect(reason="no answer to the registration request")
-            registration_result = int(result["result"])
+            result = await repository.update_account_info(
+                airco_id, hass.config.time_zone
+            )
         except (WfRacError, KeyError, TypeError, ValueError) as register_failed:
-            # Same treatment as the query above: this is the second request of
-            # the two, and the module answers only one caller at a time, so a
-            # timeout here is an ordinary outcome and belongs in the form, not
-            # in "unexpected error". ValueError covers a body that is not the
-            # JSON we expect - what a wrong IP with some other HTTP service
-            # behind it returns.
+            # ValueError covers a body that is not the JSON we expect - what a
+            # wrong address with some other HTTP service behind it returns.
             raise CannotConnect(reason=str(register_failed)) from register_failed
+        if not result:
+            raise CannotConnect(reason="no answer to the registration request")
+        try:
+            registration_result = int(result["result"])
+        except (KeyError, TypeError, ValueError) as unreadable:
+            raise CannotConnect(reason="unreadable registration answer") from unreadable
         if registration_result == 2:
             raise TooManyDevicesRegistered
 
@@ -372,16 +384,16 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data[CONF_OPERATOR_ID] = reconfigure_entry.data[CONF_OPERATOR_ID]
                 data[CONF_DEVICE_ID] = reconfigure_entry.data[CONF_DEVICE_ID]
 
-                info = await self._async_register_airco(
-                    self.hass, data, exclude_entry_id=reconfigure_entry.entry_id
+                # The address may change, the unit behind it may not: every
+                # entity's unique id is built from the airco id, so following
+                # a typo to the next unit renames them all, orphans the
+                # originals, and leaves discovery able to place neither.
+                await self._async_register_airco(
+                    self.hass,
+                    data,
+                    exclude_entry_id=reconfigure_entry.entry_id,
+                    expected_airco_id=reconfigure_entry.data[CONF_AIRCO_ID],
                 )
-
-                # The address changed, the unit behind it must not: every
-                # entity's unique id is built from the airco id, so writing a
-                # different one here renames them all, orphans the originals
-                # and leaves discovery unable to recognise either unit.
-                await self.async_set_unique_id(info[CONF_AIRCO_ID].lower())
-                self._abort_if_unique_id_mismatch(reason="wrong_device")
 
                 new_data = {**reconfigure_entry.data, **data}
 

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -127,7 +127,14 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             airco_id = await repository.get_airco_id()
-        except (WfRacError, KeyError, TypeError, ValueError) as query_failed:
+        except (
+            WfRacError,
+            KeyError,
+            TypeError,
+            ValueError,
+            AttributeError,
+            OSError,
+        ) as query_failed:
             # A discovery announcement has been seen carrying a port the module
             # does not serve. The port is fixed in the firmware and not
             # user-settable, so rather than failing on a value the device
@@ -154,7 +161,14 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             try:
                 airco_id = await repository.get_airco_id()
-            except (WfRacError, KeyError, TypeError, ValueError) as retry_failed:
+            except (
+                WfRacError,
+                KeyError,
+                TypeError,
+                ValueError,
+                AttributeError,
+                OSError,
+            ) as retry_failed:
                 raise CannotConnect(reason=str(retry_failed)) from retry_failed
             data[CONF_PORT] = DEFAULT_PORT
 
@@ -172,9 +186,18 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             result = await repository.update_account_info(
                 airco_id, hass.config.time_zone
             )
-        except (WfRacError, KeyError, TypeError, ValueError) as register_failed:
-            # ValueError covers a body that is not the JSON we expect - what a
-            # wrong address with some other HTTP service behind it returns.
+        except (
+            WfRacError,
+            KeyError,
+            TypeError,
+            ValueError,
+            AttributeError,
+            OSError,
+        ) as register_failed:
+            # Everything a wrong address can answer with counts as not
+            # reaching the unit: a body that is not JSON (ValueError), one
+            # that is JSON but not an object (AttributeError), or a TLS
+            # handshake that never got that far (OSError).
             raise CannotConnect(reason=str(register_failed)) from register_failed
         if not result:
             raise CannotConnect(reason="no answer to the registration request")

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -121,7 +121,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             airco_id = await repository.get_airco_id()
-        except (WfRacError, KeyError, TypeError) as query_failed:
+        except (WfRacError, KeyError, TypeError, ValueError) as query_failed:
             # A discovery announcement has been seen carrying a port the module
             # does not serve. The port is fixed in the firmware and not
             # user-settable, so rather than failing on a value the device
@@ -148,7 +148,7 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             try:
                 airco_id = await repository.get_airco_id()
-            except (WfRacError, KeyError, TypeError) as retry_failed:
+            except (WfRacError, KeyError, TypeError, ValueError) as retry_failed:
                 raise CannotConnect(reason=str(retry_failed)) from retry_failed
             data[CONF_PORT] = DEFAULT_PORT
 
@@ -157,10 +157,20 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             raise CannotConnect(reason="unknown reason")
 
         _LOGGER.debug("Registering this controller on airco [%s]", airco_id)
-        result = await repository.update_account_info(airco_id, hass.config.time_zone)
-        if not result:
-            raise CannotConnect(reason="no answer to the registration request")
-        if int(result["result"]) == 2:
+        try:
+            result = await repository.update_account_info(airco_id, hass.config.time_zone)
+            if not result:
+                raise CannotConnect(reason="no answer to the registration request")
+            registration_result = int(result["result"])
+        except (WfRacError, KeyError, TypeError, ValueError) as register_failed:
+            # Same treatment as the query above: this is the second request of
+            # the two, and the module answers only one caller at a time, so a
+            # timeout here is an ordinary outcome and belongs in the form, not
+            # in "unexpected error". ValueError covers a body that is not the
+            # JSON we expect - what a wrong IP with some other HTTP service
+            # behind it returns.
+            raise CannotConnect(reason=str(register_failed)) from register_failed
+        if registration_result == 2:
             raise TooManyDevicesRegistered
 
         return data
@@ -365,6 +375,13 @@ class WfRacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 info = await self._async_register_airco(
                     self.hass, data, exclude_entry_id=reconfigure_entry.entry_id
                 )
+
+                # The address changed, the unit behind it must not: every
+                # entity's unique id is built from the airco id, so writing a
+                # different one here renames them all, orphans the originals
+                # and leaves discovery unable to recognise either unit.
+                await self.async_set_unique_id(info[CONF_AIRCO_ID].lower())
+                self._abort_if_unique_id_mismatch(reason="wrong_device")
 
                 new_data = {**reconfigure_entry.data, **data}
 

--- a/custom_components/mitsubishi_wf_rac/config_flow.py
+++ b/custom_components/mitsubishi_wf_rac/config_flow.py
@@ -715,9 +715,8 @@ class KnownError(exceptions.HomeAssistantError):
     ) -> tuple[dict[str, str], dict[str, str]]:
         """Return dicts of errors and description_placeholders, for adding to async_show_form"""
         key = self.applies_to_field
-        # Errors will only be displayed to the user if the key is actually in the form (or
-        # CONF_BASE for a general error), so we'll check the schema (seems weird there
-        # isn't a more efficient way to do this...)
+        # An error only shows if its key is in the form; anything else falls
+        # back to CONF_BASE.
         if key not in {k.schema for k in schema}:
             key = CONF_BASE
         return ({key: self.error_name}, self._extra_info or {})

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -71,10 +71,12 @@ UPDATE_CONSOLIDATION_PERIOD = timedelta(milliseconds=500)
 FIRMWARE_CHECK_INTERVAL = timedelta(hours=24)
 
 # Operation data is requested for active operation-data entities and costs a
-# second request per poll. It stays on the local network and changes nothing on
-# the unit (see RacParser.status_request_to_byte) - but it is a setAirconStat,
-# so it takes the module's 60-second write lock all the same, and while we hold
-# that lock no one else can control the unit at all.
+# second request per poll. It stays on the local network, and on most modules
+# its block carries no set-bits (see RacParser.status_request_to_byte) - but it
+# is a setAirconStat, so it takes the module's 60-second write lock all the
+# same, and while we hold that lock no one else can control the unit at all.
+# On a module that needs its state carried (#329) the block is a full command
+# and the request really does write.
 #
 # The lock's deadline is `now + 60`, where `now` is the `timestamp` field of
 # the request that took it - the module has no RTC and reads its clock from
@@ -1080,8 +1082,8 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             new_airco = self._parser.translate_bytes(response["airconStat"])
         except (WfRacError, KeyError, TypeError, ValueError) as ex:
             _LOGGER.debug(
-                "Could not read [%s] before the operation-data request, "
-                "skipping this cycle: %s",
+                "Could not read [%s] before echoing its state back, "
+                "skipping the request: %s",
                 self.device_name,
                 ex,
             )
@@ -1099,16 +1101,18 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         task that deliberately swallows its errors.
         """
         await asyncio.sleep(self.service_data_offset.total_seconds())
-        # The state this is built from is almost irrelevant: a status request
-        # carries no set-bits, so the unit applies none of it (see
-        # RacParser.status_request_to_byte). Byte 5 is the one exception, since
-        # it has no set-bit to leave out - an active external temperature
-        # override rides along here, and that is the point: this is the frame
-        # that keeps it alive between commands. Note that this also makes the
-        # request a write in the strict sense, which is what the backdated
-        # timestamp below trades away part of the lock for. The offset stays
-        # because it is about spacing requests, not about what they contain -
-        # a second request too soon after the poll is what the module refuses.
+        # What this frame is built from matters on a carrying module and
+        # barely anywhere else: without the quirk the block holds no set-bits
+        # and the unit applies none of it (see
+        # RacParser.status_request_to_byte), with it the block is a full
+        # command. Byte 5 is written either way, having no set-bit to leave
+        # out - an active external temperature override rides along here, and
+        # that is the point: this is the frame that keeps it alive between
+        # commands. That also makes the request a write in the strict sense,
+        # which is what the backdated timestamp below trades away part of the
+        # lock for. The offset stays because it is about spacing requests, not
+        # about what they contain - a second request too soon after the poll is
+        # what the module refuses.
         if self._parser.status_request_carries_state and not await self._async_read_before_echo():
             return
         if not self._power_state_is_safe_to_carry():
@@ -1640,11 +1644,26 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
 
         Sent directly through set_airco() rather than async_queue_command():
         the latter coalesces this with any command queued in the same
-        window, and since this request's own block carries no set-bits (see
+        window, and on a module whose status request holds no set-bits (see
         RacParser.status_request_to_byte), a coalesced real command - e.g. a
         setpoint change - would go out in that same block without its
         set-bit and be silently ignored by the unit.
+
+        On a module that carries its state (#329) the block is a full command
+        instead, so the state it is built from is read fresh first, exactly as
+        the operation-data path does. Without that this action would write back
+        a setting up to a poll old and undo whatever was done at the unit since
+        - including switching a unit off that somebody just turned on.
         """
+        if self._parser.status_request_carries_state and not await self._async_read_before_echo():
+            # A read failure is not a reason to send the old state anyway: on
+            # this module that is a write. The caller asked for a reading, so
+            # say that it did not happen rather than failing silently.
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="status_request_read_failed",
+                translation_placeholders={"device": self.device_name},
+            )
         await self.set_airco(
             {AirconCommands.HomeLeaveModeStatusRequest: True},
             is_status_request=True,

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -1073,19 +1073,17 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         task that deliberately swallows its errors.
         """
         await asyncio.sleep(self.service_data_offset.total_seconds())
-        # What this frame is built from matters on a carrying module and
-        # barely anywhere else: without the quirk the block holds no set-bits
-        # and the unit applies none of it (see
-        # RacParser.status_request_to_byte), with it the block is a full
-        # command. Byte 5 is written either way, having no set-bit to leave
-        # out - an active external temperature override rides along here, and
-        # that is the point: this is the frame that keeps it alive between
-        # commands. That also makes the request a write in the strict sense,
-        # which is what the backdated timestamp below trades away part of the
-        # lock for. The offset stays because it is about spacing requests, not
-        # about what they contain - a second request too soon after the poll is
-        # what the module refuses.
-        if self._parser.status_request_carries_state and not await self._async_read_before_echo():
+        # What the frame carries depends on the module: no set-bits at all
+        # without the #329 quirk, a full command with it (see
+        # RacParser.status_request_to_byte). Byte 5 goes out either way,
+        # having no set-bit to leave out, which is how an active external
+        # temperature override stays alive between commands - and what makes
+        # this request a write in the strict sense, for which the backdated
+        # timestamp below gives back part of the lock.
+        if (
+            self._parser.status_request_carries_state
+            and not await self._async_read_before_echo()
+        ):
             return
         if not self._power_state_is_safe_to_carry():
             # Re-checked after the sleep, not only when the request was
@@ -1627,10 +1625,12 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         a setting up to a poll old and undo whatever was done at the unit since
         - including switching a unit off that somebody just turned on.
         """
-        if self._parser.status_request_carries_state and not await self._async_read_before_echo():
-            # A read failure is not a reason to send the old state anyway: on
-            # this module that is a write. The caller asked for a reading, so
-            # say that it did not happen rather than failing silently.
+        if (
+            self._parser.status_request_carries_state
+            and not await self._async_read_before_echo()
+        ):
+            # Sending the state we have would be a write on this module, and
+            # the caller asked for a reading.
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="status_request_read_failed",

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -5,10 +5,9 @@ import logging
 import re
 from collections import deque
 from collections.abc import Mapping
-from contextlib import suppress
 from datetime import datetime, timedelta
 from collections.abc import Callable
-from typing import Any, override
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -424,30 +423,19 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         self._sync_external_temperature_carrier()
 
     async def async_shutdown(self) -> None:
-        """Release the override's own operation-data subscription along with
-        the coordinator. A listener outstanding after unload would keep the
-        refresh timer alive for an entry that no longer exists.
+        """Release the subscription and both tasks along with the coordinator.
 
-        The consolidation task is created on hass rather than owned by
-        DataUpdateCoordinator, so it has to be cancelled here too: a command
-        queued moments before the entry unloads would otherwise still be sent
-        afterwards and publish data to entities that are already gone.
+        Neither task is owned by DataUpdateCoordinator, and hass only cancels
+        background tasks when hass itself stops - which an entry unload is
+        not. The operation-data one matters most: it spends most of its life
+        asleep waiting out its offset, so a reload catches it mid-sleep and
+        its request would go out from the old entry through a second
+        Repository while the new one is already polling. Two connections at
+        once is what the module will not take.
 
-        The operation-data task needs the same, and more urgently: it spends
-        most of its life asleep waiting out its offset (up to
-        SERVICE_DATA_REQUEST_OFFSET), so an unload almost always catches one
-        mid-sleep. hass cancels background tasks when *hass* stops, which a
-        config-entry unload is not - and on a reload the request would go out
-        from the old entry while the new one is already polling, through a
-        second Repository whose request spacing knows nothing about the
-        first. Two connections at once is what the module will not take.
-
-        Whatever either task was doing, its outcome stops mattering here, and
-        an unload that raises leaves entities loaded on an entry that no
-        longer updates. So a failure is logged and swallowed rather than
-        allowed out: a flush reports its own errors to the caller that queued
-        it (see _async_flush_queued_command), and the operation-data request
-        is optional by construction.
+        Failures are logged and swallowed: an unload that raises leaves
+        entities loaded on an entry that no longer updates, and both tasks
+        report what matters elsewhere.
         """
         self._release_external_temperature_carrier()
         for task in (self._consolidation_task, self._service_data_task):
@@ -848,37 +836,26 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
     def _note_unexpected_settings(self, someone_wrote: bool) -> None:
         """Notice a setting that changed without us changing it.
 
-        The third and least deniable signal, and the only one our own traffic
-        cannot erase. `expires` and `updatedBy` both record who wrote last and
-        are overwritten by our next write, so either is masked when a request
-        of ours lands in the same gap - and half of every gap is ours. A
-        setting is not a record of a write, it is the result of one, and
-        nothing we send afterwards puts it back.
+        The only signal our own traffic cannot erase: `expires` and
+        `updatedBy` are overwritten by our next write, a changed setting is
+        not. It adds the case no write lock was taken for - only a
+        setAirconStat moves `expires`, so a setting that moved while `expires`
+        stood still was not changed over the network at all, but at the IR
+        remote, by a timer, or by one of the unit's own modes. No lock is held
+        there, so this only reports; the stand-down stays with the writes.
 
-        What it adds is the case no write lock was taken for. Only a
-        setAirconStat moves `expires`, so a setting that changed while
-        `expires` stood still was not changed over the network at all: that is
-        the IR remote, a timer in the unit, or one of the unit's own modes.
-        Standing down for three minutes would be pointless there - nobody
-        holds the lock we would be avoiding - so this only says so, and the
-        stand-down stays with the writes it was built for.
+        someone_wrote asks whether a set-bit could have been sent in this gap,
+        not whether any frame was - our own operation-data request moves
+        `expires` every cycle while changing nothing. The price is a wrong
+        label rather than a missing message: a foreign client writing in the
+        same gap as one of our requests reads as the unit itself, the module
+        offering no second record to tell them apart.
 
-        One case is invisible here by construction, and it is ours: while the
-        operation-data request carries the power state back to a unit that
-        needs it, a change we undo inside that same gap leaves the value
-        exactly where we expect it.
-
-        The someone_wrote argument asks whether a set-bit could have been sent
-        in this gap, not whether any frame was: our own operation-data request
-        moves `expires` every cycle while changing nothing, and counting it
-        would leave nothing to attribute. The price is one wrong label rather
-        than one missing message - a foreign client writing in the same gap as
-        one of our requests reads as the unit itself here, because the module
-        gives us no second record of the write to tell them apart.
-
-        Not every one of these is somebody's doing: the unit resets its own
+        Not every one of these is somebody's doing - the unit resets its own
         setpoint after a power cycle, and Vacant and self-clean move settings
-        with nobody asking.
+        with nobody asking. And one case is invisible by construction: a
+        change we undo while carrying the power state back leaves the value
+        exactly where we expect it.
         """
         current = self._settings_snapshot()
         expected = self._expected_settings
@@ -996,16 +973,11 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
     def _power_state_is_safe_to_carry(self) -> bool:
         """Whether an operation-data request may go out right now.
 
-        Only ever False on a unit whose request has to carry its state
-        (#329), and only while we believe that unit is off. On such a module
-        the block is applied rather than ignored, so the request is a write in
-        all but name.
-
-        Skipped rather than sent empty: without the state this module reads
-        the zeros as a command to clear the settings, which is the original
-        fault. And a reading taken while the unit is off is worth little
-        anyway - the compressor is stopped and the valve is closed - so
-        nothing is lost by waiting for the poll that finds it running.
+        Only False on a unit that carries its state (#329) while we believe it
+        is off, because there the block is applied rather than ignored. Sending
+        it empty instead is the original fault - the module reads the zeros as
+        a command to clear the settings - and a reading taken while the unit is
+        off is worth little, so it waits for a poll that finds it running.
         """
         return not self._parser.status_request_carries_state or bool(
             self._airco is not None and self._airco.Operation
@@ -1762,10 +1734,6 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             _LOGGER.debug(
                 "Could not reach the airco [%s]: %s", self.device_name, error
             )
-
-    def set_available(self, available: bool) -> None:
-        """Set available status"""
-        self._set_availability(available)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/mitsubishi_wf_rac/number.py
+++ b/custom_components/mitsubishi_wf_rac/number.py
@@ -20,8 +20,9 @@ from .const import DOMAIN
 # spaces every request.
 PARALLEL_UPDATES = 0
 
-# Same bounds as the temp_rule_*/temp_setting_* fields in services.yaml's
-# set_home_leave_mode action.
+# What the box offers. The wire carries 0-127.5 (see services.py) and the
+# set_home_leave_mode selectors are narrower again; these are the values a
+# thermostat threshold plausibly takes.
 HOME_LEAVE_TEMP_MIN = 10.0
 HOME_LEAVE_TEMP_MAX = 50.0
 HOME_LEAVE_TEMP_STEP = 0.5

--- a/custom_components/mitsubishi_wf_rac/number.py
+++ b/custom_components/mitsubishi_wf_rac/number.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 from dataclasses import replace
-import logging
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.const import UnitOfTemperature
@@ -17,7 +16,6 @@ from .coordinator import Device
 from pywfrac import HomeLeaveModeSetting
 from .const import DOMAIN
 
-_LOGGER = logging.getLogger(__name__)
 # Zero although this platform writes: the coordinator already serialises and
 # spaces every request.
 PARALLEL_UPDATES = 0
@@ -50,10 +48,6 @@ async def async_setup_entry(
 class HomeLeaveModeNumber(WfRacEntity, NumberEntity):
     """Editable Home Leave Mode temperature threshold/setting (Tag 248).
 
-    Replaces the former read-only home_leave_* diagnostic sensors in
-    sensor.py - same values, but directly writable from the device's
-    Controls section instead of only via the set_home_leave_mode action.
-
     Stays unavailable until Device.async_request_home_leave_mode_status()
     has been called at least once (see the climate entity's "Request Home
     Leave Mode status" action) - the unit omits the Tag-248 extension segment
@@ -63,11 +57,9 @@ class HomeLeaveModeNumber(WfRacEntity, NumberEntity):
     overwriting real settings with defaults.
     """
 
-    # None (not DIAGNOSTIC) so these land in the device page's main Controls
-    # section, directly editable - the whole point of replacing the former
-    # diagnostic sensors. Disabled by default though, same as those sensors
-    # were: a niche away-mode feature, not everyone with a HomeLeaveMode-
-    # capable model wants six extra entities on their device page.
+    # No entity category, so these land in the device page's main Controls
+    # section and stay editable. Off by default all the same: a niche
+    # away-mode feature is not worth six extra entities on every device page.
     _attr_entity_registry_enabled_default = False
     _attr_device_class = NumberDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
@@ -114,9 +106,6 @@ class HomeLeaveModeNumber(WfRacEntity, NumberEntity):
         heating = self._device.airco.HomeLeaveModeForHeating
         if cooling is None or heating is None:
             raise HomeAssistantError(
-                "Home Leave Mode values are unknown yet - call the climate "
-                "entity's 'Request Home Leave Mode status' action once "
-                "first, the unit doesn't include them in a plain poll.",
                 translation_domain=DOMAIN,
                 translation_key="home_leave_mode_status_unknown",
             )

--- a/custom_components/mitsubishi_wf_rac/select.py
+++ b/custom_components/mitsubishi_wf_rac/select.py
@@ -84,31 +84,19 @@ class HorizontalSwingSelect(WfRacEntity, SelectEntity):
         self._attr_unique_id = (
             f"{DOMAIN}-{self._device.airco_id}-horizontal-swing-direction"
         )
-        self.select_option(
-            SWING_3D_AUTO
-            if self._device.airco.Entrust
-            else
-            list(SWING_HORIZONTAL_MODE_TRANSLATION.keys())[
-                self._device.airco.WindDirectionLR
-            ]
-        )
+        self._apply_state()
 
     def _mark_state_unknown(self) -> None:
         self._attr_current_option = None
 
     def _update_state(self) -> None:
-        self.select_option(
+        self._attr_current_option = (
             SWING_3D_AUTO
             if self._device.airco.Entrust
-            else
-            list(SWING_HORIZONTAL_MODE_TRANSLATION.keys())[
+            else list(SWING_HORIZONTAL_MODE_TRANSLATION.keys())[
                 self._device.airco.WindDirectionLR
             ]
         )
-
-    def select_option(self, option: str) -> None:
-        """Change the selected option."""
-        self._attr_current_option = option
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -126,7 +114,7 @@ class HorizontalSwingSelect(WfRacEntity, SelectEntity):
                     AirconCommands.Entrust: False,
                 }
             )
-        self.select_option(option)
+        self._attr_current_option = option
 
 class VerticalSwingSelect(WfRacEntity, SelectEntity):
     """Select component to set the vertical swing direction of the airco"""
@@ -140,29 +128,19 @@ class VerticalSwingSelect(WfRacEntity, SelectEntity):
         self._attr_unique_id = (
             f"{DOMAIN}-{self._device.airco_id}-vertical-swing-direction"
         )
-        self.select_option(
-            SWING_3D_AUTO
-            if self._device.airco.Entrust
-            else list(SWING_MODE_TRANSLATION.keys())[
-                self._device.airco.WindDirectionUD
-            ]
-        )
+        self._apply_state()
 
     def _mark_state_unknown(self) -> None:
         self._attr_current_option = None
 
     def _update_state(self) -> None:
-        self.select_option(
+        self._attr_current_option = (
             SWING_3D_AUTO
             if self._device.airco.Entrust
             else list(SWING_MODE_TRANSLATION.keys())[
                 self._device.airco.WindDirectionUD
             ]
         )
-
-    def select_option(self, option: str) -> None:
-        """Change the selected option."""
-        self._attr_current_option = option
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -180,7 +158,7 @@ class VerticalSwingSelect(WfRacEntity, SelectEntity):
                     AirconCommands.Entrust: False,
                 }
             )
-        self.select_option(option)
+        self._attr_current_option = option
 
 class FanSpeedSelect(WfRacEntity, SelectEntity):
     """Select component to set the fan speed of the airco"""
@@ -203,11 +181,8 @@ class FanSpeedSelect(WfRacEntity, SelectEntity):
         # would otherwise make it look like a real one.
         if self._device.airco.AirFlow == AIRFLOW_UNKNOWN:
             raise IndexError("the unit reported a fan step pywfrac cannot read")
-        self.select_option(list(FAN_MODE_TRANSLATION.keys())[self._device.airco.AirFlow])
+        self._attr_current_option = list(FAN_MODE_TRANSLATION.keys())[self._device.airco.AirFlow]
 
-    def select_option(self, option: str) -> None:
-        """Change the selected option."""
-        self._attr_current_option = option
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -216,7 +191,7 @@ class FanSpeedSelect(WfRacEntity, SelectEntity):
                 AirconCommands.AirFlow: FAN_MODE_TRANSLATION[option]
             }
         )
-        self.select_option(option)
+        self._attr_current_option = option
 
 
 class HomeLeaveModeSelect(WfRacEntity, SelectEntity):
@@ -249,23 +224,20 @@ class HomeLeaveModeSelect(WfRacEntity, SelectEntity):
     def _update_state(self) -> None:
         airco = self._device.airco
         if not airco.Vacant:
-            self.select_option(HOME_LEAVE_MODE_OFF)
+            self._attr_current_option = HOME_LEAVE_MODE_OFF
             return
         mode_from_operation = list(HVAC_TRANSLATION.keys())[airco.OperationMode]
         if mode_from_operation == HVACMode.COOL:
-            self.select_option(HOME_LEAVE_MODE_AWAY_COOL)
+            self._attr_current_option = HOME_LEAVE_MODE_AWAY_COOL
         elif mode_from_operation == HVACMode.HEAT:
-            self.select_option(HOME_LEAVE_MODE_AWAY_HEAT)
+            self._attr_current_option = HOME_LEAVE_MODE_AWAY_HEAT
         else:
             # Vacant set while running in some other mode than the two the
             # away feature itself uses - shouldn't happen, but "off" is a
             # safer fallback than silently claiming a direction that isn't
             # actually active.
-            self.select_option(HOME_LEAVE_MODE_OFF)
+            self._attr_current_option = HOME_LEAVE_MODE_OFF
 
-    def select_option(self, option: str) -> None:
-        """Change the selected option."""
-        self._attr_current_option = option
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -291,22 +263,19 @@ class HomeLeaveModeSelect(WfRacEntity, SelectEntity):
                     AirconCommands.PresetTemp: NORMAL_TEMP,
                 }
             )
-        self.select_option(option)
+        self._attr_current_option = option
 
 
 class HomeLeaveAirFlowSelect(WfRacEntity, SelectEntity):
     """Editable Home Leave Mode airflow level (Tag 248) for one direction.
 
-    Replaces the former read-only home_leave_{mode}_air_flow diagnostic
-    sensor in sensor.py - same value, but directly writable. Stays unknown
-    until Device.async_request_home_leave_mode_status() has been called at
-    least once, same as the TempRule/TempSetting HomeLeaveModeNumber
-    entities in number.py - see that class's docstring for why writing
-    before that is refused rather than guessed at.
+    Stays unknown until Device.async_request_home_leave_mode_status() has been
+    called at least once, same as the HomeLeaveModeNumber entities in
+    number.py - see that class for why writing before that is refused rather
+    than guessed at.
     """
 
-    # Disabled by default, same as the diagnostic sensors this replaces - a
-    # niche away-mode feature, not everyone with a HomeLeaveMode-capable
+    # A niche away-mode feature: not everyone with a HomeLeaveMode-capable
     # model wants extra entities on their device page.
     _attr_entity_registry_enabled_default = False
 
@@ -348,9 +317,6 @@ class HomeLeaveAirFlowSelect(WfRacEntity, SelectEntity):
         heating = self._device.airco.HomeLeaveModeForHeating
         if cooling is None or heating is None:
             raise HomeAssistantError(
-                "Home Leave Mode values are unknown yet - call the climate "
-                "entity's 'Request Home Leave Mode status' action once "
-                "first, the unit doesn't include them in a plain poll.",
                 translation_domain=DOMAIN,
                 translation_key="home_leave_mode_status_unknown",
             )

--- a/custom_components/mitsubishi_wf_rac/sensor.py
+++ b/custom_components/mitsubishi_wf_rac/sensor.py
@@ -34,7 +34,10 @@ from homeassistant.helpers import entity_registry as er
 from .entity import WfRacEntity
 from .coordinator import Device
 from pywfrac.parser import SERVICE_DATA_CODE_BY_FIELD
+from homeassistant.components.climate.const import HVACMode
+
 from .const import (
+    HVAC_TRANSLATION,
     ATTR_TARGET_TEMPERATURE,
     ATTR_COMPRESSOR_FREQUENCY,
     ATTR_COMPRESSOR_FREQUENCY_RAW,
@@ -150,7 +153,6 @@ async def async_set_energy_total(entity: SensorEntity, call: ServiceCall) -> Non
     """
     if not isinstance(entity, EnergyTotalSensor):
         raise ServiceValidationError(
-            f"{entity.entity_id} is not an Energy Usage Total sensor",
             translation_domain=DOMAIN,
             translation_key="entity_not_energy_total_sensor",
             translation_placeholders={"entity_id": entity.entity_id},
@@ -229,7 +231,9 @@ class DiagnosticsSensor(WfRacEntity, SensorEntity):
             self._attr_native_value = self._device.airco.ModelNrRaw
         elif self._custom_type == ATTR_COOL_HOT_JUDGE:
             airco = self._device.airco
-            if not airco.Operation or airco.OperationMode == 3:  # off or FAN_ONLY
+            if not airco.Operation or (
+                airco.OperationMode == HVAC_TRANSLATION[HVACMode.FAN_ONLY]
+            ):
                 self._attr_native_value = None
             else:
                 self._attr_native_value = "heating" if airco.CoolHotJudge else "cooling"
@@ -366,8 +370,11 @@ class EnergyTotalSensor(WfRacEntity, RestoreSensor):
 
     @property
     def extra_restore_state_data(self) -> EnergyTotalExtraStoredData:
+        # The running total, not native_value: an unreadable frame leaves the
+        # displayed value None, and a restart in that window would restore a
+        # lifetime meter of zero.
         return EnergyTotalExtraStoredData(
-            self.native_value, self.native_unit_of_measurement, self._last_raw
+            self._total, self.native_unit_of_measurement, self._last_raw
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/mitsubishi_wf_rac/services.py
+++ b/custom_components/mitsubishi_wf_rac/services.py
@@ -28,6 +28,13 @@ from .const import (
     SERVICE_SET_VERTICAL_SWING_MODE,
 )
 
+# Home Leave thresholds go on the wire as int(value * 2) in a single byte and
+# come back as raw / 2, so this is the whole range the unit can hold and hand
+# back unchanged. Unbounded, a mistyped 200 was masked to 144 and written as
+# 72 °C without a word (services.yaml's selectors are narrower still, but a
+# selector is a UI hint and validates nothing).
+_home_leave_temperature = vol.All(vol.Coerce(float), vol.Range(min=0, max=127.5))
+
 
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
@@ -77,16 +84,16 @@ def async_setup_services(hass: HomeAssistant) -> None:
         entity_domain=Platform.CLIMATE,
         func="async_set_home_leave_mode",
         schema={
-            vol.Required("temp_rule_cooling"): vol.Coerce(float),
-            vol.Required("temp_setting_cooling"): vol.Coerce(float),
+            vol.Required("temp_rule_cooling"): _home_leave_temperature,
+            vol.Required("temp_setting_cooling"): _home_leave_temperature,
             # The select selector in services.yaml submits its value as a
             # string ("0".."4") - coerce before checking range so both that
             # and a programmatic int call work.
             vol.Required("air_flow_cooling"): vol.All(
                 vol.Coerce(int), vol.In([0, 1, 2, 3, 4])
             ),
-            vol.Required("temp_rule_heating"): vol.Coerce(float),
-            vol.Required("temp_setting_heating"): vol.Coerce(float),
+            vol.Required("temp_rule_heating"): _home_leave_temperature,
+            vol.Required("temp_setting_heating"): _home_leave_temperature,
             vol.Required("air_flow_heating"): vol.All(
                 vol.Coerce(int), vol.In([0, 1, 2, 3, 4])
             ),
@@ -101,7 +108,12 @@ def async_setup_services(hass: HomeAssistant) -> None:
         func="async_set_external_temperature",
         schema={
             vol.Optional("temperature"): vol.Any(
-                vol.Range(min=EXTERNAL_TEMPERATURE_MIN, max=EXTERNAL_TEMPERATURE_MAX),
+                vol.All(
+                    vol.Coerce(float),
+                    vol.Range(
+                        min=EXTERNAL_TEMPERATURE_MIN, max=EXTERNAL_TEMPERATURE_MAX
+                    ),
+                ),
                 None,
             ),
         },

--- a/custom_components/mitsubishi_wf_rac/services.py
+++ b/custom_components/mitsubishi_wf_rac/services.py
@@ -28,11 +28,9 @@ from .const import (
     SERVICE_SET_VERTICAL_SWING_MODE,
 )
 
-# Home Leave thresholds go on the wire as int(value * 2) in a single byte and
-# come back as raw / 2, so this is the whole range the unit can hold and hand
-# back unchanged. Unbounded, a mistyped 200 was masked to 144 and written as
-# 72 °C without a word (services.yaml's selectors are narrower still, but a
-# selector is a UI hint and validates nothing).
+# Home Leave thresholds go out as int(value * 2) in a single byte, masked
+# rather than refused, so anything outside this comes back as a different
+# temperature.
 _home_leave_temperature = vol.All(vol.Coerce(float), vol.Range(min=0, max=127.5))
 
 

--- a/custom_components/mitsubishi_wf_rac/services.yaml
+++ b/custom_components/mitsubishi_wf_rac/services.yaml
@@ -147,7 +147,7 @@ set_home_leave_mode:
       example: 0
       selector:
         number:
-          min: -20
+          min: 0
           max: 30
           step: 0.5
           unit_of_measurement: "°C"

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -48,7 +48,8 @@
     "abort": {
       "existing_instance_updated": "Updated existing configuration.",
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "wrong_device": "This is a different air conditioner than the one this entry was set up for. Point it back at the original unit, or add the other one as its own entry."
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -279,25 +279,25 @@
           },
           "swing_mode": {
             "state": {
-              "up_down_auto": "Up/Down Auto",
+              "up_down_auto": "Up/down auto",
               "highest": "Highest",
               "middle": "Middle",
               "normal": "Normal",
               "lowest": "Lowest",
-              "3d_auto": "3D Auto"
+              "3d_auto": "3D auto"
             }
           },
           "swing_horizontal_mode": {
             "state": {
-              "left_right_auto": "Left/Right Auto",
-              "left_left": "Left-Left",
-              "left_center": "Left-Center",
-              "center_center": "Center-Center",
-              "center_right": "Center-Right",
-              "right_right": "Right-Right",
-              "left_right": "Left-Right",
-              "right_left": "Right-Left",
-              "3d_auto": "3D Auto"
+              "left_right_auto": "Left/right auto",
+              "left_left": "Left-left",
+              "left_center": "Left-center",
+              "center_center": "Center-center",
+              "center_right": "Center-right",
+              "right_right": "Right-right",
+              "left_right": "Left-right",
+              "right_left": "Right-left",
+              "3d_auto": "3D auto"
             }
           }
         }
@@ -307,26 +307,26 @@
       "horizontal_swing": {
         "name": "Horizontal swing direction",
         "state": {
-          "left_right_auto": "Left/Right Auto",
-          "left_left": "Left-Left",
-          "left_center": "Left-Center",
-          "center_center": "Center-Center",
-          "center_right": "Center-Right",
-          "right_right": "Right-Right",
-          "left_right": "Left-Right",
-          "right_left": "Right-Left",
-          "3d_auto": "3D Auto"
+          "left_right_auto": "Left/right auto",
+          "left_left": "Left-left",
+          "left_center": "Left-center",
+          "center_center": "Center-center",
+          "center_right": "Center-right",
+          "right_right": "Right-right",
+          "left_right": "Left-right",
+          "right_left": "Right-left",
+          "3d_auto": "3D auto"
         }
       },
       "vertical_swing": {
         "name": "Vertical swing direction",
         "state": {
-          "up_down_auto": "Up/Down Auto",
+          "up_down_auto": "Up/down auto",
           "highest": "Highest",
           "middle": "Middle",
           "normal": "Normal",
           "lowest": "Lowest",
-          "3d_auto": "3D Auto"
+          "3d_auto": "3D auto"
         }
       },
       "fan_speed": {
@@ -343,8 +343,8 @@
         "name": "Home Leave mode",
         "state": {
           "off": "Off",
-          "away_cool": "Away Cooling",
-          "away_heat": "Away Heating"
+          "away_cool": "Away cooling",
+          "away_heat": "Away heating"
         }
       },
       "home_leave_cooling_air_flow": {

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -152,6 +152,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "Home Leave mode is only available while cooling or heating, not in {hvac_mode}. Switch the unit to cool or heat first, or use the Home Leave Mode select to name the direction."
+    },
+    "status_request_read_failed": {
+      "message": "Could not read the state of the Airco at {device}, so the status request was not sent."
     }
   },
   "entity": {

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -319,7 +319,11 @@
         "name": "Modellnummer"
       },
       "cool_hot_judge": {
-        "name": "Kühl-/Heiz-Status"
+        "name": "Kühl-/Heiz-Status",
+        "state": {
+          "cooling": "Kühlen",
+          "heating": "Heizen"
+        }
       },
       "energy_usage": {
         "name": "Energieverbrauch (aktueller Lauf)"

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -82,6 +82,9 @@
     },
     "external_temperature_source_configured": {
       "message": "Die Innentemperatur wird von der eingerichteten Quell-Entität bestimmt."
+    },
+    "status_request_read_failed": {
+      "message": "Der Zustand des Klimageräts {device} ließ sich nicht lesen, die Statusanfrage wurde deshalb nicht gesendet."
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "Vorhandene Konfiguration aktualisiert.",
       "already_configured": "Klima ist bereits konfiguriert",
-      "reconfigure_successful": "Neukonfiguration erfolgreich"
+      "reconfigure_successful": "Neukonfiguration erfolgreich",
+      "wrong_device": "Hinter dieser Adresse antwortet ein anderes Klimagerät als das, für das dieser Eintrag angelegt wurde. Trage wieder die Adresse des ursprünglichen Geräts ein, oder lege für das andere einen eigenen Eintrag an."
     },
     "step": {
       "user": {

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -172,25 +172,25 @@
           },
           "swing_mode": {
             "state": {
-              "up_down_auto": "Up/Down Auto",
+              "up_down_auto": "Up/down auto",
               "highest": "Highest",
               "middle": "Middle",
               "normal": "Normal",
               "lowest": "Lowest",
-              "3d_auto": "3D Auto"
+              "3d_auto": "3D auto"
             }
           },
           "swing_horizontal_mode": {
             "state": {
-              "left_right_auto": "Left/Right Auto",
-              "left_left": "Left-Left",
-              "left_center": "Left-Center",
-              "center_center": "Center-Center",
-              "center_right": "Center-Right",
-              "right_right": "Right-Right",
-              "left_right": "Left-Right",
-              "right_left": "Right-Left",
-              "3d_auto": "3D Auto"
+              "left_right_auto": "Left/right auto",
+              "left_left": "Left-left",
+              "left_center": "Left-center",
+              "center_center": "Center-center",
+              "center_right": "Center-right",
+              "right_right": "Right-right",
+              "left_right": "Left-right",
+              "right_left": "Right-left",
+              "3d_auto": "3D auto"
             }
           }
         }
@@ -200,26 +200,26 @@
       "horizontal_swing": {
         "name": "Horizontal swing direction",
         "state": {
-          "left_right_auto": "Left/Right Auto",
-          "left_left": "Left-Left",
-          "left_center": "Left-Center",
-          "center_center": "Center-Center",
-          "center_right": "Center-Right",
-          "right_right": "Right-Right",
-          "left_right": "Left-Right",
-          "right_left": "Right-Left",
-          "3d_auto": "3D Auto"
+          "left_right_auto": "Left/right auto",
+          "left_left": "Left-left",
+          "left_center": "Left-center",
+          "center_center": "Center-center",
+          "center_right": "Center-right",
+          "right_right": "Right-right",
+          "left_right": "Left-right",
+          "right_left": "Right-left",
+          "3d_auto": "3D auto"
         }
       },
       "vertical_swing": {
         "name": "Vertical swing direction",
         "state": {
-          "up_down_auto": "Up/Down Auto",
+          "up_down_auto": "Up/down auto",
           "highest": "Highest",
           "middle": "Middle",
           "normal": "Normal",
           "lowest": "Lowest",
-          "3d_auto": "3D Auto"
+          "3d_auto": "3D auto"
         }
       },
       "fan_speed": {
@@ -236,8 +236,8 @@
         "name": "Home Leave mode",
         "state": {
           "off": "Off",
-          "away_cool": "Away Cooling",
-          "away_heat": "Away Heating"
+          "away_cool": "Away cooling",
+          "away_heat": "Away heating"
         }
       },
       "home_leave_cooling_air_flow": {

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -82,6 +82,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "Home Leave mode is only available while cooling or heating, not in {hvac_mode}. Switch the unit to cool or heat first, or use the Home Leave Mode select to name the direction."
+    },
+    "status_request_read_failed": {
+      "message": "Could not read the state of the Airco at {device}, so the status request was not sent."
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "Updated existing configuration.",
       "already_configured": "Airco is already configured",
-      "reconfigure_successful": "Re-configuration was successful"
+      "reconfigure_successful": "Re-configuration was successful",
+      "wrong_device": "This is a different air conditioner than the one this entry was set up for. Point it back at the original unit, or add the other one as its own entry."
     },
     "step": {
       "user": {

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "既存の設定が更新されました。",
       "already_configured": "エアコンは既に設定されています。",
-      "reconfigure_successful": "再設定が完了しました"
+      "reconfigure_successful": "再設定が完了しました",
+      "wrong_device": "このアドレスでは、このエントリーを作成したときとは別のエアコンが応答しています。元の機器のアドレスに戻すか、別の機器として新しいエントリーを追加してください。"
     },
     "step": {
       "user": {

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -315,7 +315,11 @@
         "name": "モデル番号"
       },
       "cool_hot_judge": {
-        "name": "Cool Hot Judge"
+        "name": "Cool Hot Judge",
+        "state": {
+          "cooling": "冷房",
+          "heating": "暖房"
+        }
       },
       "energy_usage": {
         "name": "エネルギー使用量 (今回の運転)"

--- a/custom_components/mitsubishi_wf_rac/translations/ja.json
+++ b/custom_components/mitsubishi_wf_rac/translations/ja.json
@@ -82,6 +82,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "留守モードは冷房または暖房のときだけ使えます（現在は {hvac_mode}）。先に冷房か暖房へ切り替えるか、「留守モード」の選択エンティティで留守冷房・留守暖房を直接指定してください。"
+    },
+    "status_request_read_failed": {
+      "message": "エアコン {device} の状態を読み取れなかったため、ステータス要求は送信されませんでした。"
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "Esami nustatymai atnaujinti.",
       "already_configured": "Kondicionierius jau nustatytas",
-      "reconfigure_successful": "Perkonfigūravimas sėkmingas"
+      "reconfigure_successful": "Perkonfigūravimas sėkmingas",
+      "wrong_device": "Šiuo adresu atsiliepia kitas oro kondicionierius nei tas, kuriam buvo sukurtas šis įrašas. Įveskite pradinio įrenginio adresą arba pridėkite kitą įrenginį kaip atskirą įrašą."
     },
     "step": {
       "user": {

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -315,7 +315,11 @@
         "name": "Modelio Nr."
       },
       "cool_hot_judge": {
-        "name": "Cool Hot Judge"
+        "name": "Cool Hot Judge",
+        "state": {
+          "cooling": "Vėsinimas",
+          "heating": "Šildymas"
+        }
       },
       "energy_usage": {
         "name": "Energijos suvartojimas (dabartinis ciklas)"

--- a/custom_components/mitsubishi_wf_rac/translations/lt.json
+++ b/custom_components/mitsubishi_wf_rac/translations/lt.json
@@ -82,6 +82,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "Išvykimo režimas veikia tik vėsinant arba šildant, o ne režimu {hvac_mode}. Pirma perjunkite įrenginį į vėsinimą ar šildymą arba pasirinkite kryptį per „Išvykimo režimas“."
+    },
+    "status_request_read_failed": {
+      "message": "Nepavyko nuskaityti oro kondicionieriaus {device} būsenos, todėl būsenos užklausa nebuvo išsiųsta."
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -82,6 +82,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "Afwezigheidsmodus werkt alleen tijdens koelen of verwarmen, niet in {hvac_mode}. Zet de unit eerst op koelen of verwarmen, of kies de richting rechtstreeks met de selectie Afwezigheidsmodus."
+    },
+    "status_request_read_failed": {
+      "message": "De staat van de airco {device} kon niet worden gelezen, daarom is de statusaanvraag niet verstuurd."
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -315,7 +315,11 @@
         "name": "Modelnummer"
       },
       "cool_hot_judge": {
-        "name": "Koel-/verwarmingsstatus"
+        "name": "Koel-/verwarmingsstatus",
+        "state": {
+          "cooling": "Koelen",
+          "heating": "Verwarmen"
+        }
       },
       "energy_usage": {
         "name": "Energieverbruik (huidige cyclus)"

--- a/custom_components/mitsubishi_wf_rac/translations/nl.json
+++ b/custom_components/mitsubishi_wf_rac/translations/nl.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "Huidige configuratie is geüpdatet.",
       "already_configured": "Airco is al geconfigureerd",
-      "reconfigure_successful": "Herconfiguratie geslaagd"
+      "reconfigure_successful": "Herconfiguratie geslaagd",
+      "wrong_device": "Op dit adres antwoordt een andere airco dan die waarvoor deze invoer is aangemaakt. Vul weer het adres van het oorspronkelijke apparaat in, of voeg het andere toe als eigen invoer."
     },
     "step": {
       "user": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "已更新现有配置。",
       "already_configured": "空调已配置",
-      "reconfigure_successful": "重新配置成功"
+      "reconfigure_successful": "重新配置成功",
+      "wrong_device": "此地址上响应的空调与创建此条目时的设备不同。请改回原设备的地址，或将另一台设备添加为独立条目。"
     },
     "step": {
       "user": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -82,6 +82,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "离家模式仅在制冷或制热时可用，当前为 {hvac_mode}。请先将设备切换到制冷或制热，或直接用“离家模式”选择项指定离家制冷 / 离家制热。"
+    },
+    "status_request_read_failed": {
+      "message": "无法读取空调 {device} 的状态，因此未发送状态请求。"
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hans.json
@@ -315,7 +315,11 @@
         "name": "型号编号"
       },
       "cool_hot_judge": {
-        "name": "冷热判断"
+        "name": "冷热判断",
+        "state": {
+          "cooling": "制冷",
+          "heating": "制热"
+        }
       },
       "energy_usage": {
         "name": "能耗（当前运行）"

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -10,7 +10,8 @@
     "abort": {
       "existing_instance_updated": "已更新現有配置。",
       "already_configured": "空調已配置",
-      "reconfigure_successful": "重新配置成功"
+      "reconfigure_successful": "重新配置成功",
+      "wrong_device": "此位址上回應的空調與建立此項目時的裝置不同。請改回原裝置的位址，或將另一台裝置新增為獨立項目。"
     },
     "step": {
       "user": {

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -315,7 +315,11 @@
         "name": "型號編號"
       },
       "cool_hot_judge": {
-        "name": "冷熱判斷"
+        "name": "冷熱判斷",
+        "state": {
+          "cooling": "製冷",
+          "heating": "製熱"
+        }
       },
       "energy_usage": {
         "name": "能耗（目前運轉）"

--- a/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
+++ b/custom_components/mitsubishi_wf_rac/translations/zh-Hant.json
@@ -82,6 +82,9 @@
     },
     "preset_away_needs_cool_or_heat": {
       "message": "離家模式僅在製冷或製熱時可用，目前為 {hvac_mode}。請先將設備切換到製冷或製熱，或直接用「離家模式」選擇項指定離家製冷／離家製熱。"
+    },
+    "status_request_read_failed": {
+      "message": "無法讀取空調 {device} 的狀態，因此未傳送狀態請求。"
     }
   },
   "issues": {

--- a/custom_components/mitsubishi_wf_rac/update.py
+++ b/custom_components/mitsubishi_wf_rac/update.py
@@ -6,7 +6,6 @@ that goes.
 # pylint: disable = too-few-public-methods
 
 from __future__ import annotations
-import logging
 
 from homeassistant.components.update import UpdateDeviceClass, UpdateEntity
 from homeassistant.const import EntityCategory
@@ -18,7 +17,6 @@ from .entity import WfRacEntity
 from .coordinator import Device
 from .const import DOMAIN
 
-_LOGGER = logging.getLogger(__name__)
 # Read-only as far as the device is concerned: the coordinator does the
 # polling, and nothing on this platform sends a request of its own.
 PARALLEL_UPDATES = 0

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -599,8 +599,9 @@ async def test_set_external_temperature_refuses_values_with_configured_source(de
     _with_external_temperature_source(device)
     entity = _service_entity(device)
 
-    with pytest.raises(ServiceValidationError, match="configured source"):
+    with pytest.raises(ServiceValidationError) as refused:
         await entity.async_set_external_temperature(temperature=20.0)
+    assert refused.value.translation_key == "external_temperature_source_configured"
 
 
 async def test_set_external_temperature_allows_clearing_with_configured_source(device):
@@ -776,10 +777,9 @@ async def test_set_preset_none_restores_a_normal_setpoint(device):
 # pin is what makes this reachable at all.
 
 
-async def test_unknown_fan_step_leaves_the_entity_constructed(device, monkeypatch):
+async def test_unknown_fan_step_leaves_the_entity_constructed(device):
     device.airco.AirFlow = AIRFLOW_UNKNOWN
-    set_available = MagicMock()
-    monkeypatch.setattr(device, "set_available", set_available)
+    device._set_availability(True)
 
     # Constructing must not raise: the platform would never finish setting up
     # and the entry would load without a climate entity at all.
@@ -788,7 +788,7 @@ async def test_unknown_fan_step_leaves_the_entity_constructed(device, monkeypatc
     # The unit answered and still takes commands, so only this entity's state
     # is unknown - the device stays as available as it was.
     assert entity.hvac_mode is None
-    set_available.assert_not_called()
+    assert device.available is True
 
 
 async def test_unknown_fan_step_is_recognised_by_name(device, monkeypatch):

--- a/tests/integration/test_climate.py
+++ b/tests/integration/test_climate.py
@@ -602,6 +602,7 @@ async def test_set_external_temperature_refuses_values_with_configured_source(de
     with pytest.raises(ServiceValidationError) as refused:
         await entity.async_set_external_temperature(temperature=20.0)
     assert refused.value.translation_key == "external_temperature_source_configured"
+    assert refused.value.generate_message is True
 
 
 async def test_set_external_temperature_allows_clearing_with_configured_source(device):

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -198,6 +198,60 @@ async def test_user_flow_update_account_info_falsy_is_cannot_connect(hass: HomeA
     assert result["errors"] == {"base": "cannot_connect"}
 
 
+async def test_user_flow_registration_failure_is_cannot_connect(hass: HomeAssistant):
+    """The registration request is the second of the two, and the module
+    answers one caller at a time - a timeout there is an ordinary outcome,
+    not an unexpected error."""
+    repo = _mock_repository()
+    repo.update_account_info.side_effect = WfRacError("timeout")
+    with _patch_repository(repo):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "192.168.1.50", "port": 51443}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_unreadable_registration_answer_is_cannot_connect(
+    hass: HomeAssistant,
+):
+    """Whatever answered is not a WF-RAC module."""
+    repo = _mock_repository()
+    repo.update_account_info.return_value = {"result": "not a number"}
+    with _patch_repository(repo):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "192.168.1.50", "port": 51443}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_non_json_answer_is_cannot_connect(hass: HomeAssistant):
+    """Typing the address of some other HTTP service in the house is a
+    connection problem from where the user stands. The library lets
+    json.loads' ValueError through, so the flow has to catch it."""
+    repo = _mock_repository()
+    repo.get_airco_id.side_effect = ValueError("Expecting value: line 1 column 1")
+    with _patch_repository(repo):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "192.168.1.50", "port": 51443}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
 async def test_user_flow_too_many_devices_shows_error(hass: HomeAssistant):
     repo = _mock_repository(update_result=2)
     with _patch_repository(repo):
@@ -258,7 +312,10 @@ def _existing_entry(
 ):
     entry = MockConfigEntry(
         domain=DOMAIN,
-        version=6,
+        version=7,
+        # Every entry carries the unit's own id as its unique id since the v7
+        # migration - a reconfigure compares against it.
+        unique_id="airco-1",
         data={
             "name": name,
             "host": host,
@@ -324,6 +381,27 @@ async def test_reconfigure_flow_allows_resubmitting_the_same_host(hass: HomeAssi
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+
+
+async def test_reconfigure_flow_rejects_a_different_unit(hass: HomeAssistant):
+    """A typo can point the entry at a second air conditioner. Every entity's
+    unique id is built from the airco id, so following it would rename them
+    all, orphan the originals, and leave discovery unable to place either
+    unit."""
+    entry = _existing_entry(hass, host="192.168.1.50")
+
+    repo = _mock_repository(airco_id="airco-2")
+    with _patch_repository(repo):
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "192.168.1.99", "port": 51443},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_device"
+    assert entry.data["host"] == "192.168.1.50"
+    assert entry.data[CONF_AIRCO_ID] == "airco-1"
 
 
 async def test_reconfigure_flow_rejects_another_entrys_host(hass: HomeAssistant):

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -402,6 +402,10 @@ async def test_reconfigure_flow_rejects_a_different_unit(hass: HomeAssistant):
     assert result["reason"] == "wrong_device"
     assert entry.data["host"] == "192.168.1.50"
     assert entry.data[CONF_AIRCO_ID] == "airco-1"
+    # Registering claims one of the few account slots the module has. The
+    # stranger must not lose one to our typo, so the abort comes before the
+    # write, not after it.
+    repo.update_account_info.assert_not_awaited()
 
 
 async def test_reconfigure_flow_rejects_another_entrys_host(hass: HomeAssistant):

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -234,12 +234,23 @@ async def test_user_flow_unreadable_registration_answer_is_cannot_connect(
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_user_flow_non_json_answer_is_cannot_connect(hass: HomeAssistant):
+@pytest.mark.parametrize(
+    "answer",
+    [
+        ValueError("Expecting value: line 1 column 1"),
+        AttributeError("'list' object has no attribute 'get'"),
+        OSError("[SSL] PEM lib"),
+    ],
+    ids=["not json", "json but not an object", "no tls handshake"],
+)
+async def test_user_flow_non_json_answer_is_cannot_connect(
+    hass: HomeAssistant, answer: Exception
+):
     """Typing the address of some other HTTP service in the house is a
-    connection problem from where the user stands. The library lets
-    json.loads' ValueError through, so the flow has to catch it."""
+    connection problem from where the user stands. None of these leave the
+    library as a WfRacError, so the flow has to name them itself."""
     repo = _mock_repository()
-    repo.get_airco_id.side_effect = ValueError("Expecting value: line 1 column 1")
+    repo.get_airco_id.side_effect = answer
     with _patch_repository(repo):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -767,8 +767,8 @@ async def test_home_leave_mode_status_request_does_not_swallow_a_queued_command(
     async_queue_command(), so if it landed in the same consolidation window as
     a real command, both were merged into one AirconStat. to_base64() then
     saw HomeLeaveModeStatusRequest set and picked status_request_to_byte(),
-    which carries no set-bits at all - so the real command (here: a setpoint
-    change) went out unset and was silently ignored by the unit. Sending the
+    which on this module carries no set-bits at all - so the real command
+    (here: a setpoint change) went out unset and was silently ignored. Sending the
     status request directly through set_airco() keeps it out of that merge.
     """
     monkeypatch.setattr(coordinator_module, "UPDATE_CONSOLIDATION_PERIOD", timedelta(milliseconds=5))
@@ -2229,6 +2229,59 @@ async def test_a_unit_switched_off_inside_the_offset_gets_no_request(
     await asyncio.sleep(0.1)
 
     set_airco.assert_not_awaited()
+
+
+async def test_the_home_leave_status_request_echoes_a_fresh_read(device):
+    """The Home Leave status request is a carrying frame too.
+
+    On an affected module RacParser encodes any status request as a full
+    command block, so this action writes every field it holds - and a state
+    left over from the last poll would undo whatever was done at the unit
+    since.
+    """
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device._parser.status_request_carries_state = True
+    stale_fan = device.airco.AirFlow
+    device.set_airco = set_airco = AsyncMock()
+
+    # Somebody reaches for the remote between the poll and the action.
+    device._api.get_aircon_stats.return_value = _stats_response(FAN_SPEED_4_PAYLOAD)
+    await device.async_request_home_leave_mode_status()
+
+    set_airco.assert_awaited()
+    assert device.airco.AirFlow != stale_fan
+
+
+async def test_the_home_leave_status_request_does_not_send_a_state_it_could_not_read(
+    device,
+):
+    """Sending the old state anyway is a write on this module. The caller
+    asked for a reading, so the failure has to reach it."""
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device._parser.status_request_carries_state = True
+    device.set_airco = set_airco = AsyncMock()
+    device._api.get_aircon_stats.side_effect = WfRacError("boom")
+
+    with pytest.raises(HomeAssistantError):
+        await device.async_request_home_leave_mode_status()
+
+    set_airco.assert_not_awaited()
+
+
+async def test_a_plain_home_leave_status_request_reads_nothing_extra(device):
+    """Without the quirk the block holds no set-bits, so there is nothing to
+    echo and no reason to spend a second round trip."""
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device.set_airco = set_airco = AsyncMock()
+    device._api.get_aircon_stats.reset_mock()
+
+    await device.async_request_home_leave_mode_status()
+
+    set_airco.assert_awaited()
+    device._api.get_aircon_stats.assert_not_awaited()
 
 
 async def test_a_carrying_request_writes_the_settings_back_instead_of_zeros(device):

--- a/tests/integration/test_entity.py
+++ b/tests/integration/test_entity.py
@@ -1,8 +1,8 @@
 """Regression test for #219: WfRacEntity._handle_coordinator_update() must
 not report a failure for an entity whose _update_state() runs cleanly.
 EnergyTotalResetButton had no _update_state() at all, so this exact path
-raised AttributeError on every coordinator update and called
-Device.set_available(False) - needs the `hass` fixture (Device is a
+raised AttributeError on every coordinator update and took the whole device
+offline with it - needs the `hass` fixture (Device is a
 DataUpdateCoordinator), hence tests/integration/ rather than tests/unit/.
 """
 
@@ -15,7 +15,10 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.mitsubishi_wf_rac.button import EnergyTotalResetButton
 from custom_components.mitsubishi_wf_rac.const import DOMAIN
 from custom_components.mitsubishi_wf_rac.entity import WfRacEntity
-from custom_components.mitsubishi_wf_rac.coordinator import Device
+from custom_components.mitsubishi_wf_rac.coordinator import (
+    AVAILABILITY_FAILURE_LIMIT_MIN,
+    Device,
+)
 
 
 @pytest.fixture
@@ -29,15 +32,17 @@ async def device(hass):
     return dev
 
 
-async def test_coordinator_update_does_not_report_failure(device, monkeypatch):
+async def test_coordinator_update_does_not_report_failure(device):
     entity = EnergyTotalResetButton(device)
     entity.async_write_ha_state = lambda: None
-    reported = []
-    monkeypatch.setattr(device, "set_available", lambda available: reported.append(available))
+    # A device starts out unavailable and becomes available with its first
+    # successful poll; this one has none, so say so up front.
+    device._set_availability(True)
 
-    entity._handle_coordinator_update()
+    for _ in range(AVAILABILITY_FAILURE_LIMIT_MIN + 1):
+        entity._handle_coordinator_update()
 
-    assert reported == []
+    assert device.available is True
 
 
 async def test_coordinator_contexts_include_only_contextual_entities(device):
@@ -57,22 +62,22 @@ async def test_coordinator_contexts_include_only_contextual_entities(device):
     contextless_entity._call_on_remove_callbacks()
 
 
-async def test_an_unreadable_frame_marks_the_entity_unknown_not_the_device(
-    device, monkeypatch
-):
+async def test_an_unreadable_frame_marks_the_entity_unknown_not_the_device(device):
     """The unit answered and still takes commands, so it is not unavailable."""
     entity = WfRacEntity(device)
     entity._update_state = MagicMock(side_effect=ValueError)
     entity._mark_state_unknown = MagicMock()
     entity.async_write_ha_state = lambda: None
-    set_available = MagicMock()
-    monkeypatch.setattr(device, "set_available", set_available)
+    device._set_availability(True)
 
-    entity._handle_coordinator_update()
+    # More failures in a row than it takes to declare the device unavailable:
+    # one unreadable field must not do it, and neither must a run of them.
+    for _ in range(AVAILABILITY_FAILURE_LIMIT_MIN + 1):
+        entity._handle_coordinator_update()
 
-    entity._mark_state_unknown.assert_called_once_with()
-    set_available.assert_not_called()
-    assert entity.available is device.available
+    entity._mark_state_unknown.assert_called_with()
+    assert device.available is True
+    assert entity.available is True
 
 
 async def test_apply_state_swallows_a_first_read_that_fails(device, monkeypatch):

--- a/tests/integration/test_entity.py
+++ b/tests/integration/test_entity.py
@@ -6,6 +6,7 @@ offline with it - needs the `hass` fixture (Device is a
 DataUpdateCoordinator), hence tests/integration/ rather than tests/unit/.
 """
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -32,17 +33,17 @@ async def device(hass):
     return dev
 
 
-async def test_coordinator_update_does_not_report_failure(device):
+async def test_coordinator_update_does_not_report_failure(device, caplog):
+    """EnergyTotalResetButton had no _update_state() at all, so every
+    coordinator update raised AttributeError inside it."""
     entity = EnergyTotalResetButton(device)
     entity.async_write_ha_state = lambda: None
-    # A device starts out unavailable and becomes available with its first
-    # successful poll; this one has none, so say so up front.
-    device._set_availability(True)
 
-    for _ in range(AVAILABILITY_FAILURE_LIMIT_MIN + 1):
+    with caplog.at_level(logging.WARNING):
         entity._handle_coordinator_update()
 
-    assert device.available is True
+    assert "Could not update" not in caplog.text
+    assert entity._state_unreadable is False
 
 
 async def test_coordinator_contexts_include_only_contextual_entities(device):

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -8,7 +8,7 @@ import pytest
 
 from homeassistant.components.climate.const import HVACAction, HVACMode
 from homeassistant.const import EntityCategory
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry, MockEntityPlatform
 
@@ -251,11 +251,16 @@ async def test_climate_commands_and_state_branches(platform_device):
     await entity.async_set_swing_horizontal_mode(horizontal)
     assert platform_device.async_queue_command.await_args.args[0][AirconCommands.Entrust] is False
 
-    with pytest.raises(ServiceValidationError, match="below minimum") as below:
+    with pytest.raises(ServiceValidationError) as below:
         await entity.async_set_temperature(temperature=9, hvac_mode=HVACMode.HEAT)
-    with pytest.raises(ServiceValidationError, match="above maximum") as above:
+    with pytest.raises(ServiceValidationError) as above:
         await entity.async_set_temperature(temperature=34, hvac_mode=HVACMode.COOL)
 
+    # Asserted on the key, not on the rendered text: the message the user
+    # reads comes from strings.json, and matching the English wording here
+    # would pass just as well if the key were wrong.
+    assert below.value.translation_key == "temperature_below_minimum"
+    assert above.value.translation_key == "temperature_above_maximum"
     # The message names the mode the range came from - without the
     # placeholder it renders as a literal {hvac_mode} and the one useful part
     # of the message is gone.
@@ -273,8 +278,9 @@ async def test_climate_commands_and_state_branches(platform_device):
     assert entity.min_temp == 16
     entity._attr_hvac_mode = HVACMode.HEAT
     assert entity.min_temp == 18
-    with pytest.raises(ServiceValidationError, match="below minimum"):
+    with pytest.raises(ServiceValidationError) as too_low:
         await entity.async_set_temperature(temperature=16)
+    assert too_low.value.translation_key == "temperature_below_minimum"
     entity._attr_hvac_mode = HVACMode.COOL
 
     platform_device.airco.Operation = True
@@ -290,8 +296,9 @@ async def test_climate_commands_and_state_branches(platform_device):
     assert entity.hvac_action == HVACAction.HEATING
 
     platform_device.airco.Capabilities = replace(platform_device.airco.Capabilities, home_leave_mode=False)
-    with pytest.raises(Exception, match="does not report"):
+    with pytest.raises(ServiceValidationError) as unsupported:
         await entity.async_request_home_leave_mode_status()
+    assert unsupported.value.translation_key == "home_leave_mode_not_supported"
     platform_device.airco.Capabilities = replace(platform_device.airco.Capabilities, home_leave_mode=True)
     platform_device.async_request_home_leave_mode_status = AsyncMock()
     platform_device.async_set_home_leave_mode = AsyncMock()
@@ -347,8 +354,9 @@ async def test_select_command_and_state_branches(hass, platform_device):
         select.HomeLeaveAirFlowSelect(platform_device, "heating"),
         "select.home_leave_heating_air_flow",
     )
-    with pytest.raises(Exception, match="unknown yet"):
+    with pytest.raises(HomeAssistantError) as unknown:
         await airflow.async_select_option("2")
+    assert unknown.value.translation_key == "home_leave_mode_status_unknown"
     platform_device.airco.HomeLeaveModeForCooling = HomeLeaveModeSetting(12, 31, 0)
     platform_device.airco.HomeLeaveModeForHeating = HomeLeaveModeSetting(13, 10, 1)
     platform_device.async_set_home_leave_mode = AsyncMock()
@@ -390,8 +398,9 @@ async def test_home_leave_controls_require_known_settings_and_preserve_other_sid
         number.HomeLeaveModeNumber(platform_device, mode, attribute),
         f"number.home_leave_{mode}_{attribute.lower()}",
     )
-    with pytest.raises(Exception, match="unknown yet"):
+    with pytest.raises(HomeAssistantError) as unknown:
         await control.async_set_native_value(15)
+    assert unknown.value.translation_key == "home_leave_mode_status_unknown"
     platform_device.airco.HomeLeaveModeForCooling = HomeLeaveModeSetting(12, 31, 0)
     platform_device.airco.HomeLeaveModeForHeating = HomeLeaveModeSetting(13, 10, 1)
     await control.async_set_native_value(15)
@@ -409,20 +418,19 @@ async def test_update_version_states(platform_device, available, latest):
     assert entity.latest_version == (latest if available else "1.0")
 
 
-async def test_fan_speed_select_recognises_an_unreadable_fan_step(platform_device, monkeypatch):
+async def test_fan_speed_select_recognises_an_unreadable_fan_step(platform_device):
     """Same marker as the climate entity's fan mode, same first-read guard.
 
     FanSpeedSelect indexes FAN_MODE_TRANSLATION from its own __init__, so an
     AIRFLOW_UNKNOWN nibble used to take the whole select platform with it.
     """
     platform_device.airco.AirFlow = AIRFLOW_UNKNOWN
-    set_available = MagicMock()
-    monkeypatch.setattr(platform_device, "set_available", set_available)
+    platform_device._set_availability(True)
 
     fan = select.FanSpeedSelect(platform_device)
 
     assert fan.current_option is None
-    set_available.assert_not_called()
+    assert platform_device.available is True
 
 
 async def test_home_leave_air_flow_select_recognises_an_unreadable_step(
@@ -432,13 +440,12 @@ async def test_home_leave_air_flow_select_recognises_an_unreadable_step(
     platform_device.airco.HomeLeaveModeForCooling = HomeLeaveModeSetting(
         TempRule=35.0, TempSetting=33.0, AirFlow=AIRFLOW_UNKNOWN
     )
-    set_available = MagicMock()
-    platform_device.set_available = set_available
+    platform_device._set_availability(True)
 
     entity = select.HomeLeaveAirFlowSelect(platform_device, "cooling")
 
     assert entity.current_option is None
-    set_available.assert_not_called()
+    assert platform_device.available is True
 
 
 async def test_the_climate_entity_is_the_device_itself(platform_device):

--- a/tests/integration/test_entity_platforms.py
+++ b/tests/integration/test_entity_platforms.py
@@ -261,6 +261,11 @@ async def test_climate_commands_and_state_branches(platform_device):
     # would pass just as well if the key were wrong.
     assert below.value.translation_key == "temperature_below_minimum"
     assert above.value.translation_key == "temperature_above_maximum"
+    # generate_message, not just the key: HomeAssistantError only renders
+    # the translation when it is constructed without a message of its own,
+    # and the key alone is set either way.
+    assert below.value.generate_message is True
+    assert above.value.generate_message is True
     # The message names the mode the range came from - without the
     # placeholder it renders as a literal {hvac_mode} and the one useful part
     # of the message is gone.
@@ -281,6 +286,7 @@ async def test_climate_commands_and_state_branches(platform_device):
     with pytest.raises(ServiceValidationError) as too_low:
         await entity.async_set_temperature(temperature=16)
     assert too_low.value.translation_key == "temperature_below_minimum"
+    assert too_low.value.generate_message is True
     entity._attr_hvac_mode = HVACMode.COOL
 
     platform_device.airco.Operation = True
@@ -299,6 +305,7 @@ async def test_climate_commands_and_state_branches(platform_device):
     with pytest.raises(ServiceValidationError) as unsupported:
         await entity.async_request_home_leave_mode_status()
     assert unsupported.value.translation_key == "home_leave_mode_not_supported"
+    assert unsupported.value.generate_message is True
     platform_device.airco.Capabilities = replace(platform_device.airco.Capabilities, home_leave_mode=True)
     platform_device.async_request_home_leave_mode_status = AsyncMock()
     platform_device.async_set_home_leave_mode = AsyncMock()
@@ -357,6 +364,7 @@ async def test_select_command_and_state_branches(hass, platform_device):
     with pytest.raises(HomeAssistantError) as unknown:
         await airflow.async_select_option("2")
     assert unknown.value.translation_key == "home_leave_mode_status_unknown"
+    assert unknown.value.generate_message is True
     platform_device.airco.HomeLeaveModeForCooling = HomeLeaveModeSetting(12, 31, 0)
     platform_device.airco.HomeLeaveModeForHeating = HomeLeaveModeSetting(13, 10, 1)
     platform_device.async_set_home_leave_mode = AsyncMock()
@@ -401,6 +409,7 @@ async def test_home_leave_controls_require_known_settings_and_preserve_other_sid
     with pytest.raises(HomeAssistantError) as unknown:
         await control.async_set_native_value(15)
     assert unknown.value.translation_key == "home_leave_mode_status_unknown"
+    assert unknown.value.generate_message is True
     platform_device.airco.HomeLeaveModeForCooling = HomeLeaveModeSetting(12, 31, 0)
     platform_device.airco.HomeLeaveModeForHeating = HomeLeaveModeSetting(13, 10, 1)
     await control.async_set_native_value(15)
@@ -443,6 +452,62 @@ async def test_home_leave_air_flow_select_recognises_an_unreadable_step(
     platform_device._set_availability(True)
 
     entity = select.HomeLeaveAirFlowSelect(platform_device, "cooling")
+
+    assert entity.current_option is None
+    assert platform_device.available is True
+
+
+async def test_marking_the_climate_state_unknown_clears_all_of_it(platform_device):
+    """state: unknown next to a fresh temperature and a stale action is worse
+    than either. _update_state() writes the setpoint and the room reading
+    before it reaches a field that can fail, so the hook has to undo the lot.
+    """
+    entity = climate.AircoClimate(platform_device)
+    assert entity.hvac_action is not None
+    assert entity.target_temperature is not None
+
+    entity._mark_state_unknown()
+
+    assert entity.hvac_mode is None
+    assert entity.hvac_action is None
+    assert entity.target_temperature is None
+    assert entity.current_temperature is None
+    assert entity.fan_mode is None
+    assert entity.swing_mode is None
+    assert entity.swing_horizontal_mode is None
+    assert entity.preset_mode is None
+
+
+async def test_marking_the_problem_state_unknown_drops_the_error_code(platform_device):
+    """The code is part of the state. Left behind, state_attr() keeps
+    answering with the last fault while the entity says it knows nothing."""
+    platform_device.airco.ErrorCode = "E7"
+    entity = binary_sensor.ProblemBinarySensor(platform_device)
+    assert entity.extra_state_attributes["error_code"] == "E7"
+
+    entity._mark_state_unknown()
+
+    assert entity.is_on is None
+    assert not entity.extra_state_attributes
+
+
+@pytest.mark.parametrize(
+    ("cls", "field"),
+    [
+        (select.HorizontalSwingSelect, "WindDirectionLR"),
+        (select.VerticalSwingSelect, "WindDirectionUD"),
+    ],
+)
+async def test_a_swing_select_survives_a_vane_value_it_cannot_read(
+    platform_device, cls, field
+):
+    """Both used to decode in __init__ instead of going through
+    _apply_state(), so one unreadable vane byte took the whole platform down
+    and the entry came up with no selects at all."""
+    setattr(platform_device.airco, field, 99)
+    platform_device.airco.Entrust = False
+
+    entity = cls(platform_device)
 
     assert entity.current_option is None
     assert platform_device.available is True

--- a/tests/integration/test_sensor.py
+++ b/tests/integration/test_sensor.py
@@ -42,6 +42,7 @@ async def test_setting_the_total_on_the_wrong_sensor_says_which(
             wrong, MagicMock(spec=ServiceCall, data={"value": 12.0})
         )
     assert wrong_sensor.value.translation_key == "entity_not_energy_total_sensor"
+    assert wrong_sensor.value.generate_message is True
     # The entity id is the whole point of the message and reaches it through
     # the placeholder, not through the text.
     assert (
@@ -90,6 +91,27 @@ async def test_the_judge_reports_nothing_when_it_means_nothing(
 def test_a_stored_state_that_cannot_be_read_restores_nothing():
     """from_dict has to answer for anything the state store hands it."""
     assert EnergyTotalExtraStoredData.from_dict({"native_value": 3.0}) is None
+
+
+async def test_the_total_is_stored_even_while_the_frame_is_unreadable(
+    platform_device,
+):
+    """What gets written to the store is the running total, not the displayed
+    value: an unreadable frame blanks the display, and a restart in that
+    window used to bring the meter back at zero.
+    """
+    platform_device.airco.Electric = 1.0
+    sensor = EnergyTotalSensor(platform_device)
+    sensor._total = 123.5
+
+    sensor._mark_state_unknown()
+    assert sensor.native_value is None
+
+    stored = EnergyTotalExtraStoredData.from_dict(
+        sensor.extra_restore_state_data.as_dict()
+    )
+    assert stored is not None
+    assert stored.native_value == 123.5
 
 
 async def test_the_total_survives_a_restart(hass: HomeAssistant, platform_device):

--- a/tests/integration/test_sensor.py
+++ b/tests/integration/test_sensor.py
@@ -37,10 +37,17 @@ async def test_setting_the_total_on_the_wrong_sensor_says_which(
     wrong = DiagnosticsSensor(platform_device, "error")
     wrong.entity_id = "sensor.living_room_error"
 
-    with pytest.raises(ServiceValidationError, match="sensor.living_room_error"):
+    with pytest.raises(ServiceValidationError) as wrong_sensor:
         await async_set_energy_total(
             wrong, MagicMock(spec=ServiceCall, data={"value": 12.0})
         )
+    assert wrong_sensor.value.translation_key == "entity_not_energy_total_sensor"
+    # The entity id is the whole point of the message and reaches it through
+    # the placeholder, not through the text.
+    assert (
+        wrong_sensor.value.translation_placeholders["entity_id"]
+        == "sensor.living_room_error"
+    )
 
 
 async def test_setting_the_total_reanchors_the_meter(

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -60,8 +60,9 @@ async def test_actions_exist_without_a_working_device(hass: HomeAssistant):
 async def test_set_home_leave_mode_rejects_a_temperature_the_unit_cannot_hold(
     hass: HomeAssistant, field: str
 ):
-    """The thresholds go out as int(value * 2) in a single byte. Unchecked, a
-    mistyped 200 was masked to 144 and written back as 72 °C without a word.
+    """The thresholds go out as int(value * 2) in a single byte, masked rather
+    than refused - anything outside the range reaches the unit as a different
+    temperature.
     """
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
@@ -86,9 +87,8 @@ async def test_set_home_leave_mode_rejects_a_temperature_the_unit_cannot_hold(
 
 
 async def test_set_external_temperature_takes_a_numeric_string(hass: HomeAssistant):
-    """Every other numeric field in this file coerces first; this one went
-    straight to vol.Range, where a string is not orderable against a float -
-    so a templated value, which renders as a string, was rejected.
+    """A templated value renders as a string, and a string is not orderable
+    against a float - so the schema has to coerce before it compares.
     """
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -10,6 +10,9 @@ longer depend on a platform having come up.
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+import voluptuous as vol
+
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
@@ -48,6 +51,64 @@ async def test_actions_exist_without_a_working_device(hass: HomeAssistant):
 
     for action in _ACTIONS:
         assert hass.services.has_service(DOMAIN, action), action
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["temp_rule_cooling", "temp_setting_cooling", "temp_rule_heating", "temp_setting_heating"],
+)
+async def test_set_home_leave_mode_rejects_a_temperature_the_unit_cannot_hold(
+    hass: HomeAssistant, field: str
+):
+    """The thresholds go out as int(value * 2) in a single byte. Unchecked, a
+    mistyped 200 was masked to 144 and written back as 72 °C without a word.
+    """
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    data = {
+        "temp_rule_cooling": 35.0,
+        "temp_setting_cooling": 33.0,
+        "air_flow_cooling": 0,
+        "temp_rule_heating": 5.0,
+        "temp_setting_heating": 10.0,
+        "air_flow_heating": 0,
+    }
+    data[field] = 200.0
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_HOME_LEAVE_MODE,
+            {**data, "entity_id": "climate.not_here"},
+            blocking=True,
+        )
+
+
+async def test_set_external_temperature_takes_a_numeric_string(hass: HomeAssistant):
+    """Every other numeric field in this file coerces first; this one went
+    straight to vol.Range, where a string is not orderable against a float -
+    so a templated value, which renders as a string, was rejected.
+    """
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    # Passes validation; there is no entity to run it against, which the
+    # service layer reports as a warning rather than raising.
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_EXTERNAL_TEMPERATURE,
+        {"temperature": "21.5", "entity_id": "climate.not_here"},
+        blocking=True,
+    )
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_EXTERNAL_TEMPERATURE,
+            {"temperature": "99", "entity_id": "climate.not_here"},
+            blocking=True,
+        )
 
 
 async def test_options_flow_reloads_itself(hass: HomeAssistant):

--- a/tests/unit/test_entity_coverage.py
+++ b/tests/unit/test_entity_coverage.py
@@ -1,10 +1,12 @@
-"""Guards against the #219 regression: a WfRacEntity subclass that doesn't
-override _update_state(). WfRacEntity._handle_coordinator_update() calls
-self._update_state() unconditionally on every coordinator update; a missing
-override raises AttributeError, which the base class's except clause treats
-as an update failure and reports it through Device.set_available(False) -
-not just for the one entity missing it.
+"""Guards against the #219 regression: a WfRacEntity subclass that leaves one
+of the two hooks to the base class. WfRacEntity._apply_state() calls
+_update_state() on every coordinator update and _mark_state_unknown() whenever
+that read fails; the base implementations raise NotImplementedError, so a
+missing override turns every poll - or every unreadable frame - into a
+traceback.
 """
+
+import pytest
 
 from custom_components.mitsubishi_wf_rac import (
     binary_sensor,  # noqa: F401
@@ -18,11 +20,19 @@ from custom_components.mitsubishi_wf_rac import (
 from custom_components.mitsubishi_wf_rac.entity import WfRacEntity
 
 
-def test_every_entity_subclass_overrides_update_state():
+@pytest.mark.parametrize("hook", ["_update_state", "_mark_state_unknown"])
+def test_every_entity_subclass_overrides(hook):
     # Importing the platform modules above is what populates this - each of
     # their entity classes subclasses WfRacEntity directly.
     subclasses = WfRacEntity.__subclasses__()
     assert subclasses
 
-    missing = [cls.__name__ for cls in subclasses if not hasattr(cls, "_update_state")]
-    assert not missing, f"missing _update_state(): {missing}"
+    # Compared against the base implementation rather than asked for with
+    # hasattr(): the base class defines both hooks, so hasattr() is true for
+    # every subclass whether it overrides them or not.
+    missing = [
+        cls.__name__
+        for cls in subclasses
+        if getattr(cls, hook) is getattr(WfRacEntity, hook)
+    ]
+    assert not missing, f"missing {hook}(): {missing}"


### PR DESCRIPTION
Everything the second review round turned up, in one PR rather than three — the same maintainer reviews and merges all of it either way.

## Defects

**The Home Leave status action carried a stale full command block.** `RacParser` encodes *any* status request as a full command with set-bits on a module that carries its state (#329), and this action sent it straight from `self._airco` — up to a poll old. A setpoint changed at the remote was written back, and a unit somebody had just switched on was switched off again. The operation-data path has been guarded since #361; the action now uses the same guard and reports a failed read instead of falling back on the state it holds.

**The registration request had no error handling.** Only `get_airco_id()` sat in a targeted `except`. A timeout on `update_account_info()` — likelier, since the module answers one caller at a time — came back as *"unexpected error, check the log"*. Same for a non-JSON reply, which is what a wrong address with another HTTP service behind it returns: `pywfrac` lets `json.loads`' `ValueError` through and neither clause listed it.

**A reconfigure never checked which unit answered.** A typo landing on the second air conditioner in the house wrote its id into `entry.data` while `entry.unique_id` stayed on the first: every entity id changes, the originals are orphaned, discovery matches neither. `_abort_if_unique_id_mismatch` now stops it — `quality_scale.yaml` has listed `reconfiguration-flow: done` all along.

**`set_home_leave_mode` accepted anything.** The four temperature fields had no bounds while the airflow fields did. Values go out as `int(value * 2)` in one byte and `pywfrac` masks rather than refuses, so `200` instead of `20.0` was written back as **72 °C** silently.

**Eight more exceptions never rendered their translation** — message and `translation_key` passed together, the same defect fixed for `ConfigEntryNotReady` last week.

**`_mark_state_unknown()` left most of the state behind.** Climate cleared `hvac_mode` alone, though `_update_state()` writes the setpoint and room reading before it reaches a field that can fail — a fresh temperature and a stale `hvac_action` stood next to a state the entity called unknown. The problem sensor kept `error_code` in its attributes the same way.

**`EnergyTotalSensor` could lose its lifetime meter** — it persisted `native_value`, which is `None` while a frame is unreadable, so a restart in that window restored a total of zero.

**The two swing selects still bypassed `_apply_state()`** in `__init__`, so an unreadable field there took the whole select platform down.

**The guard against exactly that could not fail:** `hasattr(cls, "_update_state")` is true for every subclass because the base class defines it. It compares against the base implementation now, and covers `_mark_state_unknown()` too.

## Style the reviewers flagged

`cool_hot_judge`'s enum options were missing from six translations; four selects overrode `SelectEntity.select_option()` as if it were a setter; `Device.set_available()` had no caller left; `coordinator.py` imported `override` and `suppress` unused; four platforms defined an unused `_LOGGER`; one mode number was hardcoded beside the table that names it; the state lists were Title Case; three oversized docstrings and a handful of comments explaining what the code used to look like were cut back (`coordinator.py` comment share 45% → 21%).

`services.yaml` offered `min: -20` for the heating rule, which the unit reads back unsigned as 108 — the selector now stops where the round trip does.

## Tests

Thirteen new. Every one was verified against the unpatched code: each fails without the change it covers. The three tests that pinned English exception wording now pin the translation key, and the ones that probed `Device.set_available` assert on `device.available` instead — behaviour rather than the method that no longer exists. 355 pass, mypy clean.