### PR TITLE
Watch for the whole block being applied, not just the shutdown

### DIFF
--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -21,16 +21,20 @@ from .const import (
     CONF_AVAILABILITY_CHECK,
     CONF_AVAILABILITY_RETRY_LIMIT,
     CONF_CARRY_POWER_STATE,
+    CONF_STATUS_REQUEST_MODE,
     CONF_CONNECTION_METHOD,
     CONF_FIRMWARE_UPDATE_CHECK,
     CONF_OPERATOR_ID, CONF_CREATE_SWING_MODE_SELECT,
     DOMAIN,
+    STATUS_REQUEST_ECHO,
+    STATUS_REQUEST_STRICT,
 )
 from .coordinator import (
     AVAILABILITY_FAILURE_LIMIT_MIN,
     Device,
     registration_full_issue_id,
     request_stops_unit_issue_id,
+    status_request_unsupported_issue_id,
 )
 from .services import async_setup_services
 
@@ -211,15 +215,22 @@ async def create_device_from_entry(entry: ConfigEntry, hass: HomeAssistant) -> D
         CONF_AVAILABILITY_RETRY_LIMIT, AVAILABILITY_FAILURE_LIMIT_MIN
     )
     connection_method: str | None = entry.data.get(CONF_CONNECTION_METHOD)
-    # The stored key predates the fix and named only the power bit; the flag
-    # it sets now decides whether the whole state is carried.
-    carries_state: bool = bool(entry.data.get(CONF_CARRY_POWER_STATE, False))
+    # Not migrated in async_migrate_entry: this is learned state, not
+    # configuration, and an entry that has never met the fault simply has
+    # neither key. The old one is honoured where it exists so a beta tester
+    # who already paid for the discovery does not pay again.
+    status_request_mode: str = entry.data.get(
+        CONF_STATUS_REQUEST_MODE,
+        STATUS_REQUEST_ECHO
+        if entry.data.get(CONF_CARRY_POWER_STATE, False)
+        else STATUS_REQUEST_STRICT,
+    )
     _device = Device(hass, entry, name, device, port, device_id, operator_id, airco_id,
                      swing_selects_enabled_default,
                      availability_failure_limit=availability_failure_limit,
                      firmware_update_check_enabled=firmware_update_check_enabled,
                      connection_method=connection_method,
-                     status_request_carries_state=carries_state)
+                     status_request_mode=status_request_mode)
     return _device
 
 
@@ -271,3 +282,6 @@ async def async_remove_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEn
     # pointing at an entry_id that no longer resolves to anything.
     ir.async_delete_issue(hass, DOMAIN, registration_full_issue_id(entry.entry_id))
     ir.async_delete_issue(hass, DOMAIN, request_stops_unit_issue_id(entry.entry_id))
+    ir.async_delete_issue(
+        hass, DOMAIN, status_request_unsupported_issue_id(entry.entry_id)
+    )

--- a/custom_components/mitsubishi_wf_rac/const.py
+++ b/custom_components/mitsubishi_wf_rac/const.py
@@ -37,9 +37,27 @@ CONF_FIRMWARE_UPDATE_CHECK = "firmware_update_check"
 # New entries must not write this key.
 CONF_CREATE_SWING_MODE_SELECT = "create_swing_mode_select"
 CONF_CONNECTION_METHOD = "connection_method"
-# Learned, not configured: set once a module has shown that it applies the
-# operation-data request's empty power field as "switch off" (see
-# Device._check_request_stopped_unit).
+# Learned, not configured: which shape of operation-data request this unit can
+# be asked with. Written by Device._check_request_was_applied() the first time
+# the unit answers one by changing its own settings.
+#
+# strict  the request carries an empty command block, no set-bits. Correct
+#         everywhere the set-bit convention holds, which is everywhere we have
+#         measured except one module (#329).
+# echo    the block carries the unit's own settings, every set-bit set, read a
+#         moment before it goes out - so the frame confirms the settings a
+#         strict block would clear. What the manufacturer's app sends.
+# silent  no request at all. The last resort for a unit that changes its
+#         settings even when the frame confirms them: the operation-data
+#         sensors and the external-temperature override are given up so the
+#         unit stays usable.
+CONF_STATUS_REQUEST_MODE = "status_request_mode"
+STATUS_REQUEST_STRICT = "strict"
+STATUS_REQUEST_ECHO = "echo"
+STATUS_REQUEST_SILENT = "silent"
+
+# Superseded by CONF_STATUS_REQUEST_MODE and read only to carry entries written
+# by 2026.9.9-beta2..beta6 forward. True there means what "echo" means now.
 CONF_CARRY_POWER_STATE = "carry_power_state"
 ATTR_DEVICE_ID = "device_id"
 ATTR_CONNECTED_ACCOUNTS = "connected_accounts"

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -7,7 +7,7 @@ from collections import deque
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Final
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -24,16 +24,19 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     AC_CERT_FILENAME,
-    CONF_CARRY_POWER_STATE,
     CONF_EXTERNAL_TEMPERATURE_SOURCE,
     CONF_OVERSHOOT_COOL,
     CONF_OVERSHOOT_DRY,
     CONF_OVERSHOOT_HEAT,
+    CONF_STATUS_REQUEST_MODE,
     DOMAIN,
     MIN_TIME_BETWEEN_UPDATES,
     OPERATION_MODE_COOL,
     OPERATION_MODE_DRY,
     OPERATION_MODE_HEAT,
