### PR TITLE
Read the evidence at the poll too, not only in the answer

### DIFF
--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -343,6 +343,9 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         self._firmware = ""
         self._connected_accounts = -1
         self._updated_by: str | None = None
+        # The settings a status request was built from, kept until something
+        # has been able to answer for them - see _check_request_was_applied().
+        self._request_baseline: dict[str, Any] | None = None
         self._account_expires: int | None = None
         self._led_status: int | None = None
         self._auto_heating: int | None = None
@@ -832,6 +835,10 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         self._note_unexpected_settings(
             wrote_settings or (expires_moved and not wrote)
         )
+        # After the settings diff, because the poll that carries the evidence
+        # is the one that has just refreshed the state it is read from.
+        self._check_request_was_applied(self._request_baseline)
+        self._request_baseline = None
         self._report_foreign_activity()
 
     def _note_foreign_write(self, evidence: str) -> None:
@@ -1131,10 +1138,17 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
             return
         params = {AirconCommands.ServiceDataStatusRequest: service_data_codes}
         timestamp_offset = -round(self._service_data_stamp_backdate().total_seconds())
-        # Taken here rather than at the poll: what the response has to be read
+        # Taken here rather than at the poll: what the answer has to be read
         # against is the state this very frame was built from, and on the echo
         # path _async_read_before_echo() has just refreshed it.
         before = self._settings_snapshot()
+        # Kept for the poll as well. The module answers our request with its
+        # own cached state, and the frame's trip down the CNS bus to the indoor
+        # unit need not have finished by then - measured on the affected unit,
+        # the settings it cleared showed up a poll later, not in the answer
+        # (#329). Checking only the answer would have reproduced the blind spot
+        # this detector was rewritten to close.
+        self._request_baseline = before
         for attempt in (1, 2):
             try:
                 await self.set_airco(
@@ -1455,6 +1469,9 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 self.device_name,
                 changed,
             )
+        # Answered for: without this the poll would read the same change again
+        # and escalate a step that has just been taken.
+        self._request_baseline = None
         self.hass.async_create_task(self._async_restore_settings(before))
         if self._status_request_mode == STATUS_REQUEST_SILENT:
             # The advice in the first issue - watch it for a few minutes - has
@@ -1661,6 +1678,9 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
                 # our expectation would swallow whole.
                 if not is_status_request:
                     self._expected_settings = self._settings_snapshot()
+                    # A real command explains any settings that move after it,
+                    # so the status request before it no longer has to.
+                    self._request_baseline = None
                 # After the write, and only for what the frame really carried:
                 # a command sent while the unit is off writes the sentinel, not
                 # the override.

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -2121,6 +2121,52 @@ async def test_a_unit_that_is_already_off_is_still_detected(device, monkeypatch)
     assert device._parser.status_request_carries_state is True
 
 
+async def test_a_change_that_only_shows_up_at_the_next_poll_is_still_detected(
+    device, monkeypatch
+):
+    """The timing the affected unit actually has (#329, log of 10.09.2026).
+
+    The module answers our request out of its own cache, and the frame's trip
+    down the CNS bus to the indoor unit need not have finished by then: his
+    request went out at 19:25:37 and the cleared setpoint, fan and both vanes
+    appeared in the poll at 19:26:08, not in the answer. A detector reading
+    only the answer would have the same blind spot as the one it replaced.
+    """
+    device.config_entry.add_to_hass(device.hass)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+
+    # The answer still shows the unit as it was.
+    device._api.send_airco_command = AsyncMock(return_value=ON_COOL_PAYLOAD)
+    await _run_service_data_request(device, monkeypatch)
+    assert device._parser.status_request_carries_state is False
+
+    device._api.get_aircon_stats.return_value = _stats_response(CLEARED_PAYLOAD)
+    await device.update()
+
+    assert device._parser.status_request_carries_state is True
+    assert device.config_entry.data[CONF_STATUS_REQUEST_MODE] == STATUS_REQUEST_ECHO
+
+
+async def test_a_change_after_a_real_command_is_not_blamed_on_the_request(
+    device, monkeypatch
+):
+    """A command of our own explains what moves after it, so the status
+    request before it stops having to answer for the next poll."""
+    device.config_entry.add_to_hass(device.hass)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+
+    device._api.send_airco_command = AsyncMock(return_value=ON_COOL_PAYLOAD)
+    await _run_service_data_request(device, monkeypatch)
+    await device.set_airco({AirconCommands.Operation: False})
+
+    device._api.get_aircon_stats.return_value = _stats_response(CLEARED_PAYLOAD)
+    await device.update()
+
+    assert device._parser.status_request_carries_state is False
+
+
 async def test_an_echo_that_still_moves_the_unit_stops_the_request(
     device, monkeypatch
 ):


### PR DESCRIPTION
Wasbiertje's log of 10.09.2026 settles a timing #366 had assumed away.

His request went out at 19:25:37; the cleared setpoint, fan and both vanes appeared in the poll at 19:26:08 — **not** in the answer to the request itself. The module answers out of its own cache, and the frame's trip down the CNS bus to the indoor unit need not have finished by then. A detector reading only the answer would have had the same blind spot as the one it replaced.

The state a status request was built from is now kept until something has been able to answer for it: the request's own answer first, and failing that the next poll. It is dropped by a real command of ours (which explains anything that moves after it) and by the step the evidence has already been acted on, so a single occurrence cannot be counted twice and escalate.

The same log also confirms what the rebuild was for: the fix never engaged on his unit. An `Unloaded entry` at 19:24:05 had reset the counter again, so the request still went out empty and the unit still fell to 10 °C.

366 tests, mypy clean.