### PR TITLE
Hand the unit back to its own sensor when Home Assistant stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ You can select a sensor under **Indoor temperature source** in the integration o
 
 Most integrations already handle this: ESPHome, Z-Wave JS and ZHA mark a device unavailable once it stops answering. Where yours does not, give it an availability rule of its own - `expire_after` on an MQTT sensor, or a template sensor wrapping the original and going unavailable when `last_updated` falls behind. Anything that produces `unavailable` hands the unit back to its internal sensor.
 
-One case nothing here can cover: if Home Assistant itself stops - host down, network gone - no frame goes out at all and the unit keeps the last value it was given. Worth weighing before arming an override for a room that is heated while nobody is home.
+**Shutting Home Assistant down hands the unit back; losing it does not.** An orderly stop spends one last frame clearing the override, so the unit measures for itself while Home Assistant is away and takes the override up again when it returns. An abrupt end cannot do that: a host that loses power or a network that disappears sends nothing, and the unit keeps the last value it was given until something else writes or it is switched off at the wall. Worth weighing before arming an override for a room that is heated while nobody is home.
 
 What an armed override costs is one request per poll cycle, which holds the unit's write lock for part of the cycle exactly as an enabled operation-data sensor does.
 

--- a/custom_components/mitsubishi_wf_rac/__init__.py
+++ b/custom_components/mitsubishi_wf_rac/__init__.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.typing import ConfigType
@@ -13,6 +13,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
     CONF_DEVICE_ID,
+    EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
 
@@ -191,6 +192,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: MitsubishiWfRacConfigEnt
         )
 
     entry.runtime_data = MitsubishiWfRacData(_device)
+
+    async def _handle_stop(_event: Event) -> None:
+        """Hand an armed external temperature override back on the way down.
+
+        Only on Home Assistant stopping, deliberately not in
+        async_unload_entry(): an unload is also what a reload is, and saving
+        the options reloads the entry - clearing the override there would put
+        the unit back on its own sensor for a moment on every settings change.
+        A stop is the case where nothing of ours writes again, which is the
+        one that leaves the value standing at the unit.
+        """
+        await _device.async_release_external_temperature()
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _handle_stop)
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/custom_components/mitsubishi_wf_rac/coordinator.py
+++ b/custom_components/mitsubishi_wf_rac/coordinator.py
@@ -474,6 +474,72 @@ class Device(DataUpdateCoordinator[Aircon]):  # pylint: disable=too-many-instanc
         self._external_temperature_override = value
         self._sync_external_temperature_carrier()
 