+    STATUS_REQUEST_ECHO,
+    STATUS_REQUEST_SILENT,
+    STATUS_REQUEST_STRICT,
 )
 from pywfrac import (
     Aircon,
@@ -171,11 +174,26 @@ FOREIGN_ACTIVITY_BACKOFF = timedelta(minutes=3)
 # point.
 WRITE_LOCK_RETRY_DELAY = timedelta(seconds=10)
 
-# How often a unit has to stop inside our own operation-data request before we
-# accept that the request is what stops it. See _check_request_stopped_unit():
-# the signal we have cannot separate us from another local client, so one
-# occurrence is a coincidence and two in a row is not.
-STOPPED_ON_REQUEST_BEFORE_CARRYING = 2
+# What the settings look like on a unit that applied an all-zero command block.
+# Every field in it decodes to the lowest value it can hold: power off, mode
+# auto, fan and both vane axes to their first position. The setpoint is not
+# listed because its zero is clamped by the unit to a floor we cannot know from
+# here (10 C on the one module that does this) - it is checked as "moved down"
+# instead. See _check_request_was_applied().
+EMPTY_BLOCK_SETTINGS: Final = {
+    "Operation": False,
+    "OperationMode": 0,
+    "AirFlow": 1,
+    "WindDirectionUD": 1,
+    "WindDirectionLR": 1,
+}
+
+# How many of those fields have to land on their zero value at once before we
+# call it applied rather than coincidence. Three, and only when no field moved
+# anywhere else in the same answer: somebody turning the fan down to step 1 and
+# the setpoint down with it would otherwise read as the fault, and the cost of
+# believing that is undoing the change they just made.
+EMPTY_BLOCK_MATCH_MIN: Final = 3
 
 # The lock runs 60 seconds, so a longer wait than that means the deadline was
 # stamped by a client whose clock is off rather than that the lock is really
@@ -248,8 +266,18 @@ AVAILABILITY_FAILURE_LIMIT_MIN = 3
 
 
 def request_stops_unit_issue_id(entry_id: str) -> str:
-    """Repair-issue id for a unit that stops when asked for operation data."""
+    """Repair-issue id for a unit that applies the request meant only to ask."""
     return f"request_stops_unit_{entry_id}"
+
+
+def status_request_unsupported_issue_id(entry_id: str) -> str:
+    """Repair-issue id for a unit we have stopped asking altogether.
+
+    Its own id rather than a second wording under the one above: the two say
+    different things and the second replaces the first, so the first has to be
+    withdrawn rather than overwritten.
+    """
+    return f"status_request_unsupported_{entry_id}"
 
 
 def registration_full_issue_id(entry_id: str) -> str:
@@ -283,7 +311,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             availability_failure_limit: int = AVAILABILITY_FAILURE_LIMIT_MIN,
             firmware_update_check_enabled: bool = False,
             connection_method: str | None = None,
-            status_request_carries_state: bool = False,
+            status_request_mode: str = STATUS_REQUEST_STRICT,
     ) -> None:
         self._api = Repository(
             async_get_clientsession(hass),
@@ -298,7 +326,10 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         # Carried over from a previous run: a module that applies a frame it
         # was not asked to apply has always done so, and relearning costs the
         # unit the same disturbance every time.
-        self._parser.status_request_carries_state = status_request_carries_state
+        self._status_request_mode = status_request_mode
+        self._parser.status_request_carries_state = (
+            status_request_mode == STATUS_REQUEST_ECHO
+        )
 
         # Protected state
         self._airco = Aircon()
@@ -312,7 +343,6 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         self._firmware = ""
         self._connected_accounts = -1
         self._updated_by: str | None = None
-        self._stopped_on_request = 0
         self._account_expires: int | None = None
         self._led_status: int | None = None
         self._auto_heating: int | None = None
@@ -970,15 +1000,18 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             and dt_util.utcnow() < self._foreign_activity_until
         )
 
-    def _power_state_is_safe_to_carry(self) -> bool:
+    def _status_request_is_allowed(self) -> bool:
         """Whether an operation-data request may go out right now.
 
-        Only False on a unit that carries its state (#329) while we believe it
-        is off, because there the block is applied rather than ignored. Sending
-        it empty instead is the original fault - the module reads the zeros as
-        a command to clear the settings - and a reading taken while the unit is
-        off is worth little, so it waits for a poll that finds it running.
+        False on a unit we have given up asking (#329), and false on one that
+        carries its state while we believe it is off: there the block is
+        applied rather than ignored, so an "off" read a moment before the frame
+        goes out would be written back as a command if the remote switched the
+        unit on in between. A reading taken while the unit is off is worth
+        little anyway, so it waits for a poll that finds it running.
         """
+        if self._status_request_mode == STATUS_REQUEST_SILENT:
+            return False
         return not self._parser.status_request_carries_state or bool(
             self._airco is not None and self._airco.Operation
         )
@@ -990,7 +1023,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         service_data_codes = self._subscribed_service_data_codes()
         if not service_data_codes:
             return
-        if not self._power_state_is_safe_to_carry():
+        if not self._status_request_is_allowed():
             return
         if self.foreign_activity:
             # Skipped entirely rather than deferred: this request would take
@@ -1085,19 +1118,23 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             and not await self._async_read_before_echo()
         ):
             return
-        if not self._power_state_is_safe_to_carry():
+        if not self._status_request_is_allowed():
             # Re-checked after the sleep, not only when the request was
             # scheduled: the offset is up to half a minute, and the unit going
             # off inside it is exactly the window this protects.
             _LOGGER.debug(
-                "Skipping the operation-data request for [%s]: the unit is "
-                "off and this request would carry its power state",
+                "Skipping the operation-data request for [%s]: it is either "
+                "not sent to this unit at all, or the unit is off and the "
+                "request would carry that state back to it",
                 self.device_name,
             )
             return
         params = {AirconCommands.ServiceDataStatusRequest: service_data_codes}
         timestamp_offset = -round(self._service_data_stamp_backdate().total_seconds())
-        was_running = self._airco is not None and self._airco.Operation
+        # Taken here rather than at the poll: what the response has to be read
+        # against is the state this very frame was built from, and on the echo
+        # path _async_read_before_echo() has just refreshed it.
+        before = self._settings_snapshot()
         for attempt in (1, 2):
             try:
                 await self.set_airco(
@@ -1109,7 +1146,7 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 )
                 if attempt > 1:
                     _LOGGER.debug("Service data request succeeded on retry")
-                self._check_request_stopped_unit(was_running)
+                self._check_request_was_applied(before)
                 self._note_service_data_offset_survived()
                 # Notify, but deliberately not through async_set_updated_data():
                 # that resets the refresh timer, and this runs half a cycle
@@ -1330,78 +1367,160 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             SERVICE_DATA_OFFSET_GOOD_CYCLES,
         )
 
-    def _check_request_stopped_unit(self, was_running: bool) -> None:
-        """Notice a unit that switches off because we asked it for readings.
+    def _empty_block_matches(self, before: Mapping[str, Any]) -> list[str]:
+        """The settings that moved to exactly what an all-zero command block
+        encodes, comparing the state before our own status request with the one
+        the unit answered it with. Empty when anything moved somewhere else.
 
-        The operation-data request carries no set-bits, so on the hardware this
-        was developed against it changes nothing. On at least one module
-        (firmType WCBN4612L, issue #329) the zero in command[2] is applied as
-        "power off" instead, and since the request repeats every 60s the unit
-        cannot be kept running at all while any operation-data sensor is
-        enabled.
+        That veto is what separates this from an ordinary change. A block
+        applied as zeros lands every field on its minimum at once; a person at
+        the remote picks values, and one field moving to a value of its own is
+        enough to say this was not our frame being applied.
 
-        Rather than guess from firmType - the bridge MCU handles this frame
-        identically across firmware branches, so the branch is the wrong thing
-        to gate on - this watches for the symptom and reacts once. From then on
-        the request carries the unit's own power state back to it, which
-        confirms the state instead of changing it.
-
-        updatedBy is what keeps this honest: "aircon" means the change was made
-        at the unit, so somebody reached for the remote in the same second and
-        this is not our doing.
+        The setpoint counts when it moved *down*: its zero is clamped by the
+        unit to a floor we do not know from here, so the value cannot be
+        predicted - only the direction can. Upwards it is a contradiction like
+        any other.
         """
-        if not was_running or self._parser.status_request_carries_state:
+        if self._airco is None:
+            return []
+        matched: list[str] = []
+        for name, zero in EMPTY_BLOCK_SETTINGS.items():
+            if before.get(name) == getattr(self._airco, name):
+                continue
+            if getattr(self._airco, name) != zero:
+                return []
+            matched.append(name)
+        setpoint_before = before.get("PresetTemp")
+        if setpoint_before is not None and self._airco.PresetTemp != setpoint_before:
+            if self._airco.PresetTemp > setpoint_before:
+                return []
+            matched.append("PresetTemp")
+        return matched
+
+    def _check_request_was_applied(self, before: Mapping[str, Any] | None) -> None:
+        """Notice a unit that applies the request we only meant to ask with.
+
+        A status request has no set-bits, so on every unit we have measured it
+        changes nothing. On at least one it is applied field by field instead
+        (issue #329): the zeros become power off, mode auto, fan and both vanes
+        to position 1, and a setpoint of zero clamped up to the unit's heating
+        floor. Since the request repeats every minute, such a unit cannot be
+        held at any setting at all while one operation-data sensor is enabled.
+
+        What is watched for is that whole pattern, not the shutdown alone. The
+        shutdown is only its most visible part and it is also the part a unit
+        that is already off can no longer show - which is where the earlier
+        version of this got stuck, on the one unit it was written for.
+
+        One occurrence is enough. The test is not that something moved but that
+        everything that moved landed on its minimum at the moment of our own
+        request, and nothing else does that: the remote and the app write the
+        values somebody chose.
+
+        Escalates rather than gives up. First occurrence switches the request
+        to carrying the unit's own settings, which is the shape the
+        manufacturer's app uses and should make the frame confirm them. A
+        second occurrence in that shape means the frame is not what the unit
+        objects to, and then the only honest answer is to stop sending it.
+        """
+        if before is None or self._status_request_mode == STATUS_REQUEST_SILENT:
             return
-        if self._airco is None or self._airco.Operation:
-            self._stopped_on_request = 0
+        matched = self._empty_block_matches(before)
+        if len(matched) < EMPTY_BLOCK_MATCH_MIN:
             return
-        # Deliberately not filtered by updatedBy. It is only ever refreshed by
-        # a poll, so at this point it names whoever wrote last *before* us -
-        # and on a unit started with the IR remote that is the remote, every
-        # time. Requiring it to name a local writer would have meant never
-        # detecting the fault on a unit its owner switches on by remote, which
-        # is the likeliest way to meet it at all. The repetition below carries
-        # the weight instead.
-        self._stopped_on_request += 1
-        if self._stopped_on_request < STOPPED_ON_REQUEST_BEFORE_CARRYING:
-            # Once is a coincidence worth surviving: "local" covers us and any
-            # app on the same network, so an app switching the unit off in the
-            # second our request lands looks exactly like this. The real fault
-            # repeats every cycle; a coincidence does not repeat twice running.
-            _LOGGER.debug(
-                "[%s] stopped during our operation-data request (%s of %s "
-                "before the request starts carrying the power state)",
+        changed = ", ".join(
+            f"{name} {before[name]} -> {getattr(self._airco, name)}"
+            for name in matched
+        )
+        if self._status_request_mode == STATUS_REQUEST_STRICT:
+            self._adopt_status_request_mode(STATUS_REQUEST_ECHO)
+            _LOGGER.warning(
+                "[%s] applied the settings in the request that asked it for "
+                "operation data, which carries none: %s. From now on that "
+                "request carries the unit's own settings back to it, so the "
+                "frame confirms them instead of clearing them",
                 self.device_name,
-                self._stopped_on_request,
-                STOPPED_ON_REQUEST_BEFORE_CARRYING,
+                changed,
             )
-            return
-        self._parser.status_request_carries_state = True
-        # Written down, not just remembered: this is a property of the module
-        # in front of us, and a restart that forgot it would put the unit
-        # through the same shutdowns again to learn the same thing.
-        entry = self.config_entry
-        self.hass.config_entries.async_update_entry(
-            entry, data={**entry.data, CONF_CARRY_POWER_STATE: True}
-        )
-        _LOGGER.warning(
-            "[%s] switched off in the same request in which we asked it for "
-            "operation data. That request carries no settings, so this module "
-            "applies a field it should ignore. From now on the request carries "
-            "the unit's own power state back to it, which should stop this. "
-            "If the unit keeps switching off, disable its operation-data "
-            "sensors (compressor, current, temperatures) and please report it",
-            self.device_name,
-        )
+        else:
+            self._adopt_status_request_mode(STATUS_REQUEST_SILENT)
+            _LOGGER.warning(
+                "[%s] changed its settings during an operation-data request "
+                "that carried its own state: %s. Nothing this integration can "
+                "put in that frame leaves the unit alone, so it will not be "
+                "sent again. The operation-data sensors and the external "
+                "temperature override stop working on this unit; everything "
+                "else is unaffected",
+                self.device_name,
+                changed,
+            )
+        self.hass.async_create_task(self._async_restore_settings(before))
+        if self._status_request_mode == STATUS_REQUEST_SILENT:
+            # The advice in the first issue - watch it for a few minutes - has
+            # been overtaken by what just happened.
+            ir.async_delete_issue(
+                self.hass, DOMAIN, request_stops_unit_issue_id(self.entry_id)
+            )
         ir.async_create_issue(
             self.hass,
             DOMAIN,
-            request_stops_unit_issue_id(self.entry_id),
+            request_stops_unit_issue_id(self.entry_id)
+            if self._status_request_mode == STATUS_REQUEST_ECHO
+            else status_request_unsupported_issue_id(self.entry_id),
             is_fixable=False,
             severity=ir.IssueSeverity.WARNING,
-            translation_key="request_stops_unit",
+            translation_key=(
+                "request_stops_unit"
+                if self._status_request_mode == STATUS_REQUEST_ECHO
+                else "status_request_unsupported"
+            ),
             translation_placeholders={"device_name": self.device_name},
         )
+
+    def _adopt_status_request_mode(self, mode: str) -> None:
+        """Switch the shape of the status request and write the choice down.
+
+        Persisted because it is a property of the unit in front of us, not of
+        this run: a restart that forgot it would put the unit through the same
+        disturbance again to learn the same thing - which is exactly what the
+        counter this replaced did, every time an update restarted Home
+        Assistant.
+        """
+        self._status_request_mode = mode
+        self._parser.status_request_carries_state = mode == STATUS_REQUEST_ECHO
+        entry = self.config_entry
+        self.hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_STATUS_REQUEST_MODE: mode}
+        )
+
+    async def _async_restore_settings(self, before: Mapping[str, Any]) -> None:
+        """Put back what the request just cleared.
+
+        The values are one round trip old rather than current, which is the
+        same freshness the echo itself runs on - and the alternative is
+        leaving the unit on settings nobody chose until somebody notices. Only
+        reached on the one frame that revealed the fault, so it cannot become
+        a loop: by the time it runs, the mode has already changed.
+        """
+        try:
+            await self.set_airco(
+                {
+                    AirconCommands.Operation: before["Operation"],
+                    AirconCommands.OperationMode: before["OperationMode"],
+                    AirconCommands.PresetTemp: before["PresetTemp"],
+                    AirconCommands.AirFlow: before["AirFlow"],
+                    AirconCommands.WindDirectionUD: before["WindDirectionUD"],
+                    AirconCommands.WindDirectionLR: before["WindDirectionLR"],
+                },
+                log_failure=False,
+            )
+        except (WfRacError, KeyError, TypeError, ValueError) as ex:
+            _LOGGER.warning(
+                "Could not restore the settings [%s] lost to our own request: %s",
+                self.device_name,
+                ex,
+            )
 
     def _report_registration_full(self) -> None:
         ir.async_create_issue(
@@ -1625,6 +1744,14 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         a setting up to a poll old and undo whatever was done at the unit since
         - including switching a unit off that somebody just turned on.
         """
+        if self._status_request_mode == STATUS_REQUEST_SILENT:
+            # This unit changes its settings whatever we put in the frame, so
+            # the frame is not sent at all any more (#329).
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="status_request_not_sent",
+                translation_placeholders={"device": self.device_name},
+            )
         if (
             self._parser.status_request_carries_state
             and not await self._async_read_before_echo()

--- a/custom_components/mitsubishi_wf_rac/strings.json
+++ b/custom_components/mitsubishi_wf_rac/strings.json
@@ -58,8 +58,12 @@
       "description": "This unit has room for four registered accounts and all four are taken, so Home Assistant cannot register itself. The module never frees a slot by itself: registrations do not expire, and a new one is refused rather than replacing an older one. In the Smart M-Air app, remove this unit from a phone that no longer needs it - each account can only remove itself, and several phones sharing one Smart M-Air account take up a single slot between them. Then reload this integration. If nobody can free a slot - a phone that is long gone still holds one - the module has to be set up again from scratch."
     },
     "request_stops_unit": {
-      "title": "{device_name} switches off when asked for operation data",
-      "description": "The diagnostic sensors for compressor, current and temperatures are read with an extra request once a minute. That request carries no settings - it only asks - but this module applies part of it anyway and reads it as \"switch off\", so the unit stops every time it arrives.\n\nHome Assistant has switched that request to a form that confirms the unit is running instead of leaving the field at zero, which should stop the unit switching off while keeping the sensors working. It only ever confirms \"on\": while Home Assistant believes this unit is off, no request goes out at all, so these sensors hold their last value until it is running again. Watch it for a few minutes.\n\nIf it still switches off, turn off the operation-data sensors on this device (compressor frequency, operating current, hot gas temperature, EEV position and the coil temperatures) and remove any indoor temperature source configured in the integration's options - both rely on that request. Then please report it, including your module's firmware version: this behaviour differs between units and only a report from an affected one can settle it."
+      "title": "{device_name} changes its own settings when asked for operation data",
+      "description": "The diagnostic sensors for compressor, current and temperatures are read with an extra request once a minute. That request carries no settings - it only asks - but this module applies it anyway, and every field it leaves empty is read as a value: the unit switches off, the mode goes to auto, fan and louvres drop to their first position, and the setpoint falls to the lowest one the unit allows.\n\nHome Assistant has switched that request to carry this unit's own settings, read a moment before it is sent, so the frame confirms them instead of clearing them. That is the shape the manufacturer's own app uses. The settings the request cleared have been written back. While Home Assistant believes this unit is off, no request goes out at all, so these sensors hold their last value until it is running again.\n\nNothing else needs doing - watch it for a few minutes. If the unit still changes its settings on its own, Home Assistant will stop sending the request altogether and say so here."
+    },
+    "status_request_unsupported": {
+      "title": "Operation data cannot be read from {device_name}",
+      "description": "This unit changes its own settings whenever it is asked for operation data, and it does so even when the request carries its current settings back to it. There is nothing left to put in that request that this unit leaves alone, so Home Assistant has stopped sending it.\n\nWhat that costs: the diagnostic sensors fed by it (compressor frequency, operating current, hot gas temperature, EEV position and the coil temperatures) no longer update, and an indoor temperature source configured in the integration's options can no longer be passed to the unit - both ride on that one request. Everything else is unaffected: power, mode, temperature, fan and louvres are sent as ordinary commands and are not touched by this.\n\nPlease report this, including your module's firmware version. Only two units are known to behave this way, and a report is the only way it can be worked on."
     }
   },
   "options": {
@@ -155,6 +159,9 @@
     },
     "status_request_read_failed": {
       "message": "Could not read the state of the Airco at {device}, so the status request was not sent."
+    },
+    "status_request_not_sent": {
+      "message": "Home Assistant no longer sends status requests to the Airco at {device}, because this unit changes its own settings in response to them."
     }
   },
   "entity": {

--- a/custom_components/mitsubishi_wf_rac/translations/de.json
+++ b/custom_components/mitsubishi_wf_rac/translations/de.json
@@ -85,6 +85,9 @@
     },
     "status_request_read_failed": {
       "message": "Der Zustand des Klimageräts {device} ließ sich nicht lesen, die Statusanfrage wurde deshalb nicht gesendet."
+    },
+    "status_request_not_sent": {
+      "message": "Home Assistant sendet an die Klimaanlage {device} keine Statusanfragen mehr, weil dieses Gerät sich daraufhin selbst verstellt."
     }
   },
   "issues": {
@@ -93,8 +96,12 @@
       "description": "Diese Klimaanlage hat Platz für vier registrierte Konten, und alle vier sind belegt - Home Assistant kann sich deshalb nicht registrieren. Das Modul gibt von sich aus keinen Platz frei: Registrierungen laufen nicht ab, und eine neue wird abgewiesen, statt eine ältere zu ersetzen. Entfernen Sie das Gerät in der Smart-M-Air-App auf einem Telefon, das es nicht mehr braucht - jedes Konto kann nur sich selbst entfernen, und mehrere Telefone mit demselben Smart-M-Air-Konto belegen zusammen nur einen Platz. Laden Sie danach diese Integration neu. Wenn niemand einen Platz freigeben kann - etwa weil ein längst abgegebenes Telefon einen belegt -, muss das Modul neu eingerichtet werden."
     },
     "request_stops_unit": {
-      "title": "{device_name} schaltet sich ab, wenn Betriebsdaten abgefragt werden",
-      "description": "Die Diagnosesensoren für Verdichter, Strom und Temperaturen werden einmal pro Minute mit einer zusätzlichen Anfrage geholt. Diese Anfrage enthält keine Einstellungen — sie fragt nur — aber dieses Modul wendet einen Teil davon trotzdem an und liest ihn als „ausschalten“, sodass das Gerät jedes Mal stehen bleibt.\n\nHome Assistant hat die Anfrage jetzt auf eine Form umgestellt, die dem Gerät bestätigt, dass es läuft, statt das Feld auf null zu lassen. Damit sollte das Abschalten aufhören, ohne dass die Sensoren ausfallen. Bestätigt wird ausschließlich „an“: solange Home Assistant dieses Gerät für ausgeschaltet hält, geht gar keine Anfrage hinaus, und diese Sensoren behalten so lange ihren letzten Wert. Bitte einige Minuten beobachten.\n\nSchaltet es sich weiterhin ab, deaktivieren Sie an diesem Gerät die Betriebsdaten-Sensoren (Verdichterfrequenz, Betriebsstrom, Heißgastemperatur, EEV-Position und die Wärmetauschertemperaturen) und entfernen Sie eine in den Optionen eingetragene Raumtemperaturquelle — beides hängt an dieser Anfrage. Melden Sie es anschließend bitte, mit der Firmwareversion Ihres Moduls: Dieses Verhalten unterscheidet sich je Gerät, und nur eine Meldung von einem betroffenen kann es klären."
+      "title": "{device_name} verstellt sich selbst, wenn Betriebsdaten abgefragt werden",
+      "description": "Die Diagnosesensoren für Verdichter, Strom und Temperaturen werden einmal pro Minute mit einer zusätzlichen Anfrage geholt. Diese Anfrage enthält keine Einstellungen — sie fragt nur — aber dieses Modul wendet sie trotzdem an, und jedes leer gelassene Feld wird als Wert gelesen: das Gerät schaltet ab, der Modus springt auf Automatik, Lüfter und Lamellen fallen auf die erste Stufe, und der Sollwert sinkt auf den niedrigsten Wert, den das Gerät zulässt.\n\nHome Assistant hat die Anfrage jetzt so umgestellt, dass sie die Einstellungen dieses Geräts mitführt, unmittelbar vorher gelesen — der Frame bestätigt sie also, statt sie zu löschen. Genau so macht es auch die App des Herstellers. Die verlorenen Einstellungen wurden zurückgeschrieben. Solange Home Assistant dieses Gerät für ausgeschaltet hält, geht gar keine Anfrage hinaus, und diese Sensoren behalten so lange ihren letzten Wert.\n\nEs ist nichts weiter zu tun — bitte einige Minuten beobachten. Verstellt sich das Gerät weiterhin von selbst, stellt Home Assistant die Anfrage ganz ein und meldet das hier."
+    },
+    "status_request_unsupported": {
+      "title": "Von {device_name} lassen sich keine Betriebsdaten lesen",
+      "description": "Dieses Gerät verstellt sich selbst, sobald Betriebsdaten abgefragt werden — auch dann, wenn die Anfrage seine aktuellen Einstellungen mitführt. Es bleibt nichts mehr, was sich in diese Anfrage schreiben ließe und das Gerät in Ruhe lässt, deshalb sendet Home Assistant sie nicht mehr.\n\nWas das kostet: die daraus gespeisten Diagnosesensoren (Verdichterfrequenz, Betriebsstrom, Heißgastemperatur, EEV-Position und die Wärmetauscher-Temperaturen) werden nicht mehr aktualisiert, und eine in den Optionen eingestellte Raumtemperaturquelle lässt sich dem Gerät nicht mehr übergeben — beides hängt an dieser einen Anfrage. Alles andere bleibt unberührt: Ein/Aus, Modus, Temperatur, Lüfter und Lamellen gehen als gewöhnliche Befehle hinaus.\n\nBitte melden Sie das, zusammen mit der Firmware-Version Ihres Moduls. Nur von wenigen Geräten ist dieses Verhalten bekannt, und ohne Meldung lässt sich nicht daran arbeiten."
     }
   },
   "options": {

--- a/custom_components/mitsubishi_wf_rac/translations/en.json
+++ b/custom_components/mitsubishi_wf_rac/translations/en.json
@@ -85,6 +85,9 @@
     },
     "status_request_read_failed": {
       "message": "Could not read the state of the Airco at {device}, so the status request was not sent."
+    },
+    "status_request_not_sent": {
+      "message": "Home Assistant no longer sends status requests to the Airco at {device}, because this unit changes its own settings in response to them."
     }
   },
   "issues": {
@@ -93,8 +96,12 @@
       "description": "This unit has room for four registered accounts and all four are taken, so Home Assistant cannot register itself. The module never frees a slot by itself: registrations do not expire, and a new one is refused rather than replacing an older one. In the Smart M-Air app, remove this unit from a phone that no longer needs it - each account can only remove itself, and several phones sharing one Smart M-Air account take up a single slot between them. Then reload this integration. If nobody can free a slot - a phone that is long gone still holds one - the module has to be set up again from scratch."
     },
     "request_stops_unit": {
-      "title": "{device_name} switches off when asked for operation data",
-      "description": "The diagnostic sensors for compressor, current and temperatures are read with an extra request once a minute. That request carries no settings - it only asks - but this module applies part of it anyway and reads it as \"switch off\", so the unit stops every time it arrives.\n\nHome Assistant has switched that request to a form that confirms the unit is running instead of leaving the field at zero, which should stop the unit switching off while keeping the sensors working. It only ever confirms \"on\": while Home Assistant believes this unit is off, no request goes out at all, so these sensors hold their last value until it is running again. Watch it for a few minutes.\n\nIf it still switches off, turn off the operation-data sensors on this device (compressor frequency, operating current, hot gas temperature, EEV position and the coil temperatures) and remove any indoor temperature source configured in the integration's options - both rely on that request. Then please report it, including your module's firmware version: this behaviour differs between units and only a report from an affected one can settle it."
+      "title": "{device_name} changes its own settings when asked for operation data",
+      "description": "The diagnostic sensors for compressor, current and temperatures are read with an extra request once a minute. That request carries no settings - it only asks - but this module applies it anyway, and every field it leaves empty is read as a value: the unit switches off, the mode goes to auto, fan and louvres drop to their first position, and the setpoint falls to the lowest one the unit allows.\n\nHome Assistant has switched that request to carry this unit's own settings, read a moment before it is sent, so the frame confirms them instead of clearing them. That is the shape the manufacturer's own app uses. The settings the request cleared have been written back. While Home Assistant believes this unit is off, no request goes out at all, so these sensors hold their last value until it is running again.\n\nNothing else needs doing - watch it for a few minutes. If the unit still changes its settings on its own, Home Assistant will stop sending the request altogether and say so here."
+    },
+    "status_request_unsupported": {
+      "title": "Operation data cannot be read from {device_name}",
+      "description": "This unit changes its own settings whenever it is asked for operation data, and it does so even when the request carries its current settings back to it. There is nothing left to put in that request that this unit leaves alone, so Home Assistant has stopped sending it.\n\nWhat that costs: the diagnostic sensors fed by it (compressor frequency, operating current, hot gas temperature, EEV position and the coil temperatures) no longer update, and an indoor temperature source configured in the integration's options can no longer be passed to the unit - both ride on that one request. Everything else is unaffected: power, mode, temperature, fan and louvres are sent as ordinary commands and are not touched by this.\n\nPlease report this, including your module's firmware version. Only two units are known to behave this way, and a report is the only way it can be worked on."
     }
   },
   "options": {

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -19,7 +19,9 @@ from homeassistant.helpers import issue_registry as ir
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.mitsubishi_wf_rac.const import (
-    CONF_CARRY_POWER_STATE,
+    CONF_STATUS_REQUEST_MODE,
+    STATUS_REQUEST_ECHO,
+    STATUS_REQUEST_SILENT,
     CONF_OVERSHOOT_COOL,
     CONF_OVERSHOOT_DRY,
     CONF_OVERSHOOT_HEAT,
@@ -2011,101 +2013,181 @@ async def _run_service_data_request(device, monkeypatch, ceiling_ms: int = 1):
     await asyncio.sleep(0.05)
 
 
-async def test_a_unit_that_stops_on_our_request_twice_gets_its_power_state_carried(
+def _cleared_payload() -> str:
+    """A running unit's capture rewritten to what an applied all-zero command
+    block leaves behind: off, mode auto, fan and both vanes at position 1, and
+    a setpoint of zero clamped up to the 10 C heating floor - the four fields
+    Wasbiertje's log showed moving together (#329).
+    """
+    raw = [
+        (256 - b) * (-1) if b > 127 else b
+        for b in base64.b64decode(ON_COOL_PAYLOAD)
+    ]
+    start = raw[18] * 4 + 21
+    content = raw[start:start + 18]
+    content[2] = 0
+    content[3] = 0
+    content[4] = 20  # the unit's own floor, not the zero it was sent
+    content[11] = 0
+    content[12] = 0
+    return _build_stat_response(content)
+
+
+CLEARED_PAYLOAD = _cleared_payload()
+
+
+async def test_a_unit_that_applies_our_request_is_switched_to_carrying_its_state(
     device, monkeypatch
 ):
     """The request carries no set-bits, so nothing should change - but one
-    module applies command[2] anyway and reads the zero as "off" (#329).
+    module applies every field anyway (#329), and the zeros land as power off,
+    mode auto, fan and vanes at 1 and the setpoint on the unit's floor.
 
-    Detected from the symptom rather than from firmType: the bridge MCU
+    Detected from that whole pattern rather than from firmType: the bridge MCU
     handles this frame identically across firmware branches, so the branch
-    would be the wrong thing to gate on. Twice, because the signal cannot
-    separate us from another client on the same network.
+    would be the wrong thing to gate on. One occurrence is enough - the test is
+    not that something moved but that everything that moved landed on its
+    minimum, and nothing else does that.
     """
     # Registered, so the entry can actually be written to - see _set_options.
     device.config_entry.add_to_hass(device.hass)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
-    assert device.airco.Operation is True
     assert device._parser.status_request_carries_state is False
 
-    # The unit answers our own request having switched itself off.
-    device._api.send_airco_command = AsyncMock(return_value=OFF_PAYLOAD)
+    device._api.send_airco_command = AsyncMock(return_value=CLEARED_PAYLOAD)
     await _run_service_data_request(device, monkeypatch)
-    assert device._parser.status_request_carries_state is False
 
+    assert device._parser.status_request_carries_state is True
+    # Written down, so the next start does not put the unit through the same
+    # disturbance to learn the same thing (#329, reported again after an update
+    # had reset the counter this replaced).
+    assert device.config_entry.data[CONF_STATUS_REQUEST_MODE] == STATUS_REQUEST_ECHO
+
+
+async def test_the_settings_the_request_cleared_are_written_back(
+    device, monkeypatch
+):
+    """Detection alone would leave the unit on values nobody chose.
+
+    The values put back are one round trip old, which is the same freshness
+    the echo itself runs on - and the alternative is a unit sitting at 10 C
+    until somebody notices.
+    """
+    device.config_entry.add_to_hass(device.hass)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    before = device._settings_snapshot()
+
+    sent: list[dict] = []
+    real_set_airco = device.set_airco
+
+    async def _record(params, **kwargs):
+        sent.append(params)
+        await real_set_airco(params, **kwargs)
+
+    monkeypatch.setattr(device, "set_airco", _record)
+    device._api.send_airco_command = AsyncMock(return_value=CLEARED_PAYLOAD)
+    await _run_service_data_request(device, monkeypatch)
+    await asyncio.sleep(0.05)
+
+    assert len(sent) == 2, "expected the request, then a frame putting it back"
+    restore = sent[-1]
+    assert restore[AirconCommands.PresetTemp] == before["PresetTemp"]
+    assert restore[AirconCommands.Operation] == before["Operation"]
+    assert restore[AirconCommands.OperationMode] == before["OperationMode"]
+    assert restore[AirconCommands.AirFlow] == before["AirFlow"]
+
+
+async def test_a_unit_that_is_already_off_is_still_detected(device, monkeypatch):
+    """The case the earlier detector could not see.
+
+    It watched for the unit switching off, which a unit that is already off can
+    no longer do - so on the one unit it was written for it stopped firing
+    after the first shutdown, while every following request went on clearing
+    the setpoint, the mode, the fan and both vanes.
+    """
+    device.config_entry.add_to_hass(device.hass)
+    running_but_off = _stats_response(ON_COOL_PAYLOAD)
+    device._api.get_aircon_stats.return_value = running_but_off
+    await device.update()
+    # Off, but with its settings intact - the state his unit sat in for five
+    # betas.
+    device._airco.Operation = False
+
+    device._api.send_airco_command = AsyncMock(return_value=CLEARED_PAYLOAD)
+    await _run_service_data_request(device, monkeypatch)
+
+    assert device._parser.status_request_carries_state is True
+
+
+async def test_an_echo_that_still_moves_the_unit_stops_the_request(
+    device, monkeypatch
+):
+    """The escalation. If the frame confirms the unit's own settings and the
+    unit changes them anyway, the frame is not what it objects to - and then
+    the only honest answer is to stop sending it, rather than to keep the unit
+    unusable for the sake of five diagnostic sensors.
+    """
+    device.config_entry.add_to_hass(device.hass)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device._status_request_mode = STATUS_REQUEST_ECHO
+    device._parser.status_request_carries_state = True
+
+    device._api.send_airco_command = AsyncMock(return_value=CLEARED_PAYLOAD)
+    await _run_service_data_request(device, monkeypatch)
+
+    assert device._status_request_mode == STATUS_REQUEST_SILENT
+    assert device.config_entry.data[CONF_STATUS_REQUEST_MODE] == STATUS_REQUEST_SILENT
+
+    # And nothing is asked of it again.
+    device._api.send_airco_command = AsyncMock(return_value=ON_COOL_PAYLOAD)
     device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
     await device.update()
     await _run_service_data_request(device, monkeypatch)
-    assert device._parser.status_request_carries_state is True
-    # Written down, so the next start does not put the unit through the same
-    # shutdowns to learn the same thing (#329, reported again after an update
-    # had reset it).
-    assert device.config_entry.data[CONF_CARRY_POWER_STATE] is True
+    device._api.send_airco_command.assert_not_awaited()
 
 
-async def test_a_learned_power_state_quirk_survives_a_restart(hass):
-    """A module that needs the power state has always needed it.
-
-    The flag used to live only in memory, so every restart and every reload
-    started the count from zero - and the unit paid for it again each time.
+async def test_an_ordinary_change_at_the_unit_is_not_read_as_the_fault(
+    device, monkeypatch
+):
+    """Somebody using the remote while our request is in flight moves fields to
+    the values they chose. Only the fault sweeps the whole block to the bottom.
     """
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_CARRY_POWER_STATE: True})
+    device.config_entry.add_to_hass(device.hass)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+
+    device._api.send_airco_command = AsyncMock(return_value=FAN_SPEED_4_PAYLOAD)
+    await _run_service_data_request(device, monkeypatch)
+
+    assert device._parser.status_request_carries_state is False
+    assert CONF_STATUS_REQUEST_MODE not in device.config_entry.data
+
+
+async def test_a_learned_status_request_mode_survives_a_restart(hass):
+    """A module that applies the request has always applied it.
+
+    The decision used to live only in memory as a counter, so every restart
+    and every reload started it from zero - and the unit paid for it again
+    each time. An update restarts Home Assistant, which is how the one
+    affected tester never reached the threshold at all.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_STATUS_REQUEST_MODE: STATUS_REQUEST_ECHO}
+    )
     entry.add_to_hass(hass)
     device = Device(
         hass, entry, "Test AC", "127.0.0.1", 51443, "device-id", "operator-id",
         "airco-id", swing_selects_enabled_default=True,
-        status_request_carries_state=bool(entry.data.get(CONF_CARRY_POWER_STATE, False)),
+        status_request_mode=entry.data[CONF_STATUS_REQUEST_MODE],
     )
     device._api = AsyncMock()
 
     assert device._parser.status_request_carries_state is True
 
     await device.async_shutdown()
-
-
-async def test_a_single_stop_during_our_request_is_not_enough(device, monkeypatch):
-    """"local" is what the module reports for us and for any app on the same
-    network alike, so one occurrence can just as well be somebody switching
-    the unit off in the second our request lands. The real fault repeats.
-    """
-    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
-    await device.update()
-    device._api.send_airco_command = AsyncMock(return_value=OFF_PAYLOAD)
-    await _run_service_data_request(device, monkeypatch)
-
-    # A cycle in which the unit keeps running clears the count again.
-    device._api.send_airco_command = AsyncMock(return_value=ON_COOL_PAYLOAD)
-    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
-    await device.update()
-    await _run_service_data_request(device, monkeypatch)
-
-    device._api.send_airco_command = AsyncMock(return_value=OFF_PAYLOAD)
-    await device.update()
-    await _run_service_data_request(device, monkeypatch)
-
-    assert device._parser.status_request_carries_state is False
-
-
-async def test_a_unit_started_by_remote_is_still_detected(device, monkeypatch):
-    """The likeliest way to meet this fault is to switch the unit on at the
-    unit and watch it stop.
-
-    updatedBy is only refreshed by a poll, so at the moment of the check it
-    names whoever wrote last *before* us - on a unit started by remote, the
-    remote. Filtering the check by it would have meant never detecting the
-    fault on exactly the units whose owners run into it.
-    """
-    running_by_remote = _stats_response(ON_COOL_PAYLOAD)
-    running_by_remote["updatedBy"] = "aircon"
-    device._api.get_aircon_stats.return_value = running_by_remote
-    device._api.send_airco_command = AsyncMock(return_value=OFF_PAYLOAD)
-
-    for _ in range(2):
-        await device.update()
-        await _run_service_data_request(device, monkeypatch)
-
-    assert device._parser.status_request_carries_state is True
 
 
 async def test_a_unit_switched_off_at_the_unit_is_not_blamed_on_us(


### PR DESCRIPTION
The detector for #329 looked for the unit switching off inside our own operation-data request. That is the one part of the fault a unit which is already off can no longer show, and it took two occurrences in a single Home Assistant lifetime to act on — the counter lived in memory, so every restart started it again, and a restart was part of the test we asked for.

On the only affected unit we know of it therefore stopped firing after the first shutdown, while every following request went on clearing the setpoint, the mode, the fan and both vanes. Six fields are damaged; `Operation` is the one an already-off unit can no longer move.

## What changes

**Detection watches the pattern.** The settings the answer to our own request comes back with are compared against the state the frame was built from. A block applied as zeros lands every field on its minimum at once, so one occurrence is enough — and one field moving anywhere else vetoes the reading, which is what keeps somebody at the remote from being mistaken for the fault. The new test found a real false positive in the first, looser version of the predicate.

**Two states become three.** `strict` → `echo` → `silent`. A unit that changes its settings even when the frame carries them back to it objects to something the frame cannot fix, so the request is given up rather than repeated: the operation-data sensors and the external-temperature override stop, everything else is untouched. Its own repair issue says so, and withdraws the first one.

**The settings each step costs are written back.** They are one round trip old, which is the freshness the echo already runs on — the alternative is a unit sitting at its heating floor until somebody notices.

The learned answer keeps living in `entry.data`; `carry_power_state` from beta2–beta6 is read forward as `echo`.

364 tests, mypy clean.