+    async def async_release_external_temperature(self) -> None:
+        """Hand the unit back to its own sensor before we stop writing.
+
+        The injected value has no expiry at the unit: whatever byte 5 last
+        carried is what it regulates on, until another frame replaces it or it
+        loses power. While the entry runs, the carrier frame refreshes it every
+        cycle and a source that stops reporting clears it - but once Home
+        Assistant stops, nothing writes at all and the value would simply
+        stand. So an orderly stop spends one last frame on clearing it, and the
+        unit measures for itself again until the entry comes back and re-arms
+        the override.
+
+        Only an orderly stop: a reload is not one (saving the options reloads
+        the entry, and the override is re-armed seconds later), and a crash or
+        a lost network cannot send anything at all. That residue is the
+        unit's, not ours to fix.
+        """
+        if self._external_temperature_override is None:
+            return
+        applied = self.external_temperature_applied
+        self.set_external_temperature_override(None)
+        if not applied:
+            # Nothing on the unit to undo: it is on its own sensor already,
+            # because it is off, in fan_only, or no frame ever carried the
+            # value (see external_temperature_applied).
+            return
+        if not self._status_request_is_allowed():
+            # The guard the periodic request answers to as well - a unit we
+            # have given up asking, or one that applies the state a carrying
+            # frame echoes while we believe it is off (#329). Handing control
+            # back is not worth a frame that might switch the unit.
+            return
+        if (
+            self._parser.status_request_carries_state
+            and not await self._async_read_before_echo()
+        ):
+            return
+        try:
+            await self.set_airco(
+                {
+                    AirconCommands.ServiceDataStatusRequest: (
+                        SERVICE_DATA_INDOOR_COIL_RAW,
+                    )
+                },
+                log_failure=False,
+                timestamp_offset=-round(
+                    self._service_data_stamp_backdate().total_seconds()
+                ),
+                is_status_request=True,
+                retry_when_locked=False,
+            )
+        except (WfRacError, KeyError, TypeError, ValueError) as ex:
+            # Debug, not a warning: this runs while Home Assistant is going
+            # down, there is nobody to act on it, and the next start re-arms
+            # the override anyway.
+            _LOGGER.debug(
+                "Could not hand [%s] back to its own sensor before stopping: %s",
+                self.device_name,
+                ex,
+            )
+        else:
+            _LOGGER.debug(
+                "Handed [%s] back to its own room sensor before stopping",
+                self.device_name,
+            )
+
     async def async_shutdown(self) -> None:
         """Release the subscription and both tasks along with the coordinator.
 

--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -505,6 +505,67 @@ async def test_arming_an_override_asks_for_the_frame_that_carries_it(device, mon
     set_airco.assert_not_awaited()
 
 
+async def test_release_hands_the_unit_back_before_stopping(device, monkeypatch):
+    """Home Assistant stopping is the case nothing else covers: the carrier
+    frame stops, and the value it last carried would stand at the unit until
+    something else wrote or the power went. One frame with byte 5 on 255 ends
+    that.
+    """
+    _shorten_service_data_timing(monkeypatch)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+
+    raw = round(18.7 * 4) + 61
+    device.set_external_temperature_override(18.7)
+    device._external_temperature_written.append(raw)
+    device.airco.ControllerRoomTempRaw = raw
+    assert device.external_temperature_applied is True
+
+    captured = {}
+
+    async def _capture_and_echo(airco_id, command, **_kwargs):
+        captured["command"] = command
+        return await _echo_send_airco_command(airco_id, command)
+
+    device._api.send_airco_command = AsyncMock(side_effect=_capture_and_echo)
+
+    await device.async_release_external_temperature()
+
+    assert device.external_temperature_override is None
+    assert base64.b64decode(captured["command"])[5] == 0xFF
+
+
+async def test_release_sends_nothing_when_the_unit_never_took_the_value(
+    device, monkeypatch
+):
+    """Armed but not applied means the unit is on its own sensor already -
+    off, in fan_only, or no frame carried it yet. Spending a frame there would
+    take the write lock for nothing on the way down.
+    """
+    _shorten_service_data_timing(monkeypatch)
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+
+    device.set_external_temperature_override(18.7)
+    device.airco.ControllerRoomTempRaw = 0xFF
+    device._api.send_airco_command = AsyncMock()
+
+    await device.async_release_external_temperature()
+
+    assert device.external_temperature_override is None
+    device._api.send_airco_command.assert_not_awaited()
+
+
+async def test_release_is_a_no_op_without_an_override(device):
+    device._api.get_aircon_stats.return_value = _stats_response(ON_COOL_PAYLOAD)
+    await device.update()
+    device._api.send_airco_command = AsyncMock()
+
+    await device.async_release_external_temperature()
+
+    device._api.send_airco_command.assert_not_awaited()
+
+
 async def test_external_temperature_applied_reads_the_echoed_byte(device):
     # The unit echoes an injected value back in byte 5 unchanged, so the byte
     # it reports matching one a recent frame carried is the whole question.

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -11,7 +11,7 @@ import pytest
 from pywfrac import WfRacConnectionError, WfRacError
 
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -260,6 +260,42 @@ async def test_a_failed_platform_unload_keeps_the_coordinator(
             await hass.async_block_till_done()
 
         assert device.last_update_success
+
+        await device.async_shutdown()
+
+
+async def test_stopping_home_assistant_hands_the_override_back(
+    hass: HomeAssistant, repository: AsyncMock
+):
+    """A stop is the one case where nothing of ours writes again, so the value
+    the unit was handed would stand there. A reload must not do this: the
+    override is re-armed seconds later, and the unit would flick back to its
+    own sensor on every saved option.
+    """
+    entry = _entry(hass, _CURRENT_VERSION, {**_DATA, CONF_HOST: "192.168.1.50"}, {})
+
+    with patch(
+        "custom_components.mitsubishi_wf_rac.coordinator.Repository",
+        return_value=repository,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        device = entry.runtime_data.device
+
+        with patch.object(
+            device, "async_release_external_temperature", AsyncMock()
+        ) as release:
+            await hass.config_entries.async_reload(entry.entry_id)
+            await hass.async_block_till_done()
+            release.assert_not_awaited()
+
+        device = entry.runtime_data.device
+        with patch.object(
+            device, "async_release_external_temperature", AsyncMock()
+        ) as release:
+            hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+            await hass.async_block_till_done()
+            release.assert_awaited_once()
 
         await device.async_shutdown()
 

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -132,7 +132,13 @@ async def test_options_flow_reloads_itself(hass: HomeAssistant):
         options={},
     )
     entry.add_to_hass(hass)
-    device = MagicMock(available=True, connection_method=None, update=AsyncMock())
+    device = MagicMock(
+        available=True,
+        connection_method=None,
+        update=AsyncMock(),
+        # Awaited when hass stops at the end of the test.
+        async_release_external_temperature=AsyncMock(),
+    )
     with (
         patch(
             "custom_components.mitsubishi_wf_rac.create_device_from_entry",


### PR DESCRIPTION
The injected room temperature has no expiry at the unit: byte 5 keeps whatever a frame last carried, and the unit regulates on it until something writes again or the power goes. While the entry runs that is covered - the carrier frame refreshes it every cycle, and a source going `unavailable` clears it within a cycle - but once Home Assistant stops, nothing writes at all and the value simply stands. Raised in a Dutch forum thread as an argument against using the feature at all, and fairly so for that one case.

So an orderly stop now spends one last frame clearing the override. The unit measures for itself while Home Assistant is away and takes the override up again when the entry comes back.

- Only on `EVENT_HOMEASSISTANT_STOP`, deliberately not in `async_unload_entry()`: an unload is also what a reload is, and saving the options reloads the entry - clearing there would flick the unit back to its own sensor on every settings change.
- Nothing is sent when the override is armed but not applied (unit off, `fan_only`, or no frame carried it yet): there is nothing at the unit to undo, and a frame would take the write lock for nothing.
- The `_status_request_is_allowed()` guard applies as it does to the periodic request, so a unit we have given up asking, or one that applies the state a carrying frame echoes, is left alone (#329).
- Failures are logged at debug and swallowed - this runs while Home Assistant is going down, and the next start re-arms the override anyway.

Also documents the part that stays with the source sensor: the unit has no timeout, so the arrangement rests on the source reporting when it stops measuring, and where an integration does not do that itself (`expire_after` on MQTT, a template wrapper) it is worth adding. An abrupt end - host power lost, network gone - cannot be covered from here, and the README now says so.

Tests: three in `test_coordinator.py` for the release path, one in `test_init.py` that a stop triggers it and a reload does not